### PR TITLE
feat: add alias for layer-toggle: layer-while-held

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -105,14 +105,17 @@
   dvk (layer-switch dvorak)
   qwr (layer-switch qwerty)
 
-  ;; aliases for layer toggling
+  ;; Aliases for layer "toggling". It's not quite toggling because the layer
+  ;; will be active while the key is held and deactivated when the key is
+  ;; released. An alternate action name you can use is layer-while-held.
+  ;; However, the rest of this document will use The term "toggle" for brevity.
   num (layer-toggle numbers)
   chr (layer-toggle chords)
   arr (layer-toggle arrows)
   msc (layer-toggle misc)
   lay (layer-toggle layers)
   mse (layer-toggle mouse)
-  fks (layer-toggle fakekeys)
+  fks (layer-while-held fakekeys)
 
   ;; tap-hold aliases with tap for dvorak key, and hold for toggle layers
   ;;

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -803,7 +803,7 @@ fn parse_action_list(ac: &[SExpr], parsed_state: &ParsedState) -> Result<&'stati
     let layers = &parsed_state.layer_idxs;
     match ac_type.as_str() {
         "layer-switch" => parse_layer_base(&ac[1..], layers),
-        "layer-toggle" => parse_layer_toggle(&ac[1..], layers),
+        "layer-toggle" | "layer-while-held" => parse_layer_toggle(&ac[1..], layers),
         "tap-hold" => parse_tap_hold(&ac[1..], parsed_state, HoldTapConfig::Default),
         "tap-hold-press" => parse_tap_hold(&ac[1..], parsed_state, HoldTapConfig::HoldOnOtherKeyPress),
         "tap-hold-release" => parse_tap_hold(&ac[1..], parsed_state, HoldTapConfig::PermissiveHold),
@@ -818,7 +818,7 @@ fn parse_action_list(ac: &[SExpr], parsed_state: &ParsedState) -> Result<&'stati
         "on-release-fakekey" => parse_on_release_fake_key_op(&ac[1..], parsed_state),
         "cmd" => parse_cmd(&ac[1..], parsed_state.is_cmd_enabled),
         _ => bail!(
-            "Unknown action type: {}. Valid types:\n\tlayer-switch\n\tlayer-toggle\n\ttap-hold\n\ttap-hold-press\n\ttap-hold-release\n\tmulti\n\tmacro\n\tunicode\n\tone-shot\n\ttap-dance\n\trelease-key\n\trelease-layer\n\tcmd",
+            "Unknown action type: {}. Valid types:\n\tlayer-switch\n\tlayer-toggle | layer-while-held\n\ttap-hold | tap-hold-press | tap-hold-release\n\tmulti\n\tmacro\n\tunicode\n\tone-shot\n\ttap-dance\n\trelease-key | release-layer\n\ton-press-fakekey | on-release-fakekey\n\tcmd",
             ac_type
         ),
     }


### PR DESCRIPTION
This commit adds an alternate action name for layer-toggle:

    layer-while-held

This is added because the word "toggle" does not quite precisely
describe what the action actually does.

A miscellaneous change included in this commit is adding some missing
action names in an error message and changing the error message's format
to group related commands together.

Closes #81 