### PR TITLE
fix KEY_MAIL; support 'calc' keycode

### DIFF
--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -184,7 +184,9 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
 
         "hmpg" | "homepage" => OsCode::KEY_HOMEPAGE,
         "mdia" | "media" => OsCode::KEY_MEDIA,
-        "mail" | "email" => OsCode::KEY_EMAIL,
+        "mail" => OsCode::KEY_MAIL,
+        "email" => OsCode::KEY_EMAIL,
+        "calc" => OsCode::KEY_CALC,
 
         // NOTE: these are linux-only right now due to missing the mappings in windows.rs
         #[cfg(tagret_os = "linux")]
@@ -961,6 +963,7 @@ impl From<KeyCode> for OsCode {
             KeyCode::K0xAB => OsCode::KEY_EMAIL,
             KeyCode::K0xAC => OsCode::KEY_PLAYER,
             KeyCode::K0xAD => OsCode::KEY_HOMEPAGE,
+            KeyCode::K0xAE => OsCode::KEY_MAIL,
             _ => OsCode::KEY_UNKNOWN,
         }
     }
@@ -1133,6 +1136,7 @@ impl From<OsCode> for KeyCode {
             OsCode::KEY_EMAIL => KeyCode::K0xAB,
             OsCode::KEY_PLAYER => KeyCode::K0xAC,
             OsCode::KEY_HOMEPAGE => KeyCode::K0xAD,
+            OsCode::KEY_MAIL => KeyCode::K0xAE,
             _ => KeyCode::No,
         }
     }


### PR DESCRIPTION
Hello and thank you for the great work that you do.

First the easy part:  I introduced the "calc" shortcut, which was missing and it was impossible to access this special key of my keyboard.

Now the difficult part that needs discussion: I know that this PR introduces a breaking change, but I didn't know how to handle it.
I handled it how I'd do for my own projects. By properly fixing an old misunderstanding.

From what I see in the sources, there are two completely different keys, the "KEY_EMAIL" and the "KEY_MAIL", with different key codes. In the original code, when defining keys, the "email" key definition had a shortcut "mail", and the "KEY_MAIL" was completely ignored.  With this PR I try to fix this.

Of course as an alternative a new different keycode could be introduced to save the breaking change, but I believe in the long run, this will introduce more confusion instead of solving problems. It's up to you to define what the roadmap should be.