### PR TITLE
feat: allow some special actions in macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "kanata-keyberon"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1045f162723bf513d2923e3ad2e0da0e2f9bf0f031c352154ae76de2f5c4302"
+checksum = "3bded72defbe3f926390f6bfdb95fc84118ea3882dad47ff771a3bcc00e4d8ca"
 dependencies = [
  "arraydeque",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,14 @@ anyhow = "1"
 parking_lot = "0.12"
 crossbeam-channel = "0.5"
 once_cell = "1"
-kanata-keyberon = "0.3.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 net2 = "0.2"
 radix_trie = "0.2"
+
+kanata-keyberon = "0.4.0"
+# Uncomment below and comment out above for testing local keyberon changes
+# kanata-keyberon = { path = "keyberon" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = "0.12.0"

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -230,12 +230,13 @@
   é AG-2
   è RA-7
   testmacro (macro AG-2 RA-7)
+  🙃 (unicode 🙃)
 
   ;; macro accepts keys, chords, and numbers (a delay in ms). Note that numbers
   ;; will be parsed as delays, so they will need to be aliased to be used.
   lch (macro h t t p @: / / 100 l o c a l h o s t @: @8 @0 @8 @0)
   tbm (macro A-(tab 200 tab 200 tab) 200 S-A-(tab 200 tab 200 tab))
-  hpy (macro S-i spc a m spc S-(h a p p y) spc m y S-f r S-i e S-n d)
+  hpy (macro S-i spc a m spc S-(h a p p y) spc m y S-f r S-i e S-n d @🙃)
 
   rls (macro-release-cancel 1 500 bspc S-1 500 bspc S-2)
 
@@ -443,7 +444,7 @@
   _    @fcp @fsp @fmp @pal _    _    _    _    _    _    _    _    _
   _    @fcr @fsr @fap @ral _    _    _    _    _    _    _    _    _
   _    @fct @fst @rma _    _    _    _    _    _    _    _    _
-  _    _    _    _    _    _    _    _    _    _    _    _
+  _    @t1  _    _    _    _    _    _    _    _    _    _
   _    _    _              _              _    _    _
 )
 
@@ -483,6 +484,9 @@
       )
   pal (on-press-fakekey pal tap)
   ral (on-press-fakekey ral tap)
+
+  ;; Test of on-press-fakekey and on-release-fakekey in a macro
+  t1 (macro-release-cancel @fsp 5 a b c @fsr 5 c b a)
 
   ;; If you find that an application isn't registering keypresses correctly
   ;; with multi, you can try out:

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -153,8 +153,8 @@ Enabling this configuration makes kanata process keys that are not in defsrc.
 This is useful if you are only mapping a few keys in defsrc instead of most of
 the keys on your keyboard.
 
-Without this, the `+rpt+`, `+tap-hold-release+`, `+tap-hold-press+`, and
-`+defseq+` actions will not activate for keys that are not in defsrc.
+Without this, some actions like `+rpt+`, `+tap-hold-release+`, `+one-shot+`,
+will not work correctly for subsequent key presses that are not in defsrc.
 
 This is disabled by default. The reason this is not enabled by default is
 because some keys may not work correctly if they are intercepted. For example,
@@ -262,9 +262,8 @@ For more context, see: https://github.com/jtroo/kanata/issues/55.
 
 NOTE: Even with these workarounds, putting `+lctl+`+`+ralt+` in your defsrc may not
 work properly with other applications that also use keyboard interception.
-Known applications with issues:
+Known application with issues: GWSL/VcXsrv
 
-* GWSL/VcXsrv
 
 === Using multiple defcfg entries
 <<table-of-contents,Back to ToC>>
@@ -747,12 +746,12 @@ of the hold action activating.
 The hold timeout is the number of milliseconds after which the hold action will
 activate.
 
-There are two additional variants of `+tap-hold-+`:
+There are two additional variants of `+tap-hold+`:
 
-* tap-hold-press
+* `+tap-hold-press+`
 ** If there is a press of a different key, the hold action is activated even if
 the hold timeout hasn't expired yet
-* tap-hold-release
+* `+tap-hold-release+`
 ** If there is a press+release of a different key, the hold action is activated
 even if the hold timeout hasn't expired yet
 
@@ -777,12 +776,18 @@ all keys are held, whereas in `+macro+`, keys are pressed then released.
 This means that with `+macro+` you can have some letters capitalized and others
 not. This is not possible with `+multi+`.
 
-The `+macro+` action accepts one or more keys, chords, and delays (unit: ms).
+The `+macro+` action accepts one or more keys, some actions, chords, and delays (unit: ms).
 It also accepts a chorded list where the list is subject to the aforementioned
 restrictions. The number keys will be parsed as delays, so they must be aliased
 to be used in a macro.
 
 Up to 4 macros can be active at the same time.
+
+The actions supported in `+macro+` are:
+
+* <<cmd, cmd>>
+* <<unicode, unicode>>
+* <<mouse-actions,mouse actions>>
 
 Example:
 
@@ -791,12 +796,13 @@ Example:
   : S-;
   8 8
   0 0
+  🙃 (unicode 🙃)
 
   ;; Type "http://localhost:8080"
   lch (macro h t t p @: / / 100 l o c a l h o s t @: @8 @0 @8 @0)
 
-  ;; Type "I am HAPPY my FrIeNd"
-  hpy (macro S-i spc a m spc S-(h a p p y) spc m y S-f r S-i e S-n d)
+  ;; Type "I am HAPPY my FrIeNd 🙃"
+  hpy (macro S-i spc a m spc S-(h a p p y) spc m y S-f r S-i e S-n d spc @🙃)
 
   ;; alt-tab(x3) and alt-shift-tab(x3) with macro
   tfd (macro A-(tab 200 tab 200 tab))
@@ -922,6 +928,9 @@ Do note that processing a fakekey-delay and even a sequence of delays will
 delay any other inputs from being processed until the fakekey-delays are all
 complete, so use with care.
 
+NOTE: You will likely want to use `+macro+` instead of fake keys with delays now
+that `+macro+` supports more actions.
+
 ----
 (defalias
   stm (multi ;; Shift -> middle mouse with a delay
@@ -935,7 +944,7 @@ complete, so use with care.
 )
 ----
 
-For more context, you could read the
+For more context, you can read the
 https://github.com/jtroo/kanata/issues/80[issue that sparked the creation of fake keys].
 
 === Sequences

--- a/keyberon/Cargo.toml
+++ b/keyberon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanata-keyberon"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>", "Robin Krahl <robin.krahl@ireas.org>", "jtroo <j.andreitabs@gmail.com>"]
 edition = "2018"
 description = "Pure Rust keyboard firmware. Fork intended for use with kanata."

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -876,10 +876,14 @@ fn parse_macro_release_cancel(
     ]))))
 }
 
+#[allow(clippy::type_complexity)] // return type is not pub
 fn parse_macro_item<'a>(
     acs: &'a [SExpr],
     parsed_state: &ParsedState,
-) -> Result<(Vec<SequenceEvent>, &'a [SExpr])> {
+) -> Result<(
+    Vec<SequenceEvent<&'static [&'static CustomAction]>>,
+    &'a [SExpr],
+)> {
     if let Ok(duration) = parse_timeout(&acs[0]) {
         let duration = u32::from(duration);
         return Ok((vec![SequenceEvent::Delay { duration }], &acs[1..]));
@@ -907,6 +911,7 @@ fn parse_macro_item<'a>(
             }
             Ok((events, &acs[1..]))
         }
+        Ok(Action::Custom(custom)) => Ok((vec![SequenceEvent::Custom(custom)], &acs[1..])),
         _ => {
             // Try to parse a chorded sub-macro, e.g. S-(tab tab tab)
             if acs.len() < 2 {


### PR DESCRIPTION
This commit enhances the `macro` and `macro-release-cancel` actions by allowing some other special actions to be used inside. Some actions, e.g. `tap-hold` don't make much sense to put in a macro, so are not supported.

The precise list of actions allowed within `macro` are those that correspond to an action in the `CustomAction` enum.

At the time of writing, the list of useful actions supported in macros are:

- cmd
- unicode
- mouse actions

There are more actions that are technically allowed, but seem like they don't make much sense to put inside of a macro. Thus they are not documented:

- fake key actions
- sequence leader
- live reload
- repeat