### PR TITLE
feat(sequence): add input mode configuration

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -615,6 +615,22 @@ If you need help, you are welcome to ask.
 ;;
 ;; You can add an entry to defcfg to change the sequence timeout (default is 1000):
 ;;     sequence-timeout <number(ms)>
+;;
+;; There is also an option to customize the key sequence input mode. Its default
+;; value when not configured is `hidden-suppressed`.
+;; 
+;; The options are:
+;; 
+;; - `visible-backspaced`: types sequence characters as they are inputted. The
+;;   typed characters will be erased with backspaces for a valid sequence termination.
+;; - `hidden-suppressed`: hides sequence characters as they are typed. Does not
+;;   output the hidden characters for an invalid sequence termination.
+;; - `hidden-delay-type`: hides sequence characters as they are typed. Outputs the
+;;   hidden characters for an invalid sequence termination either after either a
+;;   timeout or after a non-sequence key is typed.
+;;
+;; Example:
+;;     sequence-input-mode visible-backspaced
 (defseq git-status (g s t))
 (deffakekeys git-status (macro g i t spc s t a t u s))
 (defalias rcl (tap-hold-release 200 200 sldr rctl))

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -628,6 +628,11 @@ If you need help, you are welcome to ask.
 ;; - `hidden-delay-type`: hides sequence characters as they are typed. Outputs the
 ;;   hidden characters for an invalid sequence termination either after either a
 ;;   timeout or after a non-sequence key is typed.
+;; 
+;; For `visible-backspaced` and `hidden-delay-type`, a sequence leader input will
+;; be ignored if a sequence is already active. For historical reasons, and in case
+;; it is desired behaviour, a sequence leader input using `hidden-suppressed` will
+;; reset the key sequence.
 ;;
 ;; Example:
 ;;     sequence-input-mode visible-backspaced

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -278,6 +278,32 @@ Example:
 )
 ----
 
+=== sequence-input-mode
+<<table-of-contents,Back to ToC>>
+
+This option customizes the key sequence input mode. Its default value when not
+configured is `hidden-suppressed`.
+
+The options are:
+
+- `visible-backspaced`: types sequence characters as they are inputted. The
+  typed characters will be erased with backspaces for a valid sequence termination
+- `hidden-suppressed`: hides sequence characters as they are typed. Does not
+  output the hidden characters for an invalid sequence termination.
+- `hidden-delay-type`: hides sequence characters as they are typed. Outputs the
+  hidden characters for an invalid sequence termination either after either a
+  timeout or after a non-sequence key is typed.
+  
+See <<sequences>> for more about sequences.
+
+Example:
+
+----
+(defcfg
+  sequence-input-mode visible-backspaced
+)
+----
+
 === Linux only: linux-dev
 <<table-of-contents,Back to ToC>>
 
@@ -399,6 +425,7 @@ a non-applicable operating system.
   process-unmapped-keys yes
   danger-enable-cmd yes
   sequence-timeout 2000
+  sequence-input-mode visible-backspaced
   linux-dev /dev/input/dev1:/dev/input/dev2
   linux-continue-if-no-dev-found yes
   windows-altgr add-lctl-release

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -287,12 +287,17 @@ configured is `hidden-suppressed`.
 The options are:
 
 - `visible-backspaced`: types sequence characters as they are inputted. The
-  typed characters will be erased with backspaces for a valid sequence termination
+  typed characters will be erased with backspaces for a valid sequence termination.
 - `hidden-suppressed`: hides sequence characters as they are typed. Does not
   output the hidden characters for an invalid sequence termination.
 - `hidden-delay-type`: hides sequence characters as they are typed. Outputs the
   hidden characters for an invalid sequence termination either after either a
   timeout or after a non-sequence key is typed.
+  
+For `visible-backspaced` and `hidden-delay-type`, a sequence leader input will
+be ignored if a sequence is already active. For historical reasons, and in case
+it is desired behaviour, a sequence leader input using `hidden-suppressed` will
+reset the key sequence.
   
 See <<sequences>> for more about sequences.
 

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -446,11 +446,15 @@ impl Kanata {
                             std::thread::sleep(std::time::Duration::from_millis((*delay).into()));
                         }
                         CustomAction::SequenceLeader => {
-                            log::debug!("entering sequence mode");
-                            self.sequence_state = Some(SequenceState {
-                                sequence: vec![],
-                                ticks_until_timeout: self.sequence_timeout,
-                            });
+                            if self.sequence_state.is_none()
+                                && self.sequence_input_mode != SequenceInputMode::HiddenSuppressed
+                            {
+                                log::debug!("entering sequence mode");
+                                self.sequence_state = Some(SequenceState {
+                                    sequence: vec![],
+                                    ticks_until_timeout: self.sequence_timeout,
+                                });
+                            }
                         }
                         CustomAction::Repeat => {
                             let key = OsCode::from(LAST_PRESSED_KEY.load(SeqCst));

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -714,7 +714,6 @@ impl Kanata {
                     match self.sequence_input_mode {
                         SequenceInputMode::VisibleBackspaced => {
                             self.kbd_out.press_key(osc)?;
-                            self.kbd_out.release_key(osc)?;
                         }
                         SequenceInputMode::HiddenSuppressed
                         | SequenceInputMode::HiddenDelayType => {}


### PR DESCRIPTION
This commit adds a configuration to customize the input mode for sequences via a defcfg item: `sequence-input-mode`. One can choose between:

- visible-backspaced
- hidden-suppressed
- hidden-delay-type

The behaviours of these three options are documented in kanata.kbd and config.adoc appropriately. The default option is hidden-suppressed, which matches the old, non-configurable behaviour for sequence input, so as to not break someone who may be depending on or is used to this behaviour.