### PR TITLE
Add key ro alias for Linux

### DIFF
--- a/src/keys/linux.rs
+++ b/src/keys/linux.rs
@@ -1299,6 +1299,7 @@ impl From<KeyCode> for OsCode {
             KeyCode::AltErase => OsCode::KEY_ALTERASE,
             KeyCode::Cancel => OsCode::KEY_CANCEL,
             KeyCode::MediaMute => OsCode::KEY_MICMUTE,
+            KeyCode::Intl1 => OsCode::KEY_RO,
             _ => OsCode::KEY_UNKNOWN,
         }
     }
@@ -1465,6 +1466,7 @@ impl From<OsCode> for KeyCode {
             OsCode::KEY_ALTERASE => KeyCode::AltErase,
             OsCode::KEY_CANCEL => KeyCode::Cancel,
             OsCode::KEY_MICMUTE => KeyCode::MediaMute,
+            OsCode::KEY_RO => KeyCode::Intl1,
             _ => KeyCode::No,
         }
     }

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -155,6 +155,7 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "kp9" => OsCode::KEY_KP9,
         "hangeul" => OsCode::KEY_HANGEUL,
         "hanja" => OsCode::KEY_HANJA,
+        "ro" => OsCode::KEY_RO,
         _ => return None,
     })
 }


### PR DESCRIPTION
Key ro is the slash key for some keyboard layout such as ABNT2 #21