### PR TITLE
fix(windows): release all shift keys on non-physical shift release

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -52,6 +52,7 @@
   ;; This is dangerous because it allows kanata to execute arbitrary commands.
   ;; Using a binary compiled with the cmd feature enabled, uncomment below to
   ;; enable command execution:
+  ;;
   ;; danger-enable-cmd yes
 )
 

--- a/src/kanata/linux.rs
+++ b/src/kanata/linux.rs
@@ -63,4 +63,8 @@ impl Kanata {
             }
         }
     }
+
+    pub fn check_release_non_physical_shift(&mut self) -> Result<()> {
+        Ok(())
+    }
 }

--- a/src/kanata/windows/mod.rs
+++ b/src/kanata/windows/mod.rs
@@ -45,3 +45,47 @@ pub fn set_win_altgr_behaviour(cfg: &cfg::Cfg) -> Result<()> {
     };
     Ok(())
 }
+
+impl Kanata {
+    pub fn check_release_non_physical_shift(&mut self) -> Result<()> {
+        static PREV_STATES: Lazy<Mutex<Vec<State<&[&CustomAction]>>>> =
+            Lazy::new(|| Mutex::new(vec![]));
+        let mut prev_states = PREV_STATES.lock();
+        if prev_states.is_empty() {
+            prev_states.extend_from_slice(self.layout.states.as_slice());
+            return Ok(());
+        }
+
+        // This is an n^2 loop, but realistically there should be <= 5 states at a given time so
+        // this should not be a problem. State does not implement Hash so can't use a HashSet. A
+        // HashSet might perform worse anyway.
+        for prev_state in prev_states.iter() {
+            if let State::NormalKey { keycode, coord } = prev_state {
+                if !matches!(keycode, KeyCode::LShift | KeyCode::RShift)
+                    || (matches!(keycode, KeyCode::LShift)
+                        && coord.1 == u16::from(OsCode::KEY_LEFTSHIFT))
+                    || (matches!(keycode, KeyCode::RShift)
+                        && coord.1 == u16::from(OsCode::KEY_RIGHTSHIFT))
+                    || self.layout.states.contains(prev_state)
+                {
+                    continue;
+                }
+                log::debug!("releasing all {keycode:?}");
+                self.layout.states.retain(|s| match s {
+                    State::NormalKey {
+                        keycode: cur_kc, ..
+                    }
+                    | State::FakeKey { keycode: cur_kc } => cur_kc != keycode,
+                    _ => true,
+                });
+                if let Err(e) = self.kbd_out.release_key(keycode.into()) {
+                    bail!("failed to release key: {:?}", e);
+                }
+            }
+        }
+
+        prev_states.clear();
+        prev_states.extend_from_slice(self.layout.states.as_slice());
+        Ok(())
+    }
+}


### PR DESCRIPTION
Windows has some weirdness with arrow keys and the numpad where one is a shifted version of the other. I think it's a historical issue since physical arrow keys don't have this problem but injected ones do. Might be a bug in SendInput or the LLHOOK mechanism. This is relevant because it's likely related to the point below.

When injecting an arrow key while an injected lsft is held, Windows sends a fake physical lsft release and then a fake physical lsft press event. The kanata-injected arrow event is likely in between the two fake physical events. I think Windows does this because at the OS level, it thinks lsft needs to be released to be able to send an arrow key instead of a numpad key. So since the injected lsft is active in the Windows OS, Windows sends the fake lsft events without the physical keyboard being involved.

The problem is that the key Windows sends is the physical lsft key. This results in kanata's state saying that the lsft key is pressed down permanently until the physical lsft key is pressed and released. In the kanata software, the state of the key mapped to lsft independent of the state of the physical lsft key. Releasing the key remapped lsft, will not release the state of the lsft key.

The fix for this issue is that on Windows, non-physical lsft/rsft releases will release all active lsft/rsft states. On Linux, this code does not run at all. My assumption is that the use case of pressing two of the same shift at the same time is not depended on by anyone and is not useful, so this shouldn't negatively affect anyone.