### PR TITLE
feat(keycodes): add mute

### DIFF
--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -110,6 +110,7 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "home" => OsCode::KEY_HOME,
         "end" => OsCode::KEY_END,
         "nlck" | "nlk" => OsCode::KEY_NUMLOCK,
+        "mute" => OsCode::KEY_MUTE,
         "volu" => OsCode::KEY_VOLUMEUP,
         "voldwn" | "vold" => OsCode::KEY_VOLUMEDOWN,
         "brup" | "bru" => OsCode::KEY_BRIGHTNESSUP,


### PR DESCRIPTION
Adds an alias for the mute key to be used in layer definitions.