### PR TITLE
Add prtsc conditional alias (sys for Linux or prnt Windows)

### DIFF
--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -156,6 +156,10 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "hangeul" => OsCode::KEY_HANGEUL,
         "hanja" => OsCode::KEY_HANJA,
         "ro" => OsCode::KEY_RO,
+        #[cfg(target_os = "linux")]
+        "prtsc" => OsCode::KEY_SYSRQ,
+        #[cfg(target_os = "windows")]
+        "prtsc" => OsCode::KEY_PRINT,
         _ => return None,
     })
 }


### PR DESCRIPTION
I suggest having an additional alias for Print Screen.

We keep `sys` for SysReq on Linux and `prnt` for Print Screen on Windows to keep compatible with KMonad. But add a `prtsc` alias which is SysReq on Linux or Print Screen on Windows. So I can have one single config which works for both. Since the physical key is the same on ordinary keyboards.

What do you think about that idea?