### PR TITLE
Mitigate Windows altgr issue

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -23,6 +23,19 @@
 
   ;; Windows doesn't need any input/output configuration entries; however, there
   ;; must still be a defcfg entry.
+  ;;
+  ;; There is an optional configuration entry for Windows to help mitigate strange
+  ;; behaviour of AltGr if your layout uses that. Uncomment one of the items below
+  ;; to change what kanata does with the key.
+  ;;
+  ;; For more context, see: https://github.com/jtroo/kanata/issues/55.
+  ;;
+  ;; windows-altgr cancel-lctl-press ;; remove the lctl press that comes as a combo with ralt
+  ;; windows-altgr add-lctl-release  ;; add an lctl release when ralt is released
+  ;;
+  ;; NOTE: even with these workarounds, putting lctl+ralt in your defsrc may
+  ;; not work too well with other applications that use WH_KEYBOARD_LL.
+  ;; Known applications with issues: GWSL/VcXsrv
 
   ;; Optional confguration: enable kanata to execute commands.
   ;; It is also not enabled in this sample configuration.

--- a/src/keys/windows.rs
+++ b/src/keys/windows.rs
@@ -1426,7 +1426,7 @@ impl From<KeyValue> for bool {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct KeyEvent {
     pub code: OsCode,
     pub value: KeyValue,

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,10 @@ struct Args {
     /// Enable debug logging
     #[clap(short, long)]
     debug: bool,
+
+    /// Enable trace logging
+    #[clap(short, long)]
+    trace: bool,
 }
 
 /// Parse CLI arguments and initialize logging.
@@ -44,9 +48,10 @@ fn cli_init() -> Result<ValidatedArgs> {
 
     let cfg_path = Path::new(&args.cfg);
 
-    let log_lvl = match args.debug {
-        true => LevelFilter::Debug,
-        _ => LevelFilter::Info,
+    let log_lvl = match (args.debug, args.trace) {
+        (_, true) => LevelFilter::Trace,
+        (true, false) => LevelFilter::Debug,
+        (false, false) => LevelFilter::Info,
     };
 
     CombinedLogger::init(vec![TermLogger::new(


### PR DESCRIPTION
Attempted mitigation for #55.

Since I don't use an international layout, I'm not sure how effective this is in fixing the actual issue. However, it works as designed with regards to the input/output of key events.