### PR TITLE
Disable nested tap-hold

### DIFF
--- a/test_cfgs/nested_tap_hold.kbd
+++ b/test_cfgs/nested_tap_hold.kbd
@@ -1,0 +1,12 @@
+(defcfg
+  linux-dev /dev/input/by-path/platform-i8042-serio-0-event-kbd
+)
+
+(defsrc
+       a
+)
+
+;; Note: this config file is invalid and should be rejected
+(deflayer test
+       (tap-hold 200 200 (tap-hold 200 200 a b) c)
+)


### PR DESCRIPTION
This fixes the issue of unexpected behaviour from nested tap-hold by
disabling nested tap-hold. This prevents a user from spending
unnecessary time testing out the configuration and realizing it doesn't
work in the expected way.