### PR TITLE
Bump evdev-rs and remove uinput-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,12 +304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ioctl-sys"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2c4b26352496eaaa8ca7cfa9bd99e93419d3f7983dc6e99c2a35fe9e33504a"
-
-[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,7 +328,6 @@ dependencies = [
  "encode_unicode",
  "evdev-rs",
  "kanata-keyberon",
- "libc",
  "log",
  "native-windows-gui",
  "once_cell",
@@ -342,7 +335,6 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
- "uinput-sys",
  "winapi",
 ]
 
@@ -759,16 +751,6 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "uinput-sys"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aabddd8174ccadd600afeab346bb276cb1db5fafcf6a7c5c5708b8cc4b2cac7"
-dependencies = [
- "ioctl-sys",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,9 +230,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "evdev-rs"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92abc30d5fd1e4f6440dee4d626abc68f4a9b5014dc1de575901e23c2e02321"
+checksum = "d7db51abf6b3205a6e6e8dd68d7a5414d7c50d61736a6f4c9b97df86ef5567cf"
 dependencies = [
  "bitflags",
  "evdev-sys",
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "evdev-sys"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6aa4e801c7267f2f66c9efd5c4071ba8ca9d7d9de515bb09a14bbe6f639ed1"
+checksum = "80c71458f1f28b418779703f0fb17771f08562afacf0ee30176cca0e75e9e7d4"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "LGPL-3.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2.70"
 clap = { version = "3", features = [ "derive" ] }
 log = "0.4.8"
 simplelog = "0.8.0"
@@ -26,7 +25,6 @@ serde_json = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev-rs = "0.5.0"
-uinput-sys = "0.1.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 encode_unicode = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-evdev-rs = "0.4.0"
+evdev-rs = "0.5.0"
 uinput-sys = "0.1.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src/keys/linux.rs
+++ b/src/keys/linux.rs
@@ -1,6 +1,6 @@
 // This file is taken from the original ktrl project's keys.rs file with modifications.
 
-use evdev_rs::enums::{EventCode, EventType, EV_KEY};
+use evdev_rs::enums::{EventCode, EV_KEY};
 use evdev_rs::{InputEvent, TimeVal};
 use kanata_keyberon::key_code::*;
 use std::convert::TryFrom;
@@ -1543,8 +1543,8 @@ impl KeyEvent {
 impl TryFrom<InputEvent> for KeyEvent {
     type Error = ();
     fn try_from(item: InputEvent) -> Result<Self, Self::Error> {
-        match &item.event_type {
-            EventType::EV_KEY => Ok(Self {
+        match &item.event_code {
+            EventCode::EV_KEY(_) => Ok(Self {
                 time: item.time,
                 code: item.event_code.into(),
                 value: item.value.into(),
@@ -1558,7 +1558,6 @@ impl From<KeyEvent> for InputEvent {
     fn from(item: KeyEvent) -> Self {
         Self {
             time: item.time,
-            event_type: EventType::EV_KEY,
             event_code: item.code.into(),
             value: item.value as i32,
         }

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -1,32 +1,27 @@
 // This file contains the original ktrl project's `kbd_in.rs` and `kbd_out.rs` files.
 
+use evdev_rs::enums;
+use evdev_rs::enums::BusType;
 use evdev_rs::enums::EventCode;
+use evdev_rs::enums::EventType;
 use evdev_rs::enums::EV_SYN;
 use evdev_rs::Device;
+use evdev_rs::DeviceWrapper;
 use evdev_rs::GrabMode;
 use evdev_rs::InputEvent;
 use evdev_rs::ReadFlag;
 use evdev_rs::ReadStatus;
 use evdev_rs::TimeVal;
-
-use uinput_sys::uinput_user_dev;
+use evdev_rs::UInputDevice;
+use evdev_rs::UninitDevice;
 
 use crate::custom_action::*;
 use crate::keys::*;
-use libc::c_char;
-use libc::input_event as raw_event;
 
 // file i/o
-use io::Write;
 use std::fs::File;
-use std::fs::OpenOptions;
 use std::io;
-use std::os::unix::io::AsRawFd;
 use std::path::Path;
-
-// unsafe
-use std::mem;
-use std::slice;
 
 // kanata
 use crate::keys::KeyEvent;
@@ -70,79 +65,32 @@ impl KbdIn {
 }
 
 pub struct KbdOut {
-    device: File,
+    device: UInputDevice,
 }
 
 impl KbdOut {
     pub fn new() -> Result<Self, io::Error> {
-        let mut uinput_out_file = OpenOptions::new().write(true).open("/dev/uinput")?;
+        let device = UninitDevice::new()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "UninitDevice::new() failed"))?;
 
-        unsafe {
-            let rc = uinput_sys::ui_set_evbit(uinput_out_file.as_raw_fd(), uinput_sys::EV_SYN);
-            if rc != 0 {
-                log::error!("ui_set_evbit for EV_SYN returned {}", rc);
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "ui_set_evbit failed for EV_SYN",
-                ));
-            }
-            let rc = uinput_sys::ui_set_evbit(uinput_out_file.as_raw_fd(), uinput_sys::EV_KEY);
-            if rc != 0 {
-                log::error!("ui_set_evbit for EV_KEY returned {}", rc);
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "ui_set_evbit failed for EV_KEY",
-                ));
-            }
+        device.set_name("kanata");
+        device.set_bustype(BusType::BUS_USB as u16);
+        device.set_vendor_id(0x1);
+        device.set_product_id(0x1);
+        device.set_version(1);
 
-            for key in 0..300 {
-                let rc = uinput_sys::ui_set_keybit(uinput_out_file.as_raw_fd(), key);
-                if rc != 0 {
-                    log::error!("ui_set_keybit for {} returned {}", key, rc);
-                    return Err(io::Error::new(io::ErrorKind::Other, "ui_set_keybit failed"));
-                }
-            }
-
-            let mut uidev: uinput_user_dev = mem::zeroed();
-
-            const PROG_NAME: &[u8] = "kanata".as_bytes();
-            let copy_len = std::cmp::min(PROG_NAME.len(), uidev.name.len());
-            assert!(copy_len <= uidev.name.len());
-            for (i, c) in PROG_NAME.iter().copied().enumerate().take(copy_len) {
-                uidev.name[i] = c as c_char;
-            }
-
-            uidev.id.bustype = 0x3; // BUS_USB
-            uidev.id.vendor = 0x1;
-            uidev.id.product = 0x1;
-            uidev.id.version = 1;
-
-            let uidev_bytes =
-                slice::from_raw_parts(mem::transmute(&uidev), mem::size_of::<uinput_user_dev>());
-            uinput_out_file.write_all(uidev_bytes)?;
-            let rc = uinput_sys::ui_dev_create(uinput_out_file.as_raw_fd());
-            if rc != 0 {
-                log::error!("ui_dev_create for returned {}", rc);
-                return Err(io::Error::new(io::ErrorKind::Other, "ui_dev_create failed"));
-            }
+        device.enable(&EventType::EV_SYN)?;
+        device.enable(&EventType::EV_KEY)?;
+        for key in (0..300).into_iter().filter_map(enums::int_to_ev_key) {
+            device.enable(&EventCode::EV_KEY(key))?;
         }
 
-        Ok(KbdOut {
-            device: uinput_out_file,
-        })
+        let device = UInputDevice::create_from_device(&device)?;
+        Ok(KbdOut { device })
     }
 
     pub fn write(&mut self, event: InputEvent) -> Result<(), io::Error> {
-        let ev = event.as_raw();
-
-        unsafe {
-            let ev_bytes = slice::from_raw_parts(
-                mem::transmute(&ev as *const raw_event),
-                mem::size_of::<raw_event>(),
-            );
-            self.device.write_all(ev_bytes)?;
-        };
-
+        self.device.write_event(&event)?;
         Ok(())
     }
 

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -48,7 +48,7 @@ impl KbdIn {
 
     fn new_linux(dev_path: &Path) -> Result<Self, std::io::Error> {
         let kbd_in_file = File::open(dev_path)?;
-        let mut kbd_in_dev = Device::new_from_fd(kbd_in_file)?;
+        let mut kbd_in_dev = Device::new_from_file(kbd_in_file)?;
 
         // NOTE: This grab-ungrab-grab sequence magically
         // fix an issue I had with my Lenovo Yoga trackpad not working.


### PR DESCRIPTION
Please refer to commit messages for more information.

I make this pr to prepare for adding a functionality of creating a symlink for the newly created virtual device, e.g. `/dev/input/by-id/kanata0 -> /dev/input/event30`, which is useful if you want to pass the created virtual device into qemu.

