### PR TITLE
Print layer as info log when layer changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "kanata"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "kanata-keyberon"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b844fdf952085371733ccd9c3a18c61478c1c7a2f1e6e1d32ec9156ace49a1"
+checksum = "fb94d355ea9bd5453acd2e86a5fced24eaaec9d81bceae03a26fb9c49b415420"
 dependencies = [
  "arraydeque",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanata"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["jtroo <j.andreitabs@gmail.com>"]
 description = "Multi-layer keyboard customization"
 keywords = ["cli", "linux", "windows", "keyboard", "layout"]
@@ -21,8 +21,11 @@ parking_lot = "0.12"
 crossbeam-channel = "0.5"
 once_cell = "1"
 
-# Using my personal fork for tap_hold_interval and Sequence
-kanata-keyberon = "0.2"
+# Using my personal fork for:
+# - tap_hold_interval
+# - pub current_layer
+# - Sequence
+kanata-keyberon = "0.2.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev-rs = "0.4.0"


### PR DESCRIPTION
The motivation behind this change is for getting accustomed to new
layout changes. The log may be of benefit so that the user can see what
layout they're currently on and what keys are associated with it.

The info-level logs are currently empty apart from initialization, so
may as well make it useful for something.

One current limitation is that any comments in the original layout file
won't exist in the printed text.

Additional changes:

- increment version
- refactor handle_time_ticks into multiple fns
- change to new kanata-keyberon version for pub fn current_layer