### PR TITLE
fix: add defcfg item to process unmapped keys

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -52,7 +52,19 @@
   ;; This is dangerous because it allows kanata to execute arbitrary commands.
   ;; Using a binary compiled with the cmd feature enabled, uncomment below to
   ;; enable command execution:
+  ;;
   ;; danger-enable-cmd yes
+
+  ;; Optional configuration: enable processing of keys that are not in defsrc.
+  ;; This is useful if you are only mapping a few keys in defsrc instead of
+  ;; most of the keys on your keyboard. Without this, the tap-hold-release and
+  ;; tap-hold-press actions will not activate for keys that are not in defsrc.
+  ;;
+  ;; The reason this is not enabled by default is because some keys may not
+  ;; work correctly if they are intercepted. E.g. rctl/altgr on Windows; see the
+  ;; windows-altgr configuration item above for context.
+  ;;
+  ;; process-unmapped-keys yes
 )
 
 ;; Only one defsrc is allowed.

--- a/cfg_samples/minimal.kbd
+++ b/cfg_samples/minimal.kbd
@@ -15,19 +15,23 @@
 (defsrc
   caps grv         i
               j    k    l
+  lsft rsft ;; note: the reason for mapping the Shift keys is so that they get
+            ;; processed correctly by kanata for tap-hold keys.
 )
 
 (deflayer default
   @cap @grv        _
               _    _    _
+  _    _
 )
 
 (deflayer arrows
   _    _           up
               left down rght
+  _    _
 )
 
 (defalias
   cap (tap-hold-press 200 200 caps lctl)
-  grv (tap-hold-release 200 200 grv (layer-toggle arrows))
+  grv (tap-hold-press 200 200 grv (layer-toggle arrows))
 )

--- a/src/kanata/linux.rs
+++ b/src/kanata/linux.rs
@@ -30,7 +30,7 @@ impl Kanata {
 
             // Pass-through non-key events
             for in_event in events.into_iter() {
-                let mut key_event = match KeyEvent::try_from(in_event) {
+                let key_event = match KeyEvent::try_from(in_event) {
                     Ok(ev) => ev,
                     _ => {
                         let mut kanata = kanata.lock();
@@ -46,20 +46,18 @@ impl Kanata {
                 // it immediately.
                 check_for_exit(&key_event);
                 if !MAPPED_KEYS.lock().contains(&key_event.code) {
-                    log::debug!("{key_event:?} is not mapped");
                     let mut kanata = kanata.lock();
                     kanata
                         .kbd_out
                         .write_key(key_event.code, key_event.value)
                         .map_err(|e| anyhow!("failed write key: {}", e))?;
-
-                    // #139: send an event that is guaranteed to map to no-op to the processing loop so
-                    // that it will process tap-hold-press and tap-hold-release even for unmapped keys.
-                    key_event.code = OsCode::KEY_RESERVED;
+                    continue;
                 }
 
                 // Send key events to the processing loop
-                tx.send(key_event).unwrap();
+                if let Err(e) = tx.send(key_event) {
+                    bail!("failed to send on channel: {}", e)
+                }
             }
         }
     }

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -53,10 +53,6 @@ impl Kanata {
                     check_for_exit(&key_event);
                     if !MAPPED_KEYS.lock().contains(&key_event.code) {
                         log::debug!("{key_event:?} is not mapped");
-                        // #139: send an event that is guaranteed to map to no-op to the processing loop so
-                        // that it will process tap-hold-press and tap-hold-release even for unmapped keys.
-                        key_event.code = OsCode::KEY_RESERVED;
-                        tx.send(key_event).unwrap();
                         continue;
                     }
                     log::debug!("sending {key_event:?} to processing loop");

--- a/src/kanata/windows/llhook.rs
+++ b/src/kanata/windows/llhook.rs
@@ -43,11 +43,6 @@ impl Kanata {
             // unwrap is safe because the KeyEvent conversion above would've returned false otherwise
             let oscode = OsCode::from_u32(input_event.code).unwrap();
             if !MAPPED_KEYS.lock().contains(&oscode) {
-                log::debug!("{key_event:?} is not mapped");
-                // #139: send an event that is guaranteed to map to no-op to the processing loop so
-                // that it will process tap-hold-press and tap-hold-release even for unmapped keys.
-                key_event.code = OsCode::KEY_RESERVED;
-                try_send_panic(&preprocess_tx, key_event);
                 return false;
             }
 


### PR DESCRIPTION
This commit adds a new defcfg item and reverts the first attempted fix
for tap-hold-(press|release) not being triggered by keys that are not in
defsrc. The first fix was not correct because the order of keys was
incorrect.

Processing keys missing from defsrc is disabled by default. The reason
this is not enabled by default is because some keys may not work
correctly if they are intercepted. E.g. ralt/altgr on Windows using the
LLHOOK mechanism.
