### PR TITLE
refactor: adjust expect messages

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -448,9 +448,7 @@ fn parse_expr(expr: &str) -> Result<Vec<SExpr>> {
                 expr
             )
         } else if token.starts_with('"') {
-            let mut token = token
-                .strip_prefix('"')
-                .expect("Dquote prefix was checked. Cosmic ray?");
+            let mut token = token.strip_prefix('"').unwrap();
             let mut quoted_tokens = vec![];
             loop {
                 let num_dquotes = token.matches('"').count();
@@ -469,11 +467,7 @@ fn parse_expr(expr: &str) -> Result<Vec<SExpr>> {
                         if !token.ends_with('"') {
                             bail!("Invalid end of quoted string {}", token);
                         }
-                        quoted_tokens.push(
-                            token
-                                .strip_suffix('"')
-                                .expect("Dquote suffix was checked. Cosmic ray?"),
-                        );
+                        quoted_tokens.push(token.strip_suffix('"').unwrap());
                         break;
                     }
                     _ => bail!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn cli_init() -> Result<ValidatedArgs> {
         TerminalMode::Mixed,
         ColorChoice::AlwaysAnsi,
     )])
-    .expect("Couldn't initialize the logger");
+    .expect("logger can init");
     log::info!("kanata v{} starting", env!("CARGO_PKG_VERSION"));
 
     if !cfg_path.exists() {

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -179,7 +179,7 @@ impl KbdOut {
         let mut s = String::new();
         for c in hex.chars() {
             s.push(c);
-            let osc = str_to_oscode(&s).expect("invalid char in unicode output");
+            let osc = str_to_oscode(&s).expect("valid keycodes for unicode");
             s.clear();
             self.press_key(osc)?;
             self.release_key(osc)?;

--- a/src/oskbd/windows.rs
+++ b/src/oskbd/windows.rs
@@ -63,7 +63,7 @@ impl<'a> KeyboardHook<'a> {
                 handle: unsafe {
                     SetWindowsHookExW(WH_KEYBOARD_LL, Some(hook_proc), ptr::null_mut(), 0)
                         .as_mut()
-                        .expect("Failed to install low-level keyboard hook.")
+                        .expect("install low-level keyboard hook successfully")
                 },
                 lifetime: PhantomData,
             }

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -48,8 +48,8 @@ impl TcpServer {
     }
 
     pub fn start(&mut self, kanata: Arc<Mutex<Kanata>>) {
-        let listener = TcpListener::bind(format!("0.0.0.0:{}", self.port))
-            .expect("could not start the tcp server");
+        let listener =
+            TcpListener::bind(format!("0.0.0.0:{}", self.port)).expect("TCP server starts");
 
         let connections = self.connections.clone();
 
@@ -59,16 +59,16 @@ impl TcpServer {
                     Ok(mut stream) => {
                         stream
                             .set_keepalive(Some(Duration::from_secs(30)))
-                            .expect("could not set tcp connection keepalive");
+                            .expect("TCP keepalive is set");
 
                         let addr = stream
                             .peer_addr()
-                            .expect("could not find peer address")
+                            .expect("incoming conn has known address")
                             .to_string();
 
                         connections.lock().insert(
                             addr.clone(),
-                            stream.try_clone().expect("could not clone stream"),
+                            stream.try_clone().expect("stream is clonable"),
                         );
 
                         log::info!("listening for incoming messages {}", &addr);


### PR DESCRIPTION
All expect messages are adjusted or replaced with unwrap following the
guidelines here:

https://github.com/rust-lang/project-error-handling/issues/50
https://github.com/rust-lang/rust/pull/96033