### PR TITLE
feat: add input chords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "kanata-keyberon"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "arraydeque",
  "either",

--- a/cfg_samples/artsey.kbd
+++ b/cfg_samples/artsey.kbd
@@ -1,0 +1,74 @@
+;; ARTSEY MINI 0.2 https://github.com/artseyio/artsey/issues/7
+
+;; Exactly one defcfg entry is required. This is used for configuration key-pairs.
+(defcfg
+  ;; Your keyboard device will likely differ from this.
+  linux-dev /dev/input/event1
+
+  ;; Windows doesn't need any input/output configuration entries; however, there
+  ;; must still be a defcfg entry. You can keep the linux-dev entry or delete
+  ;; it and leave it empty.
+)
+
+(defsrc
+  q    w    e
+  a    s    d
+)
+
+(deflayer base
+  (chord base A) (chord base R) (chord base T)
+  (chord base S) (chord base E) (chord base Y)
+)
+
+(deflayer meta
+  (chord meta A) (chord meta R) (chord meta T)
+  (chord meta S) (chord meta E) (chord meta Y)
+)
+
+(defchords base 5000
+  (A R T S E Y) (layer-switch meta)
+  (A R T      ) (one-shot 2000 lsft)
+  (      S E Y) spc
+  (A          ) a
+  (  R T S    ) b
+  (  R   S    ) c
+  (A       E Y) d
+  (        E  ) e
+  (A R        ) f
+  (A       E  ) g
+  (      S   Y) h
+  (  R     E  ) i
+  (    T S E  ) j
+  (    T   E  ) k
+  (      S E  ) l
+  (  R T      ) m
+  (        E Y) n
+  (A     S    ) o
+  (A R       Y) p
+  (    T     Y) q
+  (  R        ) r
+  (      S    ) s
+  (    T      ) t
+  (A   T      ) u
+  (A   T   E  ) v
+  (    T S    ) w
+  (A         Y) x
+  (          Y) y
+  (  R   S E  ) z
+)
+
+(defchords meta 5000
+  (A R T S E Y) (layer-switch base)
+  (      S E Y) spc
+  (A R T      ) caps ;; should technically be shift lock, probably need to use fake keys for that 
+  (A R        ) bspc
+  (  R T      ) del
+  (      S E  ) C-c
+  (        E Y) C-v
+  (A          ) home
+  (  R        ) up
+  (    T      ) end
+  (      S    ) left
+  (        E  ) down
+  (          Y) rght
+)

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -431,7 +431,7 @@ If you need help, you are welcome to ask.
 (deflayer chords      ;; you can put list actions directly in deflayer but it's ugly, so prefer aliases.
   _    _    _    _    _    _    _    _    _    _    @🙁  (unicode 😀) _    _
   _    _    _    _    _    _    _    _    @csc @hpy @lch @tbm         _    _
-  _    @alp _    _    _    _    _    _    _    _    _    _            _
+  _    @alp _    _    _    _    _    @ch1 @ch2 @ch4 @ch8 _            _
   _    _    _    _    _    _    _    _    _    @csv _    _
   _    _    _              _              _    _    _
 )
@@ -649,3 +649,61 @@ If you need help, you are welcome to ask.
 (defseq git-status (g s t))
 (deffakekeys git-status (macro g i t spc s t a t u s))
 (defalias rcl (tap-hold-release 200 200 sldr rctl))
+
+;; Input chording.
+;;
+;; Not to be confused with output chords (like C-S-a or the chords layer
+;; defined above), these allow you to perform actions when a combination of
+;; input keys (a "chord") is pressed all at once (order does not matter).
+;; Each combination/chord can perform a different action, allowing you to bind
+;; up to `2^n - 1` different actions to just `n` keys.
+;;
+;; Each `defchords` defines a named group of such chord-action pairs.
+;; The 500 is a timeout after which a chord triggers if it isn't triggered by a
+;; key release or press of a non-chord key before the timeout expires.
+;; If a chord is not defined, no action will occur when it is triggered but the
+;; keys used to input it will be consumed regardless.
+;;
+;; Each pair consists of the keys that make up a given chord in the parenthesis
+;; followed by the action that should be executed when the given chord is
+;; pressed.
+;; Note that these keys do not directly correspond to real keys and are merely
+;; arbitrary labels that make sense within the context of the chord.
+;; They are mapped to real keys in layers by configuring the key in the layer to
+;; map to a `(chord name key)` action (like those in the `defalias` below) where
+;; `name` is the name of the chords group (here `binary`) and `key` is one of the
+;; arbitrary labels of the keys in a chord (here `1`, `2`, `4` and `8`).
+;;
+;; Note that it is perfectly valid to nest these `chord` actions that enter
+;; "chording mode" within other actions like `tap-dance` and that will work as
+;; one would expect.
+;; However, this only applies to the first key used to enter "chording mode".
+;; Once "chording mode" is active, all other keys will be directly handled by
+;; "chording mode" with no regard for wrapper actions.
+;;
+;; The action executed by a chord (the right side of the chord-action pairs) may
+;; be any regular or advanced action, including aliases. They currently cannot
+;; however contain a `chord` action.
+(defchords binary 500
+  (1      ) 1
+  (  2    ) 2
+  (1 2    ) 3
+  (    4  ) 4
+  (1   4  ) 5
+  (  2 4  ) 6
+  (1 2 4  ) 7
+  (      8) 8
+  (1     8) 9
+  (  2   8) (multi 1 0)
+  (1 2   8) (multi 1 1)
+  (    4 8) (multi 1 2)
+  (1   4 8) (multi 1 3)
+  (  2 4 8) (multi 1 4)
+  (1 2 4 8) (multi 1 5)
+)
+(defalias
+  ch1 (chord binary 1)
+  ch2 (chord binary 2)
+  ch4 (chord binary 4)
+  ch8 (chord binary 8)
+)

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -654,7 +654,7 @@ If you need help, you are welcome to ask.
 ;;
 ;; Not to be confused with output chords (like C-S-a or the chords layer
 ;; defined above), these allow you to perform actions when a combination of
-;; input keys (a "chord") is pressed all at once (order does not matter).
+;; input keys (a "chord") are pressed all at once (order does not matter).
 ;; Each combination/chord can perform a different action, allowing you to bind
 ;; up to `2^n - 1` different actions to just `n` keys.
 ;;
@@ -679,7 +679,10 @@ If you need help, you are welcome to ask.
 ;; one would expect.
 ;; However, this only applies to the first key used to enter "chording mode".
 ;; Once "chording mode" is active, all other keys will be directly handled by
-;; "chording mode" with no regard for wrapper actions.
+;; "chording mode" with no regard for wrapper actions; e.g. if a key is pressed
+;; and it maps to a tap-hold with a chord as the hold action within, that chord
+;; will immediately activate instead of the key needing to be held for the
+;; timeout period.
 ;;
 ;; The action executed by a chord (the right side of the chord-action pairs) may
 ;; be any regular or advanced action, including aliases. They currently cannot

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -628,9 +628,9 @@ If you need help, you are welcome to ask.
 ;;
 ;; There is also an option to customize the key sequence input mode. Its default
 ;; value when not configured is `hidden-suppressed`.
-;; 
+;;
 ;; The options are:
-;; 
+;;
 ;; - `visible-backspaced`: types sequence characters as they are inputted. The
 ;;   typed characters will be erased with backspaces for a valid sequence termination.
 ;; - `hidden-suppressed`: hides sequence characters as they are typed. Does not
@@ -638,7 +638,7 @@ If you need help, you are welcome to ask.
 ;; - `hidden-delay-type`: hides sequence characters as they are typed. Outputs the
 ;;   hidden characters for an invalid sequence termination either after either a
 ;;   timeout or after a non-sequence key is typed.
-;; 
+;;
 ;; For `visible-backspaced` and `hidden-delay-type`, a sequence leader input will
 ;; be ignored if a sequence is already active. For historical reasons, and in case
 ;; it is desired behaviour, a sequence leader input using `hidden-suppressed` will
@@ -656,7 +656,7 @@ If you need help, you are welcome to ask.
 ;; defined above), these allow you to perform actions when a combination of
 ;; input keys (a "chord") are pressed all at once (order does not matter).
 ;; Each combination/chord can perform a different action, allowing you to bind
-;; up to `2^n - 1` different actions to just `n` keys.
+;; up to `(n)(n+1)/2` different actions to just `n` keys.
 ;;
 ;; Each `defchords` defines a named group of such chord-action pairs.
 ;; The 500 is a timeout after which a chord triggers if it isn't triggered by a
@@ -681,7 +681,7 @@ If you need help, you are welcome to ask.
 ;; Once "chording mode" is active, all other keys will be directly handled by
 ;; "chording mode" with no regard for wrapper actions; e.g. if a key is pressed
 ;; and it maps to a tap-hold with a chord as the hold action within, that chord
-;; will immediately activate instead of the key needing to be held for the
+;; key will immediately activate instead of the key needing to be held for the
 ;; timeout period.
 ;;
 ;; The action executed by a chord (the right side of the chord-action pairs) may

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -656,7 +656,7 @@ If you need help, you are welcome to ask.
 ;; defined above), these allow you to perform actions when a combination of
 ;; input keys (a "chord") are pressed all at once (order does not matter).
 ;; Each combination/chord can perform a different action, allowing you to bind
-;; up to `(n)(n+1)/2` different actions to just `n` keys.
+;; up to `2^n - 1` different actions to just `n` keys.
 ;;
 ;; Each `defchords` defines a named group of such chord-action pairs.
 ;; The 500 is a timeout after which a chord triggers if it isn't triggered by a

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1240,6 +1240,47 @@ Example:
 For more context, you can read the
 https://github.com/jtroo/kanata/issues/97[design and motivation of sequences].
 
+=== Input Chords
+<<table-of-contents,Back to ToC>>
+
+Not to be confused with <<chords,output chords>>, `+chord+` actions can allow you
+to perform various actions based on which specific combination of input keys
+is pressed together (such an unordered combination of keys is called a "chord").
+Each combination/chord can perform a different action, allowing you to bind up to
+`+2^n - 1+` different actions to just `+n+` keys.
+
+Input chords are configured similarly to `+defalias+` with two extra parameters
+at the beginning of each `+defchords+` group: the name of the group and a
+timeout value after which a chord triggers if it isn't triggered by a key release
+or press of a non-chord key before the timeout expires.
+
+----
+(defchords example 500
+  (a      ) a
+  (   b   ) b
+  (a     c) C-v
+  (a  b  c) @three
+)
+----
+
+The first item of each pair specifies the keys that make up a given chord.
+The second item of each pair is the action to be executed when the given chord
+is pressed and may be any regular or advanced action, including aliases. It
+currently cannot however contain another `+chord+` action.
+
+Note that unlike with `+defseq+`, these keys do not directly correspond to real
+keys and are merely arbitrary labels that make sense within the context of the
+chord.
+They are mapped to real keys in layers by configuring the key in the layer to
+map to a `+(chord name key)+` action where `+name+` is the name of the chords
+group (above `+example+`) and `+key+` is one of these arbitrary labels.
+
+It is perfectly valid to nest these `+chord+` actions that enter "chording mode"
+within other actions like `+tap-dance+` and that will work as one would expect.
+However, this only applies to the first key used to enter "chording mode".
+Once "chording mode" is active, all other keys will be directly handled by
+"chording mode" with no regard for wrapper actions.
+
 === Custom tap-hold behaviour
 <<table-of-contents,Back to ToC>>
 

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1247,7 +1247,7 @@ Not to be confused with <<chords,output chords>>, `+chord+` actions can allow yo
 to perform various actions based on which specific combination of input keys
 is pressed together (such an unordered combination of keys is called a "chord").
 Each combination/chord can perform a different action, allowing you to bind up to
-`+2^n - 1+` different actions to just `+n+` keys.
+`+(n)(n+1)/2+` different actions to just `+n+` keys.
 
 Input chords are configured similarly to `+defalias+` with two extra parameters
 at the beginning of each `+defchords+` group: the name of the group and a
@@ -1255,6 +1255,12 @@ timeout value after which a chord triggers if it isn't triggered by a key releas
 or press of a non-chord key before the timeout expires.
 
 ----
+(defalias
+  cha (chord example a)
+  chb (chord example b)
+  chc (chord example c)
+)
+
 (defchords example 500
   (a      ) a
   (   b   ) b
@@ -1279,7 +1285,10 @@ It is perfectly valid to nest these `+chord+` actions that enter "chording mode"
 within other actions like `+tap-dance+` and that will work as one would expect.
 However, this only applies to the first key used to enter "chording mode".
 Once "chording mode" is active, all other keys will be directly handled by
-"chording mode" with no regard for wrapper actions.
+"chording mode" with no regard for wrapper actions; e.g. if a key is pressed
+and it maps to a tap-hold with a chord as the hold action within, that chord
+key will immediately activate instead of the key needing to be held for the
+timeout period.
 
 === Custom tap-hold behaviour
 <<table-of-contents,Back to ToC>>

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1247,7 +1247,7 @@ Not to be confused with <<chords,output chords>>, `+chord+` actions can allow yo
 to perform various actions based on which specific combination of input keys
 is pressed together (such an unordered combination of keys is called a "chord").
 Each combination/chord can perform a different action, allowing you to bind up to
-`+(n)(n+1)/2+` different actions to just `+n+` keys.
+`+2^n - 1+` different actions to just `+n+` keys.
 
 Input chords are configured similarly to `+defalias+` with two extra parameters
 at the beginning of each `+defchords+` group: the name of the group and a

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1255,6 +1255,11 @@ timeout value after which a chord triggers if it isn't triggered by a key releas
 or press of a non-chord key before the timeout expires.
 
 ----
+(defsrc a b c)
+(deflayer default
+  @cha @chb @chc
+)
+
 (defalias
   cha (chord example a)
   chb (chord example b)

--- a/keyberon/Cargo.toml
+++ b/keyberon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanata-keyberon"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>", "Robin Krahl <robin.krahl@ireas.org>", "jtroo <j.andreitabs@gmail.com>"]
 edition = "2018"
 description = "Pure Rust keyboard firmware. Fork intended for use with kanata."

--- a/keyberon/src/action.rs
+++ b/keyberon/src/action.rs
@@ -253,12 +253,12 @@ where
 }
 
 impl<T> ChordsGroup<T> {
-    /// Gets they chord keys corresponding to the given key coordinates.
+    /// Gets the chord keys corresponding to the given key coordinates.
     pub fn get_keys(&self, coord: (u8, u16)) -> Option<ChordKeys> {
         self.coords.iter().find(|c| c.0 == coord).map(|c| c.1)
     }
 
-    /// Gets chord action assigned to the given chord keys.
+    /// Gets the chord action assigned to the given chord keys.
     pub fn get_chord(&self, keys: ChordKeys) -> Option<&'static Action<T>> {
         self.chords
             .iter()

--- a/keyberon/src/action.rs
+++ b/keyberon/src/action.rs
@@ -237,6 +237,62 @@ pub enum TapDanceConfig {
     Eager,
 }
 
+/// A group of chords (actions mapped to a combination of multiple physical keys pressed together).
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ChordsGroup<T = core::convert::Infallible>
+where
+    T: 'static,
+{
+    /// List of key coordinates participating in this chord group, each with the corresponding [ChordKeys] they map to.
+    pub coords: &'static [((u8, u16), ChordKeys)],
+    /// Map of chords to actions they execute.
+    pub chords: &'static [(ChordKeys, &'static Action<T>)],
+    /// Timeout after which a chord will expire and either trigger its action or be discarded if there is no corresponding action.
+    /// A chord may trigger its action even before this timeout expires, if a chord key is released, a non-chord key is pressed or the pressed chord is already uniquely identifyable.
+    pub timeout: u16,
+}
+
+impl<T> ChordsGroup<T> {
+    /// Gets they chord keys corresponding to the given key coordinates.
+    pub fn get_keys(&self, coord: (u8, u16)) -> Option<ChordKeys> {
+        self.coords.iter().find(|c| c.0 == coord).map(|c| c.1)
+    }
+
+    /// Gets chord action assigned to the given chord keys.
+    pub fn get_chord(&self, keys: ChordKeys) -> Option<&'static Action<T>> {
+        self.chords
+            .iter()
+            .find(|(chord_keys, _)| *chord_keys == keys)
+            .map(|(_, action)| *action)
+    }
+
+    /// Gets the chord action assigned to the given chord keys if they are already unambigous (i.e. there is no key that could still be pressed that would result in a different chord).
+    pub fn get_chord_if_unambiguous(&self, keys: ChordKeys) -> Option<&'static Action<T>> {
+        self.chords
+            .iter()
+            .try_fold(None, |res, &(chord_keys, action)| {
+                if chord_keys == keys {
+                    Ok(Some(action))
+                } else if chord_keys | keys == chord_keys {
+                    // The given keys are a subset of this chord but not an exact match
+                    // -> ambiguity
+                    Err(())
+                } else {
+                    Ok(res)
+                }
+            })
+            .unwrap_or_default()
+    }
+}
+
+/// A set of virtual keys (represented as a bit mask) pressed together.
+/// The keys do not directly correspond to physical keys. They are unique to a given [ChordGroup] and their mapping from physical keys is definied in [ChordGroup.coords].
+/// As such, each chord group can effectively have at most 32 different keys (though multiple physical keys may be mapped to the same virtual key).
+pub type ChordKeys = u32;
+
+/// Defines the maximum number of (virtual) keys that can be used in a single chords group.
+pub const MAX_CHORD_KEYS: usize = ChordKeys::BITS as usize;
+
 /// The different actions that can be done.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub enum Action<T = core::convert::Infallible>
@@ -300,6 +356,15 @@ where
     /// - `timeout` ticks elapse since the last tap of the same tap-dance key
     /// - the number of taps is equal to the length of `actions`.
     TapDance(&'static TapDance<T>),
+    /// Chord key. Enters chording mode where multiple keys may be pressed together to active
+    /// different actions depending on the specific combination ("chord") pressed.
+    /// See `struct ChordGroup` for configuration info.
+    ///
+    /// Keys participating in chording mode are listed in `coords`.
+    /// Chording mode ends when a non-participating key is pressed, a participating key is released,
+    /// the timeout expires, or when the pressed chord uniquely identifies an action (i.e. there are
+    /// no more keys you could press to change the result).
+    Chords(&'static ChordsGroup<T>),
 }
 
 impl<T> Action<T> {

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -658,7 +658,10 @@ impl<const C: usize, const R: usize, const L: usize, T: 'static + Copy + std::fm
         if let Some(w) = &self.waiting {
             let hold = w.hold;
             let coord = w.coord;
-            let delay = w.delay + w.ticks;
+            let delay = match w.config {
+                WaitingConfig::HoldTap(..) => w.delay + w.ticks,
+                WaitingConfig::TapDance(_) | WaitingConfig::Chord(_) => 0,
+            };
             self.waiting = None;
             if coord == self.tap_hold_tracker.coord {
                 self.tap_hold_tracker.timeout = 0;
@@ -672,7 +675,10 @@ impl<const C: usize, const R: usize, const L: usize, T: 'static + Copy + std::fm
         if let Some(w) = &self.waiting {
             let tap = w.tap;
             let coord = w.coord;
-            let delay = w.delay + w.ticks;
+            let delay = match w.config {
+                WaitingConfig::HoldTap(..) => w.delay + w.ticks,
+                WaitingConfig::TapDance(_) | WaitingConfig::Chord(_) => 0,
+            };
             self.waiting = None;
             self.do_action(tap, coord, delay, false)
         } else {

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -1275,7 +1275,11 @@ fn parse_chord(ac_params: &[SExpr], parsed_state: &ParsedState) -> Result<&'stat
     let chord_key_index = match &ac_params[1] {
         SExpr::Atom(s) => match group.keys.iter().position(|e| e == &s.t) {
             Some(i) => i,
-            None => bail!("Identifier `{}` is not used in chord group `{}`.", &s.t, name,),
+            None => bail!(
+                "Identifier `{}` is not used in chord group `{}`.",
+                &s.t,
+                name,
+            ),
         },
         _ => bail!(ERR_MSG),
     };
@@ -1525,12 +1529,14 @@ fn fill_chords(
                 None
             }
         }
-        Action::OneShot(os @ OneShot { action: ac, .. }) => fill_chords(chord_groups, ac).map(|ac| {
-            Action::OneShot(sref(OneShot {
-                action: sref(ac),
-                ..(*os).clone()
-            }))
-        }),
+        Action::OneShot(os @ OneShot { action: ac, .. }) => {
+            fill_chords(chord_groups, ac).map(|ac| {
+                Action::OneShot(sref(OneShot {
+                    action: sref(ac),
+                    ..(*os).clone()
+                }))
+            })
+        }
         Action::MultipleActions(actions) => {
             let new_actions = actions
                 .iter()

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -1500,7 +1500,7 @@ fn fill_chords(
 ) -> Option<KanataAction> {
     match action {
         Action::Chords(ChordsGroup { coords, .. }) => {
-            let (_, group_id) = coords
+            let ((_, group_id), _) = coords
                 .iter()
                 .next()
                 .expect("unresolved chords should have exactly one entry");

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1148,7 +1148,7 @@ impl Kanata {
     pub fn can_block(&self) -> bool {
         self.layout.stacked.is_empty()
             && self.layout.waiting.is_none()
-            && self.layout.tap_hold_tracker.timeout == 0
+            && self.layout.last_press_tracker.tap_hold_timeout == 0
             && (self.layout.oneshot.timeout == 0 || self.layout.oneshot.keys.is_empty())
             && self.layout.active_sequences.is_empty()
             && self.layout.tap_dance_eager.is_none()


### PR DESCRIPTION
This PR implement input chords as described in https://github.com/jtroo/kanata/issues/99#issuecomment-1331242794.

Staying within keyberon's no-std / config is 'static limitations made some parts of it a bit ugly. In particular I have to leak the entire config twice instead of just once because I first need to parse it before I can resolve which key coordinates participate in a given chords group and I can't just mutate the existing actions because nested actions are usually expressed as `&'static Action` and are therefore immutable, so instead I re-build the actions tree only to leak it a second time.
Same "it's probably fine, how often do you re-load your config" argument as before probably still holds but might be a thing to consider for the future to first parse kanata's config into a fully owned/mutable data structure before turning that into keyberon's 'static one. Might also allow for things like aliases in fakekeys declarations because we can then resolve aliases later.

Another thing I'm unsure/unhappy about is the ambiguity (in documentation) between output and input chords. Maybe we want to change the documentation to always refer to output chords as combos instead. Or maybe there's another word we could use for input chords, though they're called chords in steno lingo, so calling them anything else feels quite odd to me.

Also unsure how keyberon changes are handled with it being a sub-crate. For now I've simply replaced it with a relative path so it just works when cloned (but would break if published).