### PR TITLE
Use evdev to create and write device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,27 +241,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "evdev-rs"
-version = "0.4.0"
+name = "evdev"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92abc30d5fd1e4f6440dee4d626abc68f4a9b5014dc1de575901e23c2e02321"
+checksum = "21eef104bd659ef808f1f84bed9a924e1aebcdd066845b377cd3b52cc497bb9f"
 dependencies = [
- "bitflags",
- "evdev-sys",
+ "bitvec",
  "libc",
- "log",
+ "nix",
 ]
 
 [[package]]
-name = "evdev-sys"
-version = "0.2.1"
+name = "funty"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6aa4e801c7267f2f66c9efd5c4071ba8ca9d7d9de515bb09a14bbe6f639ed1"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "hash32"
@@ -305,12 +311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ioctl-sys"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2c4b26352496eaaa8ca7cfa9bd99e93419d3f7983dc6e99c2a35fe9e33504a"
-
-[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,10 +333,9 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "encode_unicode",
- "evdev-rs",
+ "evdev",
  "heapless",
  "kanata-keyberon",
- "libc",
  "log",
  "native-windows-gui",
  "net2",
@@ -345,7 +344,6 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
- "uinput-sys",
  "winapi",
 ]
 
@@ -417,6 +415,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "native-windows-gui"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +462,19 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -510,12 +530,6 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "plotters"
@@ -576,6 +590,12 @@ checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "redox_syscall"
@@ -766,6 +786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,16 +814,6 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "uinput-sys"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aabddd8174ccadd600afeab346bb276cb1db5fafcf6a7c5c5708b8cc4b2cac7"
-dependencies = [
- "ioctl-sys",
- "libc",
 ]
 
 [[package]]
@@ -982,3 +998,12 @@ name = "windows_x86_64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "LGPL-3.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2.70"
 clap = { version = "3", features = [ "derive" ] }
 log = "0.4.8"
 simplelog = "0.8.0"
@@ -28,8 +27,7 @@ serde_json = "1"
 net2 = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-evdev-rs = "0.4.0"
-uinput-sys = "0.1.7"
+evdev = "0.11.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 encode_unicode = "0.3.6"

--- a/src/kanata.rs
+++ b/src/kanata.rs
@@ -394,7 +394,7 @@ impl Kanata {
             *mapped_keys = kanata.lock().mapped_keys;
         }
 
-        let kbd_in = match KbdIn::new(&kanata.lock().kbd_in_path) {
+        let mut kbd_in = match KbdIn::new(&kanata.lock().kbd_in_path) {
             Ok(kbd_in) => kbd_in,
             Err(e) => {
                 bail!("failed to open keyboard device: {}", e)
@@ -405,7 +405,7 @@ impl Kanata {
             let in_event = kbd_in.read()?;
 
             // Pass-through non-key events
-            let key_event = match KeyEvent::try_from(in_event.clone()) {
+            let key_event = match KeyEvent::try_from(in_event) {
                 Ok(ev) => ev,
                 _ => {
                     let mut kanata = kanata.lock();

--- a/src/keys/linux.rs
+++ b/src/keys/linux.rs
@@ -1,7 +1,6 @@
 // This file is taken from the original ktrl project's keys.rs file with modifications.
 
-use evdev_rs::enums::{EventCode, EventType, EV_KEY};
-use evdev_rs::{InputEvent, TimeVal};
+use evdev::{EventType, InputEvent};
 use kanata_keyberon::key_code::*;
 use std::convert::TryFrom;
 
@@ -1477,35 +1476,6 @@ impl From<&OsCode> for KeyCode {
     }
 }
 
-impl From<EventCode> for OsCode {
-    fn from(item: EventCode) -> Self {
-        match item {
-            EventCode::EV_KEY(evkey) => Self::from(evkey),
-            _ => unreachable!(),
-        }
-    }
-}
-
-impl From<OsCode> for EventCode {
-    fn from(item: OsCode) -> Self {
-        let evkey = item.into();
-        EventCode::EV_KEY(evkey)
-    }
-}
-
-impl From<EV_KEY> for OsCode {
-    fn from(item: EV_KEY) -> Self {
-        (item as u32).into()
-    }
-}
-
-impl From<OsCode> for EV_KEY {
-    fn from(item: OsCode) -> Self {
-        evdev_rs::enums::int_to_ev_key(item as u32)
-            .unwrap_or_else(|| panic!("Invalid KeyCode: {}", item as u32))
-    }
-}
-
 // ------------------ KeyValue --------------------
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -1528,26 +1498,23 @@ impl From<i32> for KeyValue {
 
 #[derive(Debug)]
 pub struct KeyEvent {
-    pub time: TimeVal,
     pub code: OsCode,
     pub value: KeyValue,
 }
 
 impl KeyEvent {
     pub fn new(code: OsCode, value: KeyValue) -> Self {
-        let time = TimeVal::new(0, 0);
-        Self { time, code, value }
+        Self { code, value }
     }
 }
 
 impl TryFrom<InputEvent> for KeyEvent {
     type Error = ();
     fn try_from(item: InputEvent) -> Result<Self, Self::Error> {
-        match &item.event_type {
-            EventType::EV_KEY => Ok(Self {
-                time: item.time,
-                code: item.event_code.into(),
-                value: item.value.into(),
+        match item.kind() {
+            evdev::InputEventKind::Key(k) => Ok(Self {
+                code: OsCode::from_u32(k.0.into()).ok_or(())?,
+                value: KeyValue::from(item.value()),
             }),
             _ => Err(()),
         }
@@ -1556,11 +1523,6 @@ impl TryFrom<InputEvent> for KeyEvent {
 
 impl From<KeyEvent> for InputEvent {
     fn from(item: KeyEvent) -> Self {
-        Self {
-            time: item.time,
-            event_type: EventType::EV_KEY,
-            event_code: item.code.into(),
-            value: item.value as i32,
-        }
+        InputEvent::new_now(EventType::KEY, item.code as u16, item.value as i32)
     }
 }

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -1,38 +1,21 @@
 // This file contains the original ktrl project's `kbd_in.rs` and `kbd_out.rs` files.
 
-use evdev_rs::enums::EventCode;
-use evdev_rs::enums::EV_SYN;
-use evdev_rs::Device;
-use evdev_rs::GrabMode;
-use evdev_rs::InputEvent;
-use evdev_rs::ReadFlag;
-use evdev_rs::ReadStatus;
-use evdev_rs::TimeVal;
-
-use uinput_sys::uinput_user_dev;
+use evdev::uinput;
+use evdev::Device;
+use evdev::InputEvent;
 
 use crate::custom_action::*;
 use crate::keys::*;
-use libc::c_char;
-use libc::input_event as raw_event;
 
-// file i/o
-use io::Write;
-use std::fs::File;
-use std::fs::OpenOptions;
 use std::io;
-use std::os::unix::io::AsRawFd;
 use std::path::Path;
-
-// unsafe
-use std::mem;
-use std::slice;
 
 // kanata
 use crate::keys::KeyEvent;
 
 pub struct KbdIn {
     device: Device,
+    events: std::collections::VecDeque<InputEvent>,
 }
 
 impl KbdIn {
@@ -47,102 +30,53 @@ impl KbdIn {
     }
 
     fn new_linux(dev_path: &Path) -> Result<Self, std::io::Error> {
-        let kbd_in_file = File::open(dev_path)?;
-        let mut kbd_in_dev = Device::new_from_fd(kbd_in_file)?;
+        let mut kbd_in_dev = Device::open(dev_path)?;
 
         // NOTE: This grab-ungrab-grab sequence magically
-        // fix an issue I had with my Lenovo Yoga trackpad not working.
-        // I honestly have no idea why this works haha.
-        kbd_in_dev.grab(GrabMode::Grab)?;
-        kbd_in_dev.grab(GrabMode::Ungrab)?;
-        kbd_in_dev.grab(GrabMode::Grab)?;
+        // fix an issue with a Lenovo Yoga trackpad not working.
+        // No idea why this works.
+        kbd_in_dev.grab()?;
+        kbd_in_dev.ungrab()?;
+        kbd_in_dev.grab()?;
 
-        Ok(KbdIn { device: kbd_in_dev })
+        Ok(KbdIn {
+            device: kbd_in_dev,
+            events: Default::default(),
+        })
     }
 
-    pub fn read(&self) -> Result<InputEvent, std::io::Error> {
-        let (status, event) = self
-            .device
-            .next_event(ReadFlag::NORMAL | ReadFlag::BLOCKING)?;
-        std::assert!(status == ReadStatus::Success);
-        Ok(event)
+    pub fn read(&mut self) -> Result<InputEvent, std::io::Error> {
+        while self.events.is_empty() {
+            self.device
+                .fetch_events()?
+                .into_iter()
+                .for_each(|ev| self.events.push_back(ev));
+        }
+        Ok(self.events.pop_front().expect("not empty"))
     }
 }
 
 pub struct KbdOut {
-    device: File,
+    device: uinput::VirtualDevice,
 }
 
 impl KbdOut {
     pub fn new() -> Result<Self, io::Error> {
-        let mut uinput_out_file = OpenOptions::new().write(true).open("/dev/uinput")?;
-
-        unsafe {
-            let rc = uinput_sys::ui_set_evbit(uinput_out_file.as_raw_fd(), uinput_sys::EV_SYN);
-            if rc != 0 {
-                log::error!("ui_set_evbit for EV_SYN returned {}", rc);
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "ui_set_evbit failed for EV_SYN",
-                ));
-            }
-            let rc = uinput_sys::ui_set_evbit(uinput_out_file.as_raw_fd(), uinput_sys::EV_KEY);
-            if rc != 0 {
-                log::error!("ui_set_evbit for EV_KEY returned {}", rc);
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "ui_set_evbit failed for EV_KEY",
-                ));
-            }
-
-            for key in 0..300 {
-                let rc = uinput_sys::ui_set_keybit(uinput_out_file.as_raw_fd(), key);
-                if rc != 0 {
-                    log::error!("ui_set_keybit for {} returned {}", key, rc);
-                    return Err(io::Error::new(io::ErrorKind::Other, "ui_set_keybit failed"));
-                }
-            }
-
-            let mut uidev: uinput_user_dev = mem::zeroed();
-
-            const PROG_NAME: &[u8] = "kanata".as_bytes();
-            let copy_len = std::cmp::min(PROG_NAME.len(), uidev.name.len());
-            assert!(copy_len <= uidev.name.len());
-            for (i, c) in PROG_NAME.iter().copied().enumerate().take(copy_len) {
-                uidev.name[i] = c as c_char;
-            }
-
-            uidev.id.bustype = 0x3; // BUS_USB
-            uidev.id.vendor = 0x1;
-            uidev.id.product = 0x1;
-            uidev.id.version = 1;
-
-            let uidev_bytes =
-                slice::from_raw_parts(mem::transmute(&uidev), mem::size_of::<uinput_user_dev>());
-            uinput_out_file.write_all(uidev_bytes)?;
-            let rc = uinput_sys::ui_dev_create(uinput_out_file.as_raw_fd());
-            if rc != 0 {
-                log::error!("ui_dev_create for returned {}", rc);
-                return Err(io::Error::new(io::ErrorKind::Other, "ui_dev_create failed"));
-            }
+        let mut keys = evdev::AttributeSet::new();
+        for k in 0..300u16 {
+            keys.insert(evdev::Key(k));
         }
-
         Ok(KbdOut {
-            device: uinput_out_file,
+            device: uinput::VirtualDeviceBuilder::new()?
+                .name("kanata")
+                .input_id(evdev::InputId::new(evdev::BusType::BUS_USB, 1, 1, 1))
+                .with_keys(&keys)?
+                .build()?,
         })
     }
 
     pub fn write(&mut self, event: InputEvent) -> Result<(), io::Error> {
-        let ev = event.as_raw();
-
-        unsafe {
-            let ev_bytes = slice::from_raw_parts(
-                mem::transmute(&ev as *const raw_event),
-                mem::size_of::<raw_event>(),
-            );
-            self.device.write_all(ev_bytes)?;
-        };
-
+        self.device.emit(&[event])?;
         Ok(())
     }
 
@@ -150,18 +84,7 @@ impl KbdOut {
         let key_ev = KeyEvent::new(key, value);
         let input_ev = key_ev.into();
         log::debug!("input ev: {:?}", input_ev);
-        self.write(input_ev)?;
-
-        let sync = InputEvent::new(
-            &TimeVal {
-                tv_sec: 0,
-                tv_usec: 0,
-            },
-            &EventCode::EV_SYN(EV_SYN::SYN_REPORT),
-            0,
-        );
-        self.write(sync)?;
-
+        self.device.emit(&[input_ev])?;
         Ok(())
     }
 


### PR DESCRIPTION
The evdev crate is added and these dependencies are dropped:

- libc
- uinput-sys
- evdev-rs

Replace uinput-sys with evdev because evdev is a wrapper library for
evdev devices that provides interfaces to create uinput devices and send
events. Using evdev is less error-prone than accessing uinput directly,
and should be considered for new software[1]. evdev is also needed to
create a symlink in /dev/input/by-id/

libc is dropped since its struct definitions are no longer required.

evdev-rs is replaced by evdev so that the system library libevdev is no
longer a dependency.

[1]: https://www.kernel.org/doc/html/latest/input/uinput.html