### PR TITLE
feat: add custom key labels in cfg

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -78,11 +78,20 @@ If you need help, you are welcome to ask.
   ;; process-unmapped-keys yes
 )
 
-;; defcustomkeys enables you to define and use key names that match your locale
+;; deflocalkeys-* enables you to define and use key names that match your locale
 ;; by defining OS code number mappings for that character.
 ;;
-;; Only one defcustomkeys is allowed. It is parsed similarly to defcfg; it is
-;; composed of pairs of keys and values.
+;; There are three variants of deflocalkeys-*:
+;; - deflocalkeys-win
+;; - deflocalkeys-wintercept
+;; - deflocalkeys-linux
+;;
+;; Only one of each deflocalkeys-* variant is allowed. The variants that are
+;; not applicable will be ignored, e.g. deflocalkeys-linux and deflocalkeys-wintercept
+;; are both ignored when using the default Windows kanata binary.
+;;
+;; The configuration item is parsed similarly to defcfg; it is composed of
+;; pairs of keys and values.
 ;;
 ;; You can check docs/locales.adoc for the mapping for your locale. If your
 ;; locale is not there, please ask for help if needed, and add the mapping for
@@ -93,7 +102,16 @@ If you need help, you are welcome to ask.
 ;;
 ;; To see how you can discover key mappings for yourself, see the "Non-US keyboards"
 ;; section of docs/config.adoc.
-(defcustomkeys
+
+(deflocalkeys-win
+  ì 187
+)
+
+(deflocalkeys-wintercept
+  ì 187
+)
+
+(deflocalkeys-linux
   ì 13
 )
 

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -78,6 +78,25 @@ If you need help, you are welcome to ask.
   ;; process-unmapped-keys yes
 )
 
+;; defcustomkeys enables you to define and use key names that match your locale
+;; by defining OS code number mappings for that character.
+;;
+;; Only one defcustomkeys is allowed. It is parsed similarly to defcfg; it is
+;; composed of pairs of keys and values.
+;;
+;; You can check docs/locales.adoc for the mapping for your locale. If your
+;; locale is not there, please ask for help if needed, and add the mapping for
+;; your locale to the document.
+;;
+;; This example is for an Italian keyboard remapping in Linux. The numbers will
+;; unfortunately differ between Linux, Windows-hooks, and Windows-interception.
+;;
+;; To see how you can discover key mappings for yourself, see the "Non-US keyboards"
+;; section of docs/config.adoc.
+(defcustomkeys
+  ì 13
+)
+
 ;; Only one defsrc is allowed.
 ;;
 ;; defsrc defines the keys that will be intercepted by kanata. The order of the
@@ -342,8 +361,8 @@ If you need help, you are welcome to ask.
 ;; The intended use case is to be able to use a different finger to repeat a
 ;; double letter, as opposed to double-tapping a letter.
 (deflayer misc
-  _    _    _    _    _    _    _    _    _    @é   @è    _    _    _
-  _    _    _    _    _    _    ins  @{   @}   [    ]    _    _    _
+  _    _    _    _    _    _    _    _    _    @é   @è   _    ì #|random custom key for testing|#   _
+  _    _    _    _    _    _    ins  @{   @}   [    ]    _    _    +
   _    _    _    _    C-u  _    del  bspc esc  ret  _    _    _
   _    C-z  C-x  C-c  C-v  _    _    _    @td  @os1 @os2 @os3
   rpt  _    _              _              _    _    _

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -97,11 +97,15 @@ If you need help, you are welcome to ask.
 ;; locale is not there, please ask for help if needed, and add the mapping for
 ;; your locale to the document.
 ;;
+;; Web link for locales: https://github.com/jtroo/kanata/blob/main/docs/locales.adoc
+;;
 ;; This example is for an Italian keyboard remapping in Linux. The numbers will
 ;; unfortunately differ between Linux, Windows-hooks, and Windows-interception.
 ;;
 ;; To see how you can discover key mappings for yourself, see the "Non-US keyboards"
 ;; section of docs/config.adoc.
+;;
+;; Web link or config: https://github.com/jtroo/kanata/blob/main/docs/config.adoc
 
 (deflocalkeys-win
   ì 187

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -92,10 +92,7 @@ approximately 60% keyboard layout:
 )
 ----
 
-For non-US layouts, there is a discussion here that may be of help:
-https://github.com/jtroo/kanata/discussions/158. If you do not see your locale
-there, please be welcome to ask for help to generate a `defsrc` for yours, and
-then kindly contribute to the discussion with a working sample.
+For non-US keyboards, see <<non-us-keyboards,this section>>.
 
 === deflayer
 <<table-of-contents,Back to ToC>>
@@ -155,6 +152,49 @@ An example minimal configuration is:
 
 This will make kanata remap your `a b c` keys to `1 2 3`. This is almost
 certainly undesirable but is a valid configuration.
+
+== Non-US keyboards
+<<table-of-contents,Back to ToC>>
+
+For non-US keyboard users, you may have some keys on your keyboard that are
+cannot be mapped in `defsrc` by default. You can use `defcustomkeys` to define
+additional key names that can be used in `defsrc`, `deflayer` and anywhere else
+in the configuration.
+
+You can find configurations that others have made in xref:locales.adoc[this
+document]. If you do not see your keyboard there and are not confident in using
+the available tools, you are welcome to ask for help in a discussion or issue.
+Please contribute to the document if you are able!
+
+Example:
+
+----
+(defcustomkeys
+  ì 13
+)
+
+(defsrc
+  grv  1    2    3    4    5    6    7    8    9    0    -    ì    bspc
+)
+----
+
+The number used for a custom key represents the converted value for an OsCode in
+base 10. This differs between Windows-hooks, Windows-interception, and Linux.
+
+In Linux, `evtest` will give the correct number for the physical key you press.
+
+In Windows using the default hook mechanism, the non-interception version of the
+keyboard tester in the kanata repository will give the correct number.
+(https://github.com/jtroo/kanata/releases/tag/win-keycode-tester-v0.2.0[prebuilt binary])
+
+In Windows using Interception, the interception version of the keyboard tester
+will give the correct number. Between the hook and interception versions, some
+keys may agree but some will not; do be aware that they are **not** compatible!
+
+Ideas are for improving the user-friendliness of this system is welcome! As
+mentioned before, please ask for help in an issue or discussion if needed, and
+help with xref:locales.adoc[this document] is very welcome, so that future
+users can have an easier time 🙂.
 
 == Optional defcfg entries
 

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -157,9 +157,20 @@ certainly undesirable but is a valid configuration.
 <<table-of-contents,Back to ToC>>
 
 For non-US keyboard users, you may have some keys on your keyboard that are
-cannot be mapped in `defsrc` by default. You can use `defcustomkeys` to define
-additional key names that can be used in `defsrc`, `deflayer` and anywhere else
-in the configuration.
+cannot be mapped in `defsrc` by default, at least according to the symbol
+shown. You can use `deflocalkeys` to define additional key names that can be
+used in `defsrc`, `deflayer` and anywhere else in the configuration.
+
+There are three variants of deflocalkeys:
+
+- `deflocalkeys-win`
+- `deflocalkeys-winintercept`
+- `deflocalkeys-linux`
+
+
+Only one of each deflocalkeys-* variant is allowed. The variants that are not
+applicable will be ignored, e.g. deflocalkeys-linux and deflocalkeys-wintercept
+are both ignored when using the default Windows kanata binary.
 
 You can find configurations that others have made in xref:locales.adoc[this
 document]. If you do not see your keyboard there and are not confident in using
@@ -169,7 +180,15 @@ Please contribute to the document if you are able!
 Example:
 
 ----
-(defcustomkeys
+(deflocalkeys-win
+  ì 187
+)
+
+(deflocalkeys-wintercept
+  ì 187
+)
+
+(deflocalkeys-linux
   ì 13
 )
 
@@ -189,11 +208,11 @@ keyboard tester in the kanata repository will give the correct number.
 
 In Windows using Interception, the interception version of the keyboard tester
 will give the correct number. Between the hook and interception versions, some
-keys may agree but some will not; do be aware that they are **not** compatible!
+keys may agree but others may not; do be aware that they are **not** compatible!
 
-Ideas are for improving the user-friendliness of this system is welcome! As
+Ideas for improving the user-friendliness of this system are welcome! As
 mentioned before, please ask for help in an issue or discussion if needed, and
-help with xref:locales.adoc[this document] is very welcome, so that future
+help with xref:locales.adoc[this document] is very welcome so that future
 users can have an easier time 🙂.
 
 == Optional defcfg entries

--- a/docs/locales.adoc
+++ b/docs/locales.adoc
@@ -22,14 +22,14 @@ toc::[]
   ^    220
   ´    221
   ä    222
-  <>|  226
+  <    226
 )
 
 (defsrc
   ^         1    2    3    4    5    6    7    8    9    0    ß    ´    bspc
   tab       q    w    e    r    t    z    u    i    o    p    ü    +
   caps      a    s    d    f    g    h    j    k    l    ö    ä    #    ret
-  lsft <>|  y    x    c    v    b    n    m    ,    .    -    rsft
+  lsft <    y    x    c    v    b    n    m    ,    .    -    rsft
   lctl lmet lalt           spc            ralt rmet rctl
 )
 ----

--- a/docs/locales.adoc
+++ b/docs/locales.adoc
@@ -6,10 +6,12 @@
 == Table of contents
 toc::[]
 
-== ISO German QWERTZ - Windows hooks
+== ISO German QWERTZ - Windows (non-interception)
 
 === Using `defcustomkeys`:
 
+[%collapsible]
+====
 ----
 (defcustomkeys
   ü    186
@@ -31,9 +33,12 @@ toc::[]
   lctl lmet lalt           spc            ralt rmet rctl
 )
 ----
+====
 
 === Without using `defcustomkeys`:
 
+[%collapsible]
+====
 ----
 (defsrc
   \         1    2    3    4    5    6    7    8    9    0    [    ]    bspc
@@ -43,3 +48,55 @@ toc::[]
   lctl lmet lalt           spc            ralt rmet rctl
 )
 ----
+====
+
+=== Example aliases
+
+[%collapsible]
+====
+----
+(defalias
+  ;; shifted german keys
+  ! S-1
+  ˝ S-2  ;; unicode 02DD ˝ look-a-like is used because @" is no valid alias, to be displayed correctly
+         ;; in console requires a font that can - e.g. cascadia
+  §	S-3
+  $	S-4
+  %	S-5
+  &	S-6
+  /	S-7
+  ﴾	S-8  ;; unicode FD3E ﴾ look-a-like is used because @( is no valid alias, to be displayed correctly...
+  ﴿	S-9  ;; unicode FD3F ﴿ look-a-like is used because @) is no valid alias, to be displayed correctly ...
+  =	S-0
+  ? S-ß
+  * S-+
+  ' S-#
+  ; S-,
+  : S-.
+  _ S--
+  > S-<
+  < <   ;; not really needed but having @< and @> looks consistent
+
+  ;; change dead keys in normal keys
+  ´ (macro ´ spc )	  ;; ´ 
+  ` (macro S-´ spc )  ;; `
+  ^ (macro ^ spc )    ;; ^ = \ - shifting @^ will produce an incorrect space now
+  ° S-^
+  
+  ;; AltGr german keys
+  ~ A-C-+
+  \ A-C-ß
+  ẞ A-C-S-ß
+  | A-C-<
+  } A-C-0
+  { A-C-7
+  ] A-C-9
+  [ A-C-8	
+  € A-C-e
+  @ A-C-q
+  ² A-C-2
+  ³ A-C-3
+  µ A-C-m
+)
+----
+====

--- a/docs/locales.adoc
+++ b/docs/locales.adoc
@@ -1,0 +1,45 @@
+= Keyboard locales
+:toc:
+:toc-placement!:
+:toc-title!:
+
+== Table of contents
+toc::[]
+
+== ISO German QWERTZ - Windows hooks
+
+=== Using `defcustomkeys`:
+
+----
+(defcustomkeys
+  ü    186
+  +    187
+  #    191
+  ö    192
+  ß    219
+  ^    220
+  ´    221
+  ä    222
+  <>|  226
+)
+
+(defsrc
+  ^         1    2    3    4    5    6    7    8    9    0    ß    ´    bspc
+  tab       q    w    e    r    t    z    u    i    o    p    ü    +
+  caps      a    s    d    f    g    h    j    k    l    ö    ä    #    ret
+  lsft <>|  y    x    c    v    b    n    m    ,    .    -    rsft
+  lctl lmet lalt           spc            ralt rmet rctl
+)
+----
+
+=== Without using `defcustomkeys`:
+
+----
+(defsrc
+  \         1    2    3    4    5    6    7    8    9    0    [    ]    bspc
+  tab       q    w    e    r    t    z    u    i    o    p    ;    =
+  caps      a    s    d    f    g    h    j    k    l    grv  '    /    ret
+  lsft 102d y    x    c    v    b    n    m    ,    .    -    rsft
+  lctl lmet lalt           spc            ralt rmet rctl
+)
+----

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -250,6 +250,13 @@ fn parse_cfg(
     ))
 }
 
+#[cfg(all(not(feature = "interception_driver"), target_os = "windows"))]
+const DEF_LOCAL_KEYS: &str = "deflocalkeys-win";
+#[cfg(all(feature = "interception_driver", target_os = "windows"))]
+const DEF_LOCAL_KEYS: &str = "deflocalkeys-winercept";
+#[cfg(target_os = "linux")]
+const DEF_LOCAL_KEYS: &str = "deflocalkeys-linux";
+
 #[allow(clippy::type_complexity)] // return type is not pub
 fn parse_cfg_raw(
     p: &std::path::Path,
@@ -282,14 +289,14 @@ fn parse_cfg_raw(
 
     if let Some(result) = root_exprs
         .iter()
-        .find(gen_first_atom_filter("defcustomkeys"))
-        .map(|custom_keys| parse_defcustomkeys(custom_keys))
+        .find(gen_first_atom_filter(DEF_LOCAL_KEYS))
+        .map(|custom_keys| parse_deflocalkeys(custom_keys))
     {
         result?;
     }
     if root_exprs
         .iter()
-        .filter(gen_first_atom_filter("defcustomkeys"))
+        .filter(gen_first_atom_filter(DEF_LOCAL_KEYS))
         .count()
         > 1
     {
@@ -474,36 +481,36 @@ fn parse_defcfg(expr: &[SExpr]) -> Result<HashMap<String, String>> {
     }
 }
 
-/// Parse custom keys from an expression starting with defcustomkeys. Statefully updates the `keys`
+/// Parse custom keys from an expression starting with deflocalkeys. Statefully updates the `keys`
 /// module using the custom keys parsed.
-fn parse_defcustomkeys(expr: &[SExpr]) -> Result<()> {
+fn parse_deflocalkeys(expr: &[SExpr]) -> Result<()> {
     let mut cfg = HashMap::default();
-    let mut exprs = check_first_expr(expr.iter(), "defcustomkeys")?;
+    let mut exprs = check_first_expr(expr.iter(), DEF_LOCAL_KEYS)?;
     clear_custom_str_oscode_mapping();
     // Read k-v pairs from the configuration
     loop {
         let key = match exprs.next() {
             Some(k) => k
                 .atom()
-                .ok_or_else(|| anyhow!("defcustomkeys contains a list; no lists are allowed"))?,
+                .ok_or_else(|| anyhow!("{DEF_LOCAL_KEYS} contains a list; no lists are allowed"))?,
             None => {
                 replace_custom_str_oscode_mapping(&cfg);
                 return Ok(());
             }
         };
         if str_to_oscode(key).is_some() {
-            bail!("{key} is a default key name in kanata; it cannot be used in defcustomkeys");
+            bail!("{key} is a default key name in kanata; it cannot be used in {DEF_LOCAL_KEYS}");
         } else if cfg.contains_key(key) {
             bail!(
-                "{key} has been defined more than once in defcustomkeys; no duplicates are allowed"
+                "{key} has been defined more than once in {DEF_LOCAL_KEYS}; no duplicates are allowed"
             );
         }
         let osc = match exprs.next() {
             Some(v) => v.atom()
-                .ok_or_else(|| anyhow!("defcustomkeys contains a list; no lists are allowed"))
-                .and_then(|osc| osc.parse::<u16>().map_err(|_| anyhow!("defcustomkeys unknown number {osc}")))
-                .and_then(|osc| OsCode::from_u16(osc).ok_or_else(|| anyhow!("defcustomkeys unknown number {osc}")))?,
-            None => bail!("Incorrect number of elements found in defcustomkeys; they should be pairs of keys and numbers."),
+                .ok_or_else(|| anyhow!("{DEF_LOCAL_KEYS} contains a list; no lists are allowed"))
+                .and_then(|osc| osc.parse::<u16>().map_err(|_| anyhow!("{DEF_LOCAL_KEYS} unknown number {osc}")))
+                .and_then(|osc| OsCode::from_u16(osc).ok_or_else(|| anyhow!("{DEF_LOCAL_KEYS} unknown number {osc}")))?,
+            None => bail!("Incorrect number of elements found in {DEF_LOCAL_KEYS}; they should be pairs of keys and numbers."),
         };
         log::debug!("custom mapping: {key} {}", osc.as_u16());
         cfg.insert(key.to_owned(), osc);


### PR DESCRIPTION
This commit adds a new configuration item `defcustomkeys`. This allows a user to define custom keys that can be used without aliases in `defsrc`, `deflayer` and other config items.

The documentation is updated to hopefully encourage community-created resources for non-US keyboard `defsrc` configurations.

Related to #204