### PR TITLE
Add support for mouse axes in KbdOut to support fallthrough of mousemovement events

### DIFF
--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -138,6 +138,12 @@ impl KbdOut {
         let mut axes = evdev::AttributeSet::new();
         axes.insert(RelativeAxisType::REL_WHEEL);
         axes.insert(RelativeAxisType::REL_HWHEEL);
+        axes.insert(RelativeAxisType::REL_X);
+        axes.insert(RelativeAxisType::REL_Y);
+        axes.insert(RelativeAxisType::REL_Z);
+        axes.insert(RelativeAxisType::REL_RX);
+        axes.insert(RelativeAxisType::REL_RY);
+        axes.insert(RelativeAxisType::REL_RZ);
 
         let mut device = uinput::VirtualDeviceBuilder::new()?
             .name("kanata")


### PR DESCRIPTION
This little fix takes care of mouse movements which are swallowed in the virtual device if the mouse is specified as input device (mouse stops moving, but buttons are still working).

The virtual device should probably even be extended to support all features of `evdev::uinput::VirtualDevice` to not swallow any non-handled events in the input devices.