### PR TITLE
Add support for keyberon's HoldOnOtherKeyPress and PermissiveHold

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -123,6 +123,21 @@
   ;; the key within the tap timeout window (number is milliseconds). Simply
   ;; holding the key results in the hold action activating, which is why you
   ;; need to double-press for the tap action to stay pressed.
+  ;;
+  ;; There are two additional versions of tap-hold available:
+  ;; 1. tap-hold-press: if there is a key press, the hold action is activated
+  ;; 2. tap-hold-release: if there is a press and release of another key, the
+  ;; hold action is activated
+  ;;
+  ;; These versions are useful if you don't want to wait for the whole hold
+  ;; timeout to activate, but want to activate the hold action immediately
+  ;; based on the next key press or press and release of another key. These
+  ;; versions might be great to implement home row mods.
+  ;;
+  ;; If you come from kmonad, tap-hold-press and tap-hold-release are similar
+  ;; to tap-hold-next and tap-hold-next-release, respectively. If you know
+  ;; the underlying keyberon crate, tap-hold-press is the HoldOnOtherKeyPress
+  ;; and tap-hold-release is the PermissiveHold configuration.
   anm (tap-hold 200 200 a @num)   ;; tap: a      hold: numbers layer
   oar (tap-hold 200 200 o @arr)   ;; tap: o      hold: arrows layer
   ech (tap-hold 200 200 e @chr)   ;; tap: e      hold: chords layer

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -809,7 +809,7 @@ fn layer_idx(ac_params: &[SExpr], layers: &LayerIndexes) -> Result<usize> {
 fn parse_tap_hold(
     ac_params: &[SExpr],
     parsed_state: &ParsedState,
-    config: HoldTapConfig
+    config: HoldTapConfig,
 ) -> Result<&'static KanataAction> {
     if ac_params.len() != 4 {
         bail!("tap-hold expects 4 atoms after it: <tap-timeout> <hold-timeout> <tap-action> <hold-action>, got {}", ac_params.len())
@@ -825,7 +825,7 @@ fn parse_tap_hold(
         bail!("tap-hold is not allowed inside of tap-hold")
     }
     Ok(sref(Action::HoldTap {
-        config: config,
+        config,
         tap_hold_interval: tap_timeout,
         timeout: hold_timeout,
         tap: tap_action,

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -758,7 +758,9 @@ fn parse_action_list(ac: &[SExpr], parsed_state: &ParsedState) -> Result<&'stati
     match ac_type.as_str() {
         "layer-switch" => parse_layer_base(&ac[1..], layers),
         "layer-toggle" => parse_layer_toggle(&ac[1..], layers),
-        "tap-hold" => parse_tap_hold(&ac[1..], parsed_state),
+        "tap-hold" => parse_tap_hold(&ac[1..], parsed_state, HoldTapConfig::Default),
+        "tap-hold-press" => parse_tap_hold(&ac[1..], parsed_state, HoldTapConfig::HoldOnOtherKeyPress),
+        "tap-hold-release" => parse_tap_hold(&ac[1..], parsed_state, HoldTapConfig::PermissiveHold),
         "multi" => parse_multi(&ac[1..], parsed_state),
         "macro" => parse_macro(&ac[1..], parsed_state),
         "unicode" => parse_unicode(&ac[1..]),
@@ -768,7 +770,7 @@ fn parse_action_list(ac: &[SExpr], parsed_state: &ParsedState) -> Result<&'stati
         "release-layer" => parse_release_layer(&ac[1..], parsed_state),
         "cmd" => parse_cmd(&ac[1..], parsed_state.is_cmd_enabled),
         _ => bail!(
-            "Unknown action type: {}. Valid types:\n\tlayer-switch\n\tlayer-toggle\n\ttap-hold\n\tmulti\n\tmacro\n\tunicode\n\tone-shot\n\ttap-dance\n\trelease-key\n\trelease-layer\n\tcmd",
+            "Unknown action type: {}. Valid types:\n\tlayer-switch\n\tlayer-toggle\n\ttap-hold\n\ttap-hold-press\n\ttap-hold-release\n\tmulti\n\tmacro\n\tunicode\n\tone-shot\n\ttap-dance\n\trelease-key\n\trelease-layer\n\tcmd",
             ac_type
         ),
     }
@@ -807,6 +809,7 @@ fn layer_idx(ac_params: &[SExpr], layers: &LayerIndexes) -> Result<usize> {
 fn parse_tap_hold(
     ac_params: &[SExpr],
     parsed_state: &ParsedState,
+    config: HoldTapConfig
 ) -> Result<&'static KanataAction> {
     if ac_params.len() != 4 {
         bail!("tap-hold expects 4 atoms after it: <tap-timeout> <hold-timeout> <tap-action> <hold-action>, got {}", ac_params.len())
@@ -822,7 +825,7 @@ fn parse_tap_hold(
         bail!("tap-hold is not allowed inside of tap-hold")
     }
     Ok(sref(Action::HoldTap {
-        config: HoldTapConfig::Default,
+        config: config,
         tap_hold_interval: tap_timeout,
         timeout: hold_timeout,
         tap: tap_action,


### PR DESCRIPTION
Add support for keyberon's HoldOnOtherKeyPress and PermissiveHold options for tap-hold.

Hope my docs are clear. I couldn't think of an example that wasn't redundant there. They all do the same thing, only on slightly different moments.