### PR TITLE
feat(win-interception): implement mouse btns in defsrc

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -65,6 +65,19 @@
   ;; windows-altgr configuration item above for context.
   ;;
   ;; process-unmapped-keys yes
+
+  ;; Optional configuration: intercept mouse buttons for a specific mouse device.
+  ;; The intended use case for this is for laptops such as a Thinkpad, which have
+  ;; mouse buttons that may be useful to activate kanata actions with. This only
+  ;; works with the Interception driver.
+  ;;
+  ;; To know what numbers to put into the string, you can run the
+  ;; kanata-wintercept variant with this defcfg item defined with random numbers.
+  ;; Then when a button is first pressed on the mouse device, kanata will print
+  ;; its hwid in the log; you can then copy-paste that into this configuration
+  ;; entry. If this defcfg item is not defined, the log will not print.
+  ;;
+  ;; windows-interception-mouse-hwid "70, 0, 90, 0, 20"
 )
 
 ;; Only one defsrc is allowed.

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -264,6 +264,31 @@ NOTE: Even with these workarounds, putting `+lctl+`+`+ralt+` in your defsrc may 
 work properly with other applications that also use keyboard interception.
 Known application with issues: GWSL/VcXsrv
 
+=== Windows only: windows-interception-mouse-hwid
+<<table-of-contents,Back to ToC>>
+
+This defcfg item allows you to intercept mouse buttons for a specific mouse
+device. This only works with the Interception driver (the -wintercept variants
+of the binary).
+
+The intended use case for this is for laptops such as a Thinkpad, which have
+mouse buttons that may be desirable to activate kanata actions with.
+
+To know what numbers to put into the string, you can run the variant with this
+defcfg item defined with any numbers. Then when a button is first pressed on
+the mouse device, kanata will print its hwid in the log; you can then
+copy-paste that into this configuration entry. If this defcfg item is not
+defined, the log will not print.
+
+https://github.com/jtroo/kanata/issues/108[Relevant issue].
+
+Example:
+
+----
+(defcfg
+  windows-interception-mouse-hwid "70, 0, 60, 0"
+)
+----
 
 === Using multiple defcfg entries
 <<table-of-contents,Back to ToC>>
@@ -288,6 +313,7 @@ a non-applicable operating system.
   sequence-timeout 2000
   linux-dev /dev/input/dev1:/dev/input/dev2
   windows-altgr add-lctl-release
+  windows-interception-mouse-hwid "70, 0, 60, 0"
 )
 ----
 

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -435,7 +435,13 @@ fn parse_defcfg(expr: &[SExpr]) -> Result<HashMap<String, String>> {
         };
         match (&key, &val) {
             (SExpr::Atom(k), SExpr::Atom(v)) => {
-                if cfg.insert(k.t.clone(), v.t.clone()).is_some() {
+                if cfg
+                    .insert(
+                        k.t.trim_matches('"').to_owned(),
+                        v.t.trim_matches('"').to_owned(),
+                    )
+                    .is_some()
+                {
                     bail!("duplicate cfg entries for key {}", k.t);
                 }
             }
@@ -1058,9 +1064,9 @@ fn parse_cmd(ac_params: &[SExpr], is_cmd_enabled: bool) -> Result<&'static Kanat
         Box::leak(
             ac_params
                 .iter()
-                .try_fold(Vec::new(), |mut v, p| {
+                .try_fold(vec![], |mut v, p| {
                     if let SExpr::Atom(s) = p {
-                        v.push(s.t.clone());
+                        v.push(s.t.trim_matches('"').to_owned());
                         Ok(v)
                     } else {
                         bail!("{}, found a list", ERR_STR);

--- a/src/cfg/sexpr.rs
+++ b/src/cfg/sexpr.rs
@@ -120,7 +120,7 @@ impl std::fmt::Debug for SExpr {
 enum Token {
     Open,
     Close,
-    String,
+    StringTok,
 }
 pub struct Lexer<'a> {
     s: &'a str,
@@ -174,7 +174,7 @@ impl<'a> Lexer<'a> {
                         b'"' => {
                             self.next_while(|b| b != b'"' && b != b'\n');
                             match self.bytes.next() {
-                                Some(b'"') => String,
+                                Some(b'"') => StringTok,
                                 _ => return Some((start, Err("Unterminated string".to_string()))),
                             }
                         }
@@ -202,7 +202,7 @@ impl<'a> Lexer<'a> {
     fn next_string(&mut self) -> Token {
         // might want to limit this to ascii or XID_START/XID_CONTINUE
         self.next_while(|b| !is_start(b));
-        Token::String
+        Token::StringTok
     }
 }
 
@@ -242,7 +242,7 @@ fn parse_with(
                     }
                     stack.last_mut().unwrap().t.push(expr);
                 }
-                String => stack
+                StringTok => stack
                     .last_mut()
                     .unwrap()
                     .t

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -8,6 +8,7 @@ use crate::kanata::*;
 use crate::keys::{KeyValue, OsCode};
 
 static PRESSED_KEYS: Lazy<Mutex<HashSet<OsCode>>> = Lazy::new(|| Mutex::new(HashSet::default()));
+const HWID_ARR_SZ: usize = 128;
 
 impl Kanata {
     pub fn event_loop(kanata: Arc<Mutex<Self>>, tx: Sender<KeyEvent>) -> Result<()> {
@@ -20,13 +21,28 @@ impl Kanata {
             state: ic::KeyState::empty(),
             information: 0,
         }; 32];
+        intrcptn.set_filter(ic::is_mouse, ic::Filter::MouseFilter(ic::MouseState::all()));
+
+        let mouse_to_intercept_hwid: Option<[u8; HWID_ARR_SZ]> = kanata
+            .lock()
+            .intercept_mouse_hwid.as_ref()
+            .map(|hwid| {
+                hwid.iter().copied().enumerate()
+                    .fold([0u8; HWID_ARR_SZ], |mut hwid, idx_byte| {
+                        let (i, b) = idx_byte;
+                        if i > HWID_ARR_SZ {
+                            panic!("windows-interception-mouse-hwid is too long; it should be up to {HWID_ARR_SZ} 8-bit unsigned integers");
+                        }
+                        hwid[i] = b;
+                        hwid
+                    })
+            });
+        let mut is_dev_interceptable: HashMap<ic::Device, bool> = HashMap::default();
 
         loop {
             let dev = intrcptn.wait_with_timeout(std::time::Duration::from_millis(1));
             if dev > 0 {
-                let num_strokes = intrcptn.receive(dev, &mut strokes);
-                let num_strokes = num_strokes as usize;
-
+                let num_strokes = intrcptn.receive(dev, &mut strokes) as usize;
                 for i in 0..num_strokes {
                     log::debug!("got stroke {:?}", strokes[i]);
                     let mut key_event = match strokes[i] {
@@ -45,9 +61,26 @@ impl Kanata {
                             };
                             KeyEvent { code, value }
                         }
-                        _ => {
-                            intrcptn.send(dev, &strokes[i..i + 1]);
-                            continue;
+                        ic::Stroke::Mouse { state, .. } => {
+                            log::trace!("matched on mouse stroke");
+                            if let Some(hwid) = mouse_to_intercept_hwid {
+                                log::trace!("checking mouse state to event");
+                                if let Some(event) = mouse_state_to_event(
+                                    dev,
+                                    &hwid,
+                                    state,
+                                    &intrcptn,
+                                    &mut is_dev_interceptable,
+                                ) {
+                                    event
+                                } else {
+                                    intrcptn.send(dev, &strokes[i..i + 1]);
+                                    continue;
+                                }
+                            } else {
+                                intrcptn.send(dev, &strokes[i..i + 1]);
+                                continue;
+                            }
                         }
                     };
                     check_for_exit(&key_event);
@@ -99,5 +132,82 @@ impl Kanata {
                 Err(TryRecvError::Empty) => {}
             }
         }
+    }
+}
+
+fn mouse_state_to_event(
+    input_dev: ic::Device,
+    allowed_hwid: &[u8; HWID_ARR_SZ],
+    state: ic::MouseState,
+    intrcptn: &ic::Interception,
+    is_dev_interceptable: &mut HashMap<ic::Device, bool>,
+) -> Option<KeyEvent> {
+    if !match is_dev_interceptable.get(&input_dev) {
+        Some(v) => *v,
+        None => {
+            let mut hwid = [0u8; HWID_ARR_SZ];
+            log::trace!("getting hardware id for input dev: {input_dev}");
+            let res = intrcptn.get_hardware_id(input_dev, &mut hwid);
+            let dev_is_interceptable = hwid == *allowed_hwid;
+            log::info!("res {res}; device #{input_dev} hwid {hwid:?} matches allowed mouse input: {dev_is_interceptable}");
+            is_dev_interceptable.insert(input_dev, dev_is_interceptable);
+            dev_is_interceptable
+        }
+    } {
+        return None;
+    }
+
+    if state.contains(ic::MouseState::RIGHT_BUTTON_DOWN) {
+        Some(KeyEvent {
+            code: OsCode::BTN_RIGHT,
+            value: KeyValue::Press,
+        })
+    } else if state.contains(ic::MouseState::RIGHT_BUTTON_UP) {
+        Some(KeyEvent {
+            code: OsCode::BTN_RIGHT,
+            value: KeyValue::Release,
+        })
+    } else if state.contains(ic::MouseState::LEFT_BUTTON_DOWN) {
+        Some(KeyEvent {
+            code: OsCode::BTN_LEFT,
+            value: KeyValue::Press,
+        })
+    } else if state.contains(ic::MouseState::LEFT_BUTTON_UP) {
+        Some(KeyEvent {
+            code: OsCode::BTN_LEFT,
+            value: KeyValue::Release,
+        })
+    } else if state.contains(ic::MouseState::MIDDLE_BUTTON_DOWN) {
+        Some(KeyEvent {
+            code: OsCode::BTN_MIDDLE,
+            value: KeyValue::Press,
+        })
+    } else if state.contains(ic::MouseState::MIDDLE_BUTTON_UP) {
+        Some(KeyEvent {
+            code: OsCode::BTN_MIDDLE,
+            value: KeyValue::Release,
+        })
+    } else if state.contains(ic::MouseState::BUTTON_4_DOWN) {
+        Some(KeyEvent {
+            code: OsCode::BTN_SIDE,
+            value: KeyValue::Press,
+        })
+    } else if state.contains(ic::MouseState::BUTTON_4_UP) {
+        Some(KeyEvent {
+            code: OsCode::BTN_SIDE,
+            value: KeyValue::Release,
+        })
+    } else if state.contains(ic::MouseState::BUTTON_5_DOWN) {
+        Some(KeyEvent {
+            code: OsCode::BTN_EXTRA,
+            value: KeyValue::Press,
+        })
+    } else if state.contains(ic::MouseState::BUTTON_5_UP) {
+        Some(KeyEvent {
+            code: OsCode::BTN_EXTRA,
+            value: KeyValue::Release,
+        })
+    } else {
+        None
     }
 }


### PR DESCRIPTION
This commit implements mouse buttons in defsrc for Windows with the use of the interception driver. It includes a new defcfg item which states which mouse hardware ID to intercept. Since the intended use case is for laptops that have builtin mouse buttons like Lenovo Thinkpads, only a single hardware ID is allowed for now.

This commit also fixes a bug in the parsing which probably only affected the `cmd` action. The bug is that quoted strings keep their quotes when parsed as an atom by the S-expression parser. This was introduced in v1.0.8. This behaviour is not changed; instead, the quotes are trimmed when parsing `cmd` and `defcfg`. If one day the parser is properly fixed to remove the leading and trailing quotes from atoms, then the trimming code should still be fine; `trim_matches` will be fine with or without the quotes.

Closes #108 