### PR TITLE
feat: add cancellable macro

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -237,6 +237,8 @@
   tbm (macro A-(tab 200 tab 200 tab) 200 S-A-(tab 200 tab 200 tab))
   hpy (macro S-i spc a m spc S-(h a p p y) spc m y S-f r S-i e S-n d)
 
+  rls (macro-release-cancel 1 500 bspc S-1 500 bspc S-2)
+
   ;; unicode accepts a single unicode character. The unicode character will
   ;; not be automatically repeated by holding the key down. The alias name
   ;; is the unicode character itself and is referenced by @🙁 in deflayer.

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -782,6 +782,8 @@ It also accepts a chorded list where the list is subject to the aforementioned
 restrictions. The number keys will be parsed as delays, so they must be aliased
 to be used in a macro.
 
+Up to 4 macros can be active at the same time.
+
 Example:
 
 ----
@@ -799,6 +801,25 @@ Example:
   ;; alt-tab(x3) and alt-shift-tab(x3) with macro
   tfd (macro A-(tab 200 tab 200 tab))
   tbk (macro A-S-(tab 200 tab 200 tab))
+)
+----
+
+There is a variant of the `+macro+` action that will cancel all active macros
+upon releasing the key: `+macro-release-cancel+`. It is parsed identically to
+the non-cancelling version. An example use case for this action is holding down
+a key to get different outputs, similar to tap-dance but one can see which keys
+are being outputted.
+
+E.g. in the example below, when holding the key, first `1` is typed, then
+replaced by `!` after 500ms, and finally that is replaced by `@` after another
+500ms. However, if the key is released, the last character typed will remain
+and the rest of the macro does not run.
+
+----
+(defalias
+  ;; macro-release-cancel to output different characters with visual feedback
+  ;; after holding for different amounts of time.
+  1!@ (macro-release-cancel 1 500 bspc S-1 500 bspc S-2)
 )
 ----
 

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -677,6 +677,7 @@ fn parse_action_list(ac: &[SExpr], parsed_state: &ParsedState) -> Result<&'stati
         "tap-hold-release" => parse_tap_hold(&ac[1..], parsed_state, HoldTapConfig::PermissiveHold),
         "multi" => parse_multi(&ac[1..], parsed_state),
         "macro" => parse_macro(&ac[1..], parsed_state),
+        "macro-release-cancel" => parse_macro_release_cancel(&ac[1..], parsed_state),
         "unicode" => parse_unicode(&ac[1..]),
         "one-shot" => parse_one_shot(&ac[1..], parsed_state),
         "tap-dance" => parse_tap_dance(&ac[1..], parsed_state),
@@ -862,6 +863,17 @@ fn parse_macro(ac_params: &[SExpr], parsed_state: &ParsedState) -> Result<&'stat
     Ok(sref(Action::Sequence {
         events: sref(all_events),
     }))
+}
+
+fn parse_macro_release_cancel(
+    ac_params: &[SExpr],
+    parsed_state: &ParsedState,
+) -> Result<&'static KanataAction> {
+    let macro_action = parse_macro(ac_params, parsed_state)?;
+    Ok(sref(Action::MultipleActions(sref(vec![
+        *macro_action,
+        Action::Custom(sref_slice(CustomAction::CancelMacroOnRelease)),
+    ]))))
 }
 
 fn parse_macro_item<'a>(

--- a/src/custom_action.rs
+++ b/src/custom_action.rs
@@ -22,6 +22,7 @@ pub enum CustomAction {
     SequenceLeader,
     LiveReload,
     Repeat,
+    CancelMacroOnRelease,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -340,6 +340,14 @@ impl Kanata {
                             }
                             pbtn
                         }
+                        CustomAction::CancelMacroOnRelease => {
+                            log::debug!("cancelling all macros");
+                            self.layout.active_sequences.clear();
+                            self.layout
+                                .states
+                                .retain(|s| !matches!(s, State::FakeKey { .. }));
+                            pbtn
+                        }
                         _ => pbtn,
                     })
                     .map(|btn| {


### PR DESCRIPTION
The use case motivating this feature is to be able to hold a key for different amounts of time and outputting different characters with visual feedback on what's getting outputted. It is similar to tap-dance but instead of tapping a key for varying number of repeats, the key is held for a varying amount of time to get the different outputs.