### PR TITLE
fix: add multi key and multi action to key outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "radix_trie",
+ "rustc-hash",
  "serde",
  "serde_json",
  "signal-hook",
@@ -367,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "kanata-keyberon"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bded72defbe3f926390f6bfdb95fc84118ea3882dad47ff771a3bcc00e4d8ca"
+checksum = "41fc12097885f8c361bac7de8264e8425c4d961f8e526d91315cbc7aecc4e162"
 dependencies = [
  "arraydeque",
  "either",
@@ -723,6 +724,12 @@ dependencies = [
  "lazy_static",
  "regex",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 net2 = "0.2"
 radix_trie = "0.2"
+rustc-hash = "1.1.0"
 
-kanata-keyberon = "0.4.0"
+kanata-keyberon = "0.5.0"
 # Uncomment below and comment out above for testing local keyberon changes
 # kanata-keyberon = { path = "keyberon" }
 

--- a/keyberon/Cargo.toml
+++ b/keyberon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanata-keyberon"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>", "Robin Krahl <robin.krahl@ireas.org>", "jtroo <j.andreitabs@gmail.com>"]
 edition = "2018"
 description = "Pure Rust keyboard firmware. Fork intended for use with kanata."

--- a/keyberon/src/action.rs
+++ b/keyberon/src/action.rs
@@ -43,8 +43,14 @@ impl<T> Debug for SequenceEvent<T> {
             Self::Press(arg0) => f.debug_tuple("Press").field(arg0).finish(),
             Self::Release(arg0) => f.debug_tuple("Release").field(arg0).finish(),
             Self::Tap(arg0) => f.debug_tuple("Tap").field(arg0).finish(),
-            Self::Delay { duration } => f.debug_struct("Delay").field("duration", duration).finish(),
-            Self::Continue { index, events } => f.debug_struct("Continue").field("index", index).field("events", events).finish(),
+            Self::Delay { duration } => {
+                f.debug_struct("Delay").field("duration", duration).finish()
+            }
+            Self::Continue { index, events } => f
+                .debug_struct("Continue")
+                .field("index", index)
+                .field("events", events)
+                .finish(),
             Self::Custom(_) => write!(f, "Custom"),
             Self::Complete => write!(f, "Complete"),
         }
@@ -221,7 +227,6 @@ where
 }
 
 /// The different actions that can be done.
-#[non_exhaustive]
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub enum Action<T = core::convert::Infallible>
 where

--- a/keyberon/src/hid.rs
+++ b/keyberon/src/hid.rs
@@ -16,14 +16,14 @@ const INTERFACE_CLASS_HID: u8 = 0x03;
 
 pub struct Error;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Subclass {
     None = 0x00,
     BootInterface = 0x01,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Protocol {
     None = 0x00,
@@ -39,7 +39,7 @@ pub enum DescriptorType {
     _Physical = 0x23,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Request {
     GetReport = 0x01,
@@ -64,7 +64,7 @@ impl Request {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReportType {
     Input,
     Output,

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -663,7 +663,7 @@ impl<const C: usize, const R: usize, const L: usize, T: 'static + Copy> Layout<C
                             }
                         }
                         Some(SequenceEvent::Custom(custom)) => {
-                            let _ =  self.states.push(State::SeqCustomPending(&custom));
+                            let _ = self.states.push(State::SeqCustomPending(custom));
                         }
                         _ => {} // We'll never get here
                     }

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::kanata::*;
 use crate::keys::{KeyValue, OsCode};
 
-static PRESSED_KEYS: Lazy<Mutex<HashSet<OsCode>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+static PRESSED_KEYS: Lazy<Mutex<HashSet<OsCode>>> = Lazy::new(|| Mutex::new(HashSet::default()));
 
 impl Kanata {
     pub fn event_loop(kanata: Arc<Mutex<Self>>, tx: Sender<KeyEvent>) -> Result<()> {

--- a/src/kanata/windows/llhook.rs
+++ b/src/kanata/windows/llhook.rs
@@ -1,13 +1,14 @@
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use parking_lot::Mutex;
-use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use std::time;
 
 use crate::kanata::*;
 
-static PRESSED_KEYS: Lazy<Mutex<HashSet<OsCode>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+type HashSet<T> = rustc_hash::FxHashSet<T>;
+
+static PRESSED_KEYS: Lazy<Mutex<HashSet<OsCode>>> = Lazy::new(|| Mutex::new(HashSet::default()));
 
 impl Kanata {
     /// Initialize the callback that is passed to the Windows low level hook to receive key events

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -7,7 +7,6 @@ use signal_hook::{
     iterator::Signals,
 };
 
-use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::os::unix::io::AsRawFd;
@@ -18,6 +17,8 @@ use crate::custom_action::*;
 use crate::keys::KeyEvent;
 use crate::keys::*;
 
+type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
+
 pub struct KbdIn {
     devices: HashMap<Token, Device>,
     poll: Poll,
@@ -26,7 +27,7 @@ pub struct KbdIn {
 
 impl KbdIn {
     pub fn new(dev_paths: &[String]) -> Result<Self, io::Error> {
-        let mut device_map = HashMap::new();
+        let mut device_map = HashMap::default();
         let poll = Poll::new()?;
 
         let devices = if !dev_paths.is_empty() {

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -3,12 +3,13 @@ use anyhow::Result;
 use net2::TcpStreamExt;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
+
+type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ServerMessage {
@@ -43,7 +44,7 @@ impl TcpServer {
     pub fn new(port: i32) -> Self {
         Self {
             port,
-            connections: Arc::new(Mutex::new(HashMap::new())),
+            connections: Arc::new(Mutex::new(HashMap::default())),
         }
     }
 


### PR DESCRIPTION
This commit fixes a bug where `multi` and chorded keys like `S-b` were not generating key outputs for the purposes of repeat. The new code fixes the issue with hopes to prevent further regressions by changing the keyberon `Action` to be exhaustively matchable and explicitly handling all cases instead of using a catch-all `_ => { ... }` branch.