### PR TITLE
fix(tap-hold-eager): change assert and interruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,9 +398,7 @@ dependencies = [
 
 [[package]]
 name = "kanata-keyberon"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915c7c8d1045afca3c54b1a81a681db2ebd9c5df9ff67ad37306e529c6ccb545"
+version = "0.7.1"
 dependencies = [
  "arraydeque",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ net2 = "0.2"
 radix_trie = "0.2"
 rustc-hash = "1.1.0"
 
-kanata-keyberon = "0.6.1"
+# kanata-keyberon = "0.7.1"
 # Uncomment below and comment out above for testing local keyberon changes
-# kanata-keyberon = { path = "keyberon" }
+kanata-keyberon = { path = "keyberon" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = "0.12.0"

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -293,12 +293,12 @@ The options are:
 - `hidden-delay-type`: hides sequence characters as they are typed. Outputs the
   hidden characters for an invalid sequence termination either after either a
   timeout or after a non-sequence key is typed.
-  
+
 For `visible-backspaced` and `hidden-delay-type`, a sequence leader input will
 be ignored if a sequence is already active. For historical reasons, and in case
 it is desired behaviour, a sequence leader input using `hidden-suppressed` will
 reset the key sequence.
-  
+
 See <<sequences>> for more about sequences.
 
 Example:
@@ -1205,6 +1205,11 @@ that `+macro+` supports more actions.
 
 For more context, you can read the
 https://github.com/jtroo/kanata/issues/80[issue that sparked the creation of fake keys].
+
+Something notable about fake keys is that they don't always interrupt the state
+of an active `+tap-dance-eager+`. If a `macro` action is assigned to a fake
+key, this won't interrupt a tap dance. However, most other action types,
+notably a "normal" key action like `+rsft+` will still interrupt a tap dance.
 
 === Sequences
 <<table-of-contents,Back to ToC>>

--- a/keyberon/Cargo.toml
+++ b/keyberon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanata-keyberon"
-version = "0.6.1"
+version = "0.7.1"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>", "Robin Krahl <robin.krahl@ireas.org>", "jtroo <j.andreitabs@gmail.com>"]
 edition = "2018"
 description = "Pure Rust keyboard firmware. Fork intended for use with kanata."

--- a/keyberon/src/action.rs
+++ b/keyberon/src/action.rs
@@ -238,7 +238,7 @@ pub enum TapDanceConfig {
 }
 
 /// The different actions that can be done.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub enum Action<T = core::convert::Infallible>
 where
     T: 'static,
@@ -300,60 +300,6 @@ where
     /// - `timeout` ticks elapse since the last tap of the same tap-dance key
     /// - the number of taps is equal to the length of `actions`.
     TapDance(&'static TapDance<T>),
-}
-
-impl<T> Debug for Action<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NoOp => write!(f, "NoOp"),
-            Self::Trans => write!(f, "Trans"),
-            Self::KeyCode(arg0) => f.debug_tuple("KeyCode").field(arg0).finish(),
-            Self::MultipleKeyCodes(arg0) => f.debug_tuple("MultipleKeyCodes").field(arg0).finish(),
-            Self::MultipleActions(arg0) => f.debug_tuple("MultipleActions").field(arg0).finish(),
-            Self::Layer(arg0) => f.debug_tuple("Layer").field(arg0).finish(),
-            Self::DefaultLayer(arg0) => f.debug_tuple("DefaultLayer").field(arg0).finish(),
-            Self::HoldTap(HoldTapAction {
-                timeout,
-                hold,
-                tap,
-                config,
-                tap_hold_interval,
-            }) => f
-                .debug_struct("HoldTap")
-                .field("timeout", timeout)
-                .field("hold", hold)
-                .field("tap", tap)
-                .field("config", config)
-                .field("tap_hold_interval", tap_hold_interval)
-                .finish(),
-            Self::Sequence { events } => {
-                f.debug_struct("Sequence").field("events", events).finish()
-            }
-            Self::CancelSequences => write!(f, "CancelSequences"),
-            Self::OneShot(OneShot {
-                action,
-                timeout,
-                end_config,
-            }) => f
-                .debug_struct("OneShot")
-                .field("action", action)
-                .field("timeout", timeout)
-                .field("end_config", end_config)
-                .finish(),
-            Self::TapDance(TapDance {
-                actions,
-                timeout,
-                config,
-            }) => f
-                .debug_struct("TapDance")
-                .field("actions", actions)
-                .field("timeout", timeout)
-                .field("config", config)
-                .finish(),
-            Self::Custom(_) => f.debug_tuple("Custom").finish(),
-            Self::ReleaseState(arg0) => f.debug_tuple("ReleaseState").field(arg0).finish(),
-        }
-    }
 }
 
 impl<T> Action<T> {


### PR DESCRIPTION
This commit changes the keyberon action assertion. The intent of the old assertion was as a bug check in the code and configuration. If a waiting state exists, e.g. tap-dance or tap-hold, then the code should not be performing any actions until that state is done processing. However, the `Custom` action type is special because it has minimal impact on the rest of the keyberon state, and so is fine to allow in. This enables a previously crashing use case, which is fine to not crash on.

In addition, fake keys will no longer interrupt the tap-dance-eager state. This is so fake key actions like on-release-fakekey can be used while in the middle of a tap-dance-eager sequence, which is a requested use case.