### PR TITLE
refactor: free allocated memory on layout drop (v1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ interception = { version = "0.1.2", optional = true }
 
 [features]
 cmd = []
-interception_driver = [ "interception" ]
+interception_driver = ["interception"]
 
 [profile.release]
 opt-level = "z"

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -358,16 +358,6 @@ If you need help, you are welcome to ask.
 ;; Upon a successful reload, the kanata state will begin on the default base layer
 ;; in the configuration. E.g. in this example configuration, you would start on
 ;; the qwerty layer.
-;;
-;; WARNING: live reload leaks memory. This should not be a major problem though.
-;; Here are the measurements of memory consumption on Windows for version 1.0.0:
-;; - 20 reloads: 15.4 MB memory consumed
-;; - 50 reloads: 20.4 MB memory consumed
-;; So about 170 KB used per live reload. You'll probably be fine.
-;;
-;; Note: version 1.0.3 has probably doubled the amount of memory leaked per
-;; reload, though it has not been measured. In practice it's still negligible
-;; compared to a browser for example.
 (deflayer layers
   _    @qwr @dvk lrld @td2 _    _    _    _    _    _    _    _    _
   _    _    _    _    _    _    _    _    _    _    _    _    _    _

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -515,17 +515,6 @@ You can put the `+lrld+` action onto a key to live-reload your configuration
 file. If kanata can't parse the file, it will continue using the previous
 configuration.
 
-It should be noted that the live reload action currently leaks memory. In
-practice this should not matter. Some measurements on Windows for version
-1.0.0:
-
-* 20 reloads: 15.4 MB memory consumed
-* 50 reloads: 20.4 MB memory consumed
-
-This is about 170 KB used per live reload. In more recent versions the memory
-usage per reload has likely more than doubled, but even still, in practice this
-is negligible memory usage compared to other applications like a browser.
-
 Example:
 
 ----

--- a/src/cfg/alloc.rs
+++ b/src/cfg/alloc.rs
@@ -1,0 +1,87 @@
+//! This module contains a helper struct for generating 'static lifetime allocations while still
+//! keeping track of them so that they can be freed later.
+
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+/// This struct tracks the allocations that are leaked by its provided methods and frees them when
+/// dropped. The `new` function is unsafe because dropping the struct can create dangling
+/// references. Care must be taken to ensure that all allocations made by this struct's methods are
+/// no longer referenced when the struct gets dropped.
+///
+/// In practice, this is not difficult to do in the `cfg` module which only exposes a single public
+/// method.
+pub(crate) struct Allocations {
+    allocations: Mutex<Vec<usize>>,
+}
+
+impl std::fmt::Debug for Allocations {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Allocations").finish()
+    }
+}
+
+impl Drop for Allocations {
+    fn drop(&mut self) {
+        log::debug!(
+            "freeing allocations of length {}",
+            self.allocations.lock().len()
+        );
+        for p in self.allocations.lock().iter().rev().copied() {
+            unsafe { drop(Box::from_raw(p as *mut usize)) };
+        }
+    }
+}
+
+impl Allocations {
+    /// Create a new allocations group.
+    ///
+    /// # Safety
+    ///
+    /// Ensure that all associated allocations are no longer referenced before dropping all
+    /// clones of the `Arc`.
+    pub(super) unsafe fn new() -> Arc<Self> {
+        Arc::new(Self {
+            allocations: Mutex::new(vec![]),
+        })
+    }
+
+    /// Returns a `&'static T` by leaking the existing box.
+    pub(super) fn bref<T>(&self, v: Box<T>) -> &'static T {
+        let p = Box::into_raw(v);
+        if (p as usize) < 16 {
+            panic!("bref bad ptr");
+        }
+        self.allocations.lock().push(p as usize);
+        Box::leak(unsafe { Box::from_raw(p) })
+    }
+
+    /// Returns a `&'static T` by leaking a newly created Box of `v`.
+    pub(super) fn sref<T>(&self, v: T) -> &'static T {
+        let p = Box::into_raw(Box::new(v));
+        if (p as usize) < 16 {
+            panic!("sref bad ptr");
+        }
+        self.allocations.lock().push(p as usize);
+        Box::leak(unsafe { Box::from_raw(p) })
+    }
+
+    fn bref_slice<T>(&self, v: Box<[T]>) -> &'static [T] {
+        // An empty slice has no backing allocation. `Box<[T]>` is a fat pointer so the leaked return
+        // will contain a length of 0 and an invalid pointer.
+        if !v.is_empty() {
+            self.allocations.lock().push(v.as_ptr() as usize);
+        }
+        Box::leak(v)
+    }
+
+    /// Returns a &'static [&'static T] from a `Vec<T>` by converting to a boxed slice and leaking it.
+    pub(super) fn sref_vec<T>(&self, v: Vec<T>) -> &'static [T] {
+        self.bref_slice(v.into_boxed_slice())
+    }
+
+    /// Returns a `&'static [&'static T]` by leaking a newly created box and boxed slice of `v`.
+    pub(super) fn sref_slice<T>(&self, v: T) -> &'static [&'static T] {
+        self.bref_slice(vec![self.sref(v)].into_boxed_slice())
+    }
+}

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -39,6 +39,9 @@
 //! The specific values in example above applies to Linux, but the same logic applies to Windows.
 mod sexpr;
 
+mod alloc;
+use alloc::*;
+
 use crate::custom_action::*;
 use crate::keys::*;
 use crate::layers::*;
@@ -46,6 +49,8 @@ use crate::layers::*;
 use anyhow::{anyhow, bail, Result};
 use radix_trie::Trie;
 use std::collections::hash_map::Entry;
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 
 type HashSet<T> = rustc_hash::FxHashSet<T>;
 type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
@@ -58,8 +63,36 @@ use sexpr::SExpr;
 use self::sexpr::Spanned;
 
 pub type KanataAction = Action<&'static [&'static CustomAction]>;
-pub type KanataLayout = Layout<KEYS_IN_ROW, 2, ACTUAL_NUM_LAYERS, &'static [&'static CustomAction]>;
+pub type KLayout = Layout<KEYS_IN_ROW, 2, ACTUAL_NUM_LAYERS, &'static [&'static CustomAction]>;
 pub type KeySeqsToFKeys = Trie<Vec<u16>, (u8, u16)>;
+
+pub struct KanataLayout {
+    layout: KLayout,
+    _allocations: Arc<Allocations>,
+}
+
+impl KanataLayout {
+    fn new(layout: KLayout, a: Arc<Allocations>) -> Self {
+        Self {
+            layout,
+            _allocations: a,
+        }
+    }
+}
+
+impl Deref for KanataLayout {
+    type Target = KLayout;
+
+    fn deref(&self) -> &Self::Target {
+        &self.layout
+    }
+}
+
+impl DerefMut for KanataLayout {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.layout
+    }
+}
 
 pub struct Cfg {
     /// The list of keys that kanata should be processing. Keys that are missing from `mapped_keys`
@@ -79,19 +112,18 @@ pub struct Cfg {
     pub sequences: KeySeqsToFKeys,
 }
 
-impl Cfg {
-    pub fn new_from_file(p: &std::path::Path) -> Result<Self> {
-        let (items, mapped_keys, layer_info, key_outputs, layout, sequences) = parse_cfg(p)?;
-        log::info!("config parsed");
-        Ok(Self {
-            items,
-            mapped_keys,
-            layer_info,
-            key_outputs,
-            layout,
-            sequences,
-        })
-    }
+/// Parse a new configuration from a file.
+pub fn new_from_file(p: &std::path::Path) -> Result<Cfg> {
+    let (items, mapped_keys, layer_info, key_outputs, layout, sequences) = parse_cfg(p)?;
+    log::info!("config parsed");
+    Ok(Cfg {
+        items,
+        mapped_keys,
+        layer_info,
+        key_outputs,
+        layout,
+        sequences,
+    })
 }
 
 pub type MappedKeys = HashSet<OsCode>;
@@ -109,36 +141,37 @@ fn add_kc_output(osc_slot: OsCode, kc: OsCode, outs: &mut HashMap<OsCode, Vec<Os
 
 #[test]
 fn parse_simple() {
-    parse_cfg(&std::path::PathBuf::from("./cfg_samples/simple.kbd")).unwrap();
+    new_from_file(&std::path::PathBuf::from("./cfg_samples/simple.kbd")).unwrap();
 }
 
 #[test]
 fn parse_minimal() {
-    parse_cfg(&std::path::PathBuf::from("./cfg_samples/minimal.kbd")).unwrap();
+    new_from_file(&std::path::PathBuf::from("./cfg_samples/minimal.kbd")).unwrap();
 }
 
 #[test]
 fn parse_default() {
-    parse_cfg(&std::path::PathBuf::from("./cfg_samples/kanata.kbd")).unwrap();
+    new_from_file(&std::path::PathBuf::from("./cfg_samples/kanata.kbd")).unwrap();
 }
 
 #[test]
 fn parse_jtroo() {
-    let (_, _, layer_strings, _, _, _) =
-        parse_cfg(&std::path::PathBuf::from("./cfg_samples/jtroo.kbd")).unwrap();
-    assert_eq!(layer_strings.len(), 16);
+    let cfg = new_from_file(&std::path::PathBuf::from("./cfg_samples/jtroo.kbd")).unwrap();
+    assert_eq!(cfg.layer_info.len(), 16);
 }
 
 #[test]
 fn parse_f13_f24() {
-    parse_cfg(&std::path::PathBuf::from("./cfg_samples/f13_f24.kbd")).unwrap();
+    new_from_file(&std::path::PathBuf::from("./cfg_samples/f13_f24.kbd")).unwrap();
 }
 
 #[test]
 fn parse_transparent_default() {
-    let (_, _, layer_strings, layers, _) = parse_cfg_raw(&std::path::PathBuf::from(
-        "./cfg_samples/transparent_default.kbd",
-    ))
+    let mut s = ParsedState::default();
+    let (_, _, layer_strings, layers, _) = parse_cfg_raw(
+        &std::path::PathBuf::from("./cfg_samples/transparent_default.kbd"),
+        &mut s,
+    )
     .unwrap();
 
     assert_eq!(layer_strings.len(), 4);
@@ -177,7 +210,7 @@ fn parse_transparent_default() {
 
 #[test]
 fn parse_all_keys() {
-    parse_cfg(&std::path::PathBuf::from(
+    new_from_file(&std::path::PathBuf::from(
         "./cfg_samples/all_keys_in_defsrc.kbd",
     ))
     .unwrap();
@@ -185,7 +218,7 @@ fn parse_all_keys() {
 
 #[test]
 fn parse_multiline_comment() {
-    parse_cfg(&std::path::PathBuf::from(
+    new_from_file(&std::path::PathBuf::from(
         "./test_cfgs/multiline_comment.kbd",
     ))
     .unwrap();
@@ -193,7 +226,7 @@ fn parse_multiline_comment() {
 
 #[test]
 fn disallow_nested_tap_hold() {
-    match parse_cfg(&std::path::PathBuf::from("./test_cfgs/nested_tap_hold.kbd"))
+    match new_from_file(&std::path::PathBuf::from("./test_cfgs/nested_tap_hold.kbd"))
         .map_err(|e| e.to_string())
     {
         Ok(_) => panic!("invalid nested tap-hold in tap action was Ok'd"),
@@ -203,7 +236,7 @@ fn disallow_nested_tap_hold() {
 
 #[test]
 fn disallow_ancestor_seq() {
-    match parse_cfg(&std::path::PathBuf::from("./test_cfgs/ancestor_seq.kbd"))
+    match new_from_file(&std::path::PathBuf::from("./test_cfgs/ancestor_seq.kbd"))
         .map_err(|e| e.to_string())
     {
         Ok(_) => panic!("invalid ancestor seq was Ok'd"),
@@ -213,7 +246,7 @@ fn disallow_ancestor_seq() {
 
 #[test]
 fn disallow_descendent_seq() {
-    match parse_cfg(&std::path::PathBuf::from("./test_cfgs/descendant_seq.kbd"))
+    match new_from_file(&std::path::PathBuf::from("./test_cfgs/descendant_seq.kbd"))
         .map_err(|e| e.to_string())
     {
         Ok(_) => panic!("invalid descendant seq was Ok'd"),
@@ -238,14 +271,15 @@ fn parse_cfg(
     KanataLayout,
     KeySeqsToFKeys,
 )> {
-    let (cfg, src, layer_info, klayers, seqs) = parse_cfg_raw(p)?;
+    let mut s = ParsedState::default();
+    let (cfg, src, layer_info, klayers, seqs) = parse_cfg_raw(p, &mut s)?;
 
     Ok((
         cfg,
         src,
         layer_info,
         create_key_outputs(&klayers),
-        create_layout(klayers),
+        create_layout(klayers, s.a),
         seqs,
     ))
 }
@@ -260,6 +294,7 @@ const DEF_LOCAL_KEYS: &str = "deflocalkeys-linux";
 #[allow(clippy::type_complexity)] // return type is not pub
 fn parse_cfg_raw(
     p: &std::path::Path,
+    s: &mut ParsedState,
 ) -> Result<(
     HashMap<String, String>,
     MappedKeys,
@@ -320,6 +355,7 @@ fn parse_cfg_raw(
     let layer_exprs = root_exprs
         .iter()
         .filter(&deflayer_filter)
+        .cloned()
         .collect::<Vec<_>>();
 
     if layer_exprs.is_empty() {
@@ -369,8 +405,10 @@ fn parse_cfg_raw(
         .iter()
         .filter(gen_first_atom_filter("defalias"))
         .collect::<Vec<_>>();
-    let defsrc_layer = parse_defsrc_layer(src_expr, &mapping_order);
-    let mut parsed_state = ParsedState {
+    let defsrc_layer = parse_defsrc_layer(src_expr, &mapping_order, s);
+
+    *s = ParsedState {
+        a: s.a.clone(),
         layer_exprs,
         layer_idxs,
         mapping_order,
@@ -400,25 +438,25 @@ fn parse_cfg_raw(
         .iter()
         .filter(gen_first_atom_filter("defchords"))
         .collect::<Vec<_>>();
-    parse_chord_groups(&chords_exprs, &mut parsed_state)?;
+    parse_chord_groups(&chords_exprs, s)?;
 
     let fake_keys_exprs = root_exprs
         .iter()
         .filter(gen_first_atom_filter("deffakekeys"))
         .collect::<Vec<_>>();
-    parse_fake_keys(&fake_keys_exprs, &mut parsed_state)?;
+    parse_fake_keys(&fake_keys_exprs, s)?;
 
     let sequence_exprs = root_exprs
         .iter()
         .filter(gen_first_atom_filter("defseq"))
         .collect::<Vec<_>>();
-    let sequences = parse_sequences(&sequence_exprs, &parsed_state)?;
+    let sequences = parse_sequences(&sequence_exprs, s)?;
 
-    parse_aliases(&alias_exprs, &mut parsed_state)?;
+    parse_aliases(&alias_exprs, s)?;
 
-    let mut klayers = parse_layers(&parsed_state)?;
+    let mut klayers = parse_layers(s)?;
 
-    resolve_chord_groups(&mut klayers, &mut parsed_state)?;
+    resolve_chord_groups(&mut klayers, s)?;
 
     Ok((cfg, src, layer_info, klayers, sequences))
 }
@@ -580,7 +618,7 @@ type Aliases = HashMap<String, &'static KanataAction>;
 
 /// Returns layer names and their indexes into the keyberon layout. This also checks that all
 /// layers have the same number of items as the defsrc.
-fn parse_layer_indexes(exprs: &[&Vec<SExpr>], expected_len: usize) -> Result<LayerIndexes> {
+fn parse_layer_indexes(exprs: &[Vec<SExpr>], expected_len: usize) -> Result<LayerIndexes> {
     let mut layer_indexes = HashMap::default();
     for (i, expr) in exprs.iter().enumerate() {
         let mut subexprs = check_first_expr(expr.iter(), "deflayer")?;
@@ -606,18 +644,19 @@ fn parse_layer_indexes(exprs: &[&Vec<SExpr>], expected_len: usize) -> Result<Lay
 }
 
 #[derive(Debug)]
-struct ParsedState<'a> {
-    layer_exprs: Vec<&'a Vec<SExpr>>,
+struct ParsedState {
+    layer_exprs: Vec<Vec<SExpr>>,
     aliases: Aliases,
     layer_idxs: LayerIndexes,
     mapping_order: Vec<usize>,
     fake_keys: HashMap<String, (usize, &'static KanataAction)>,
-    chord_groups: HashMap<String, ChordGroup<'a>>,
+    chord_groups: HashMap<String, ChordGroup>,
     defsrc_layer: [KanataAction; KEYS_IN_ROW],
     is_cmd_enabled: bool,
+    a: Arc<Allocations>,
 }
 
-impl<'a> Default for ParsedState<'a> {
+impl Default for ParsedState {
     fn default() -> Self {
         Self {
             layer_exprs: Default::default(),
@@ -628,23 +667,24 @@ impl<'a> Default for ParsedState<'a> {
             fake_keys: Default::default(),
             chord_groups: Default::default(),
             is_cmd_enabled: false,
+            a: unsafe { Allocations::new() },
         }
     }
 }
 
 #[derive(Debug, Clone)]
-struct ChordGroup<'a> {
+struct ChordGroup {
     id: u16,
     name: String,
     keys: Vec<String>,
     coords: Vec<((u8, u16), ChordKeys)>,
-    chords: HashMap<u32, &'a SExpr>,
+    chords: HashMap<u32, SExpr>,
     timeout: u16,
 }
 
 /// Parse alias->action mappings from multiple exprs starting with defalias.
-/// Mutates the input `parsed_state` by storing aliases inside.
-fn parse_aliases(exprs: &[&Vec<SExpr>], parsed_state: &mut ParsedState) -> Result<()> {
+/// Mutates the input `s` by storing aliases inside.
+fn parse_aliases(exprs: &[&Vec<SExpr>], s: &mut ParsedState) -> Result<()> {
     for expr in exprs {
         let mut subexprs = check_first_expr(expr.iter(), "defalias")?;
         // Read k-v pairs from the configuration
@@ -657,8 +697,8 @@ fn parse_aliases(exprs: &[&Vec<SExpr>], parsed_state: &mut ParsedState) -> Resul
                 SExpr::Atom(a) => &a.t,
                 _ => bail!("Alias keys must be atoms. Invalid alias: {:?}", alias),
             };
-            let action = parse_action(action, parsed_state)?;
-            if parsed_state.aliases.insert(alias.into(), action).is_some() {
+            let action = parse_action(action, s)?;
+            if s.aliases.insert(alias.into(), action).is_some() {
                 bail!("Duplicate alias: {}", alias);
             }
         }
@@ -666,99 +706,97 @@ fn parse_aliases(exprs: &[&Vec<SExpr>], parsed_state: &mut ParsedState) -> Resul
     Ok(())
 }
 
-/// Returns a `&'static T` by leaking a box.
-fn sref<T>(v: T) -> &'static T {
-    Box::leak(Box::new(v))
-}
-
-/// Returns a `&'static [&'static T]` by leaking a box + boxed array
-fn sref_slice<T>(v: T) -> &'static [&'static T] {
-    Box::leak(vec![sref(v)].into_boxed_slice())
-}
-
 /// Parse a `kanata_keyberon::action::Action` from a `SExpr`.
-fn parse_action(expr: &SExpr, parsed_state: &ParsedState) -> Result<&'static KanataAction> {
+fn parse_action(expr: &SExpr, s: &ParsedState) -> Result<&'static KanataAction> {
     match expr {
-        SExpr::Atom(a) => parse_action_atom(a, &parsed_state.aliases),
-        SExpr::List(l) => parse_action_list(&l.t, parsed_state),
+        SExpr::Atom(a) => parse_action_atom(a, s),
+        SExpr::List(l) => parse_action_list(&l.t, s),
     }
 }
 
 /// Parse a `kanata_keyberon::action::Action` from a string.
-fn parse_action_atom(ac: &Spanned<String>, aliases: &Aliases) -> Result<&'static KanataAction> {
+fn parse_action_atom(ac: &Spanned<String>, s: &ParsedState) -> Result<&'static KanataAction> {
     let ac = &*ac.t;
     match ac {
-        "_" => return Ok(sref(Action::Trans)),
-        "XX" => return Ok(sref(Action::NoOp)),
-        "lrld" => return Ok(sref(Action::Custom(sref_slice(CustomAction::LiveReload)))),
+        "_" => return Ok(s.a.sref(Action::Trans)),
+        "XX" => return Ok(s.a.sref(Action::NoOp)),
+        "lrld" => {
+            return Ok(s
+                .a
+                .sref(Action::Custom(s.a.sref_slice(CustomAction::LiveReload))))
+        }
         "sldr" => {
-            return Ok(sref(Action::Custom(sref_slice(
-                CustomAction::SequenceLeader,
-            ))))
+            return Ok(s
+                .a
+                .sref(Action::Custom(s.a.sref_slice(CustomAction::SequenceLeader))))
         }
         "mlft" | "mouseleft" => {
-            return Ok(sref(Action::Custom(sref_slice(CustomAction::Mouse(
-                Btn::Left,
-            )))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref_slice(CustomAction::Mouse(Btn::Left)),
+            )))
         }
         "mrgt" | "mouseright" => {
-            return Ok(sref(Action::Custom(sref_slice(CustomAction::Mouse(
-                Btn::Right,
-            )))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref_slice(CustomAction::Mouse(Btn::Right)),
+            )))
         }
         "mmid" | "mousemid" => {
-            return Ok(sref(Action::Custom(sref_slice(CustomAction::Mouse(
-                Btn::Mid,
-            )))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref_slice(CustomAction::Mouse(Btn::Mid)),
+            )))
         }
         "mfwd" | "mouseforward" => {
-            return Ok(sref(Action::Custom(sref_slice(CustomAction::Mouse(
-                Btn::Forward,
-            )))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref_slice(CustomAction::Mouse(Btn::Forward)),
+            )))
         }
         "mbck" | "mousebackward" => {
-            return Ok(sref(Action::Custom(sref_slice(CustomAction::Mouse(
-                Btn::Backward,
-            )))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref_slice(CustomAction::Mouse(Btn::Backward)),
+            )))
         }
         "mltp" | "mousetapleft" => {
-            return Ok(sref(Action::Custom(sref_slice(CustomAction::MouseTap(
-                Btn::Left,
-            )))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref_slice(CustomAction::MouseTap(Btn::Left)),
+            )))
         }
         "mrtp" | "mousetapright" => {
-            return Ok(sref(Action::Custom(sref_slice(CustomAction::MouseTap(
-                Btn::Right,
-            )))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref_slice(CustomAction::MouseTap(Btn::Right)),
+            )))
         }
         "mmtp" | "mousetapmid" => {
-            return Ok(sref(Action::Custom(sref_slice(CustomAction::MouseTap(
-                Btn::Mid,
-            )))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref_slice(CustomAction::MouseTap(Btn::Mid)),
+            )))
         }
         "mftp" | "mousetapforward" => {
-            return Ok(sref(Action::Custom(sref_slice(CustomAction::MouseTap(
-                Btn::Forward,
-            )))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref_slice(CustomAction::MouseTap(Btn::Forward)),
+            )))
         }
         "mbtp" | "mousetapbackward" => {
-            return Ok(sref(Action::Custom(sref_slice(CustomAction::MouseTap(
-                Btn::Backward,
-            )))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref_slice(CustomAction::MouseTap(Btn::Backward)),
+            )))
         }
-        "rpt" | "repeat" => return Ok(sref(Action::Custom(sref_slice(CustomAction::Repeat)))),
+        "rpt" | "repeat" => {
+            return Ok(s
+                .a
+                .sref(Action::Custom(s.a.sref_slice(CustomAction::Repeat))))
+        }
         "dynamic-macro-record-stop" => {
-            return Ok(sref(Action::Custom(sref_slice(
-                CustomAction::DynamicMacroRecordStop,
-            ))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref_slice(CustomAction::DynamicMacroRecordStop),
+            )))
         }
         _ => {}
     };
     if let Some(oscode) = str_to_oscode(ac) {
-        return Ok(sref(k(oscode.into())));
+        return Ok(s.a.sref(k(oscode.into())));
     }
     if let Some(alias) = ac.strip_prefix('@') {
-        return match aliases.get(alias) {
+        return match s.aliases.get(alias) {
             Some(ac) => Ok(*ac),
             None => bail!(
                 "Referenced unknown alias {}. Note that order of declarations matter.",
@@ -774,54 +812,53 @@ fn parse_action_atom(ac: &Spanned<String>, aliases: &Aliases) -> Result<&'static
             .ok_or_else(|| anyhow!("Could not parse: {ac:?}"))?
             .into(),
     );
-    Ok(sref(Action::MultipleKeyCodes(sref(keys).as_ref())))
+    Ok(s.a.sref(Action::MultipleKeyCodes(s.a.sref_vec(keys))))
 }
 
 /// Parse a `kanata_keyberon::action::Action` from a `SExpr::List`.
-fn parse_action_list(ac: &[SExpr], parsed_state: &ParsedState) -> Result<&'static KanataAction> {
+fn parse_action_list(ac: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
     if ac.is_empty() {
-        return Ok(sref(Action::NoOp));
+        return Ok(s.a.sref(Action::NoOp));
     }
     let ac_type = match &ac[0] {
         SExpr::Atom(a) => &a.t,
         _ => bail!("Action list must start with an atom"),
     };
-    let layers = &parsed_state.layer_idxs;
     match ac_type.as_str() {
-        "layer-switch" => parse_layer_base(&ac[1..], layers),
-        "layer-toggle" | "layer-while-held" => parse_layer_toggle(&ac[1..], layers),
-        "tap-hold" => parse_tap_hold(&ac[1..], parsed_state, HoldTapConfig::Default),
-        "tap-hold-press" => parse_tap_hold(&ac[1..], parsed_state, HoldTapConfig::HoldOnOtherKeyPress),
-        "tap-hold-release" => parse_tap_hold(&ac[1..], parsed_state, HoldTapConfig::PermissiveHold),
-        "multi" => parse_multi(&ac[1..], parsed_state),
-        "macro" => parse_macro(&ac[1..], parsed_state),
-        "macro-release-cancel" => parse_macro_release_cancel(&ac[1..], parsed_state),
-        "unicode" => parse_unicode(&ac[1..]),
-        "one-shot" => parse_one_shot(&ac[1..], parsed_state),
-        "tap-dance" => parse_tap_dance(&ac[1..], parsed_state, TapDanceConfig::Lazy),
-        "tap-dance-eager" => parse_tap_dance(&ac[1..], parsed_state, TapDanceConfig::Eager),
-        "chord" => parse_chord(&ac[1..], parsed_state),
-        "release-key" => parse_release_key(&ac[1..], parsed_state),
-        "release-layer" => parse_release_layer(&ac[1..], parsed_state),
-        "on-press-fakekey" => parse_fake_key_op(&ac[1..], parsed_state),
-        "on-release-fakekey" => parse_on_release_fake_key_op(&ac[1..], parsed_state),
-        "on-press-fakekey-delay" => parse_fake_key_delay(&ac[1..]),
-        "on-release-fakekey-delay" => parse_on_release_fake_key_delay(&ac[1..]),
-        "mwheel-up" => parse_mwheel(&ac[1..], MWheelDirection::Up),
-        "mwheel-down" => parse_mwheel(&ac[1..], MWheelDirection::Down),
-        "mwheel-left" => parse_mwheel(&ac[1..], MWheelDirection::Left),
-        "mwheel-right" => parse_mwheel(&ac[1..], MWheelDirection::Right),
-        "movemouse-up" => parse_move_mouse(&ac[1..], MoveDirection::Up),
-        "movemouse-down" => parse_move_mouse(&ac[1..], MoveDirection::Down),
-        "movemouse-left" => parse_move_mouse(&ac[1..], MoveDirection::Left),
-        "movemouse-right" => parse_move_mouse(&ac[1..], MoveDirection::Right),
-        "movemouse-accel-up" => parse_move_mouse_accel(&ac[1..], MoveDirection::Up),
-        "movemouse-accel-down" => parse_move_mouse_accel(&ac[1..], MoveDirection::Down),
-        "movemouse-accel-left" => parse_move_mouse_accel(&ac[1..], MoveDirection::Left),
-        "movemouse-accel-right" => parse_move_mouse_accel(&ac[1..], MoveDirection::Right),
-        "dynamic-macro-record" => parse_dynamic_macro_record(&ac[1..]),
-        "dynamic-macro-play" => parse_dynamic_macro_play(&ac[1..]),
-        "cmd" => parse_cmd(&ac[1..], parsed_state.is_cmd_enabled),
+        "layer-switch" => parse_layer_base(&ac[1..], s),
+        "layer-toggle" | "layer-while-held" => parse_layer_toggle(&ac[1..], s),
+        "tap-hold" => parse_tap_hold(&ac[1..], s, HoldTapConfig::Default),
+        "tap-hold-press" => parse_tap_hold(&ac[1..], s, HoldTapConfig::HoldOnOtherKeyPress),
+        "tap-hold-release" => parse_tap_hold(&ac[1..], s, HoldTapConfig::PermissiveHold),
+        "multi" => parse_multi(&ac[1..], s),
+        "macro" => parse_macro(&ac[1..], s),
+        "macro-release-cancel" => parse_macro_release_cancel(&ac[1..], s),
+        "unicode" => parse_unicode(&ac[1..], s),
+        "one-shot" => parse_one_shot(&ac[1..], s),
+        "tap-dance" => parse_tap_dance(&ac[1..], s, TapDanceConfig::Lazy),
+        "tap-dance-eager" => parse_tap_dance(&ac[1..], s, TapDanceConfig::Eager),
+        "chord" => parse_chord(&ac[1..], s),
+        "release-key" => parse_release_key(&ac[1..], s),
+        "release-layer" => parse_release_layer(&ac[1..], s),
+        "on-press-fakekey" => parse_fake_key_op(&ac[1..], s),
+        "on-release-fakekey" => parse_on_release_fake_key_op(&ac[1..], s),
+        "on-press-fakekey-delay" => parse_fake_key_delay(&ac[1..], s),
+        "on-release-fakekey-delay" => parse_on_release_fake_key_delay(&ac[1..], s),
+        "mwheel-up" => parse_mwheel(&ac[1..], MWheelDirection::Up, s),
+        "mwheel-down" => parse_mwheel(&ac[1..], MWheelDirection::Down, s),
+        "mwheel-left" => parse_mwheel(&ac[1..], MWheelDirection::Left, s),
+        "mwheel-right" => parse_mwheel(&ac[1..], MWheelDirection::Right, s),
+        "movemouse-up" => parse_move_mouse(&ac[1..], MoveDirection::Up, s),
+        "movemouse-down" => parse_move_mouse(&ac[1..], MoveDirection::Down, s),
+        "movemouse-left" => parse_move_mouse(&ac[1..], MoveDirection::Left, s),
+        "movemouse-right" => parse_move_mouse(&ac[1..], MoveDirection::Right, s),
+        "movemouse-accel-up" => parse_move_mouse_accel(&ac[1..], MoveDirection::Up, s),
+        "movemouse-accel-down" => parse_move_mouse_accel(&ac[1..], MoveDirection::Down, s),
+        "movemouse-accel-left" => parse_move_mouse_accel(&ac[1..], MoveDirection::Left, s),
+        "movemouse-accel-right" => parse_move_mouse_accel(&ac[1..], MoveDirection::Right, s),
+        "dynamic-macro-record" => parse_dynamic_macro_record(&ac[1..], s),
+        "dynamic-macro-play" => parse_dynamic_macro_play(&ac[1..], s),
+        "cmd" => parse_cmd(&ac[1..], s),
         _ => bail!(
             "Unknown action type: {}. Valid types:\n\tlayer-switch\n\tlayer-toggle | layer-while-held\n\ttap-hold | tap-hold-press | tap-hold-release\n\tmulti\n\tmacro\n\tunicode\n\tone-shot\n\ttap-dance\n\trelease-key | release-layer\n\tmwheel-up | mwheel-down | mwheel-left | mwheel-right\n\ton-press-fakekey | on-release-fakekey\n\ton-press-fakekey-delay | on-release-fakekey-delay\n\tcmd",
             ac_type
@@ -829,14 +866,14 @@ fn parse_action_list(ac: &[SExpr], parsed_state: &ParsedState) -> Result<&'stati
     }
 }
 
-fn parse_layer_base(ac_params: &[SExpr], layers: &LayerIndexes) -> Result<&'static KanataAction> {
-    Ok(sref(Action::DefaultLayer(
-        layer_idx(ac_params, layers)? * 2,
+fn parse_layer_base(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
+    Ok(s.a.sref(Action::DefaultLayer(
+        layer_idx(ac_params, &s.layer_idxs)? * 2,
     )))
 }
 
-fn parse_layer_toggle(ac_params: &[SExpr], layers: &LayerIndexes) -> Result<&'static KanataAction> {
-    Ok(sref(Action::Layer(layer_idx(ac_params, layers)? * 2 + 1)))
+fn parse_layer_toggle(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
+    Ok(s.a.sref(Action::Layer(layer_idx(ac_params, &s.layer_idxs)? * 2 + 1)))
 }
 
 fn layer_idx(ac_params: &[SExpr], layers: &LayerIndexes) -> Result<usize> {
@@ -861,7 +898,7 @@ fn layer_idx(ac_params: &[SExpr], layers: &LayerIndexes) -> Result<usize> {
 
 fn parse_tap_hold(
     ac_params: &[SExpr],
-    parsed_state: &ParsedState,
+    s: &ParsedState,
     config: HoldTapConfig,
 ) -> Result<&'static KanataAction> {
     if ac_params.len() != 4 {
@@ -871,12 +908,12 @@ fn parse_tap_hold(
         parse_timeout(&ac_params[0]).map_err(|e| anyhow!("invalid tap-timeout: {}", e))?;
     let hold_timeout =
         parse_timeout(&ac_params[1]).map_err(|e| anyhow!("invalid tap-timeout: {}", e))?;
-    let tap_action = parse_action(&ac_params[2], parsed_state)?;
-    let hold_action = parse_action(&ac_params[3], parsed_state)?;
+    let tap_action = parse_action(&ac_params[2], s)?;
+    let hold_action = parse_action(&ac_params[3], s)?;
     if matches!(tap_action, Action::HoldTap { .. }) {
         bail!("tap-hold does not work in the tap-action of tap-hold")
     }
-    Ok(sref(Action::HoldTap(sref(HoldTapAction {
+    Ok(s.a.sref(Action::HoldTap(s.a.sref(HoldTapAction {
         config,
         tap_hold_interval: tap_timeout,
         timeout: hold_timeout,
@@ -892,14 +929,14 @@ fn parse_timeout(a: &SExpr) -> Result<u16> {
     }
 }
 
-fn parse_multi(ac_params: &[SExpr], parsed_state: &ParsedState) -> Result<&'static KanataAction> {
+fn parse_multi(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
     if ac_params.is_empty() {
         bail!("multi expects at least one atom after it")
     }
     let mut actions = Vec::new();
     let mut custom_actions: Vec<&'static CustomAction> = Vec::new();
     for expr in ac_params {
-        let ac = parse_action(expr, parsed_state)?;
+        let ac = parse_action(expr, s)?;
         match ac {
             Action::Custom(acs) => {
                 for ac in acs.iter() {
@@ -924,10 +961,10 @@ fn parse_multi(ac_params: &[SExpr], parsed_state: &ParsedState) -> Result<&'stat
     }
 
     if !custom_actions.is_empty() {
-        actions.push(Action::Custom(Box::leak(custom_actions.into_boxed_slice())));
+        actions.push(Action::Custom(s.a.sref_vec(custom_actions)));
     }
 
-    Ok(sref(Action::MultipleActions(sref(actions))))
+    Ok(s.a.sref(Action::MultipleActions(s.a.sref_vec(actions))))
 }
 
 #[test]
@@ -953,10 +990,8 @@ fn recursive_multi_is_flattened() {
             list!([atom!("multi"), atom!("c"), atom!("mrtp"),])
         ]),
     ];
-    let parsed_state = ParsedState::default();
-    if let KanataAction::MultipleActions(parsed_multi) =
-        parse_multi(&params, &parsed_state).unwrap()
-    {
+    let s = ParsedState::default();
+    if let KanataAction::MultipleActions(parsed_multi) = parse_multi(&params, &s).unwrap() {
         assert_eq!(parsed_multi.len(), 4);
         assert_eq!(parsed_multi[0], Action::KeyCode(KeyCode::A));
         assert_eq!(parsed_multi[1], Action::KeyCode(KeyCode::B));
@@ -979,37 +1014,37 @@ fn recursive_multi_is_flattened() {
 const MACRO_ERR: &str =
     "Action \"macro\" only accepts delays, keys, chords, and chorded sub-macros";
 
-fn parse_macro(ac_params: &[SExpr], parsed_state: &ParsedState) -> Result<&'static KanataAction> {
+fn parse_macro(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
     if ac_params.is_empty() {
         bail!("macro expects at least one atom after it")
     }
-    let mut all_events = Vec::new();
-    let mut events;
+    let mut all_events = Vec::with_capacity(256);
     let mut params_remainder = ac_params;
     while !params_remainder.is_empty() {
-        (events, params_remainder) = parse_macro_item(params_remainder, parsed_state)?;
+        let mut events;
+        (events, params_remainder) = parse_macro_item(params_remainder, s)?;
         all_events.append(&mut events);
     }
-    Ok(sref(Action::Sequence {
-        events: sref(all_events),
+    Ok(s.a.sref(Action::Sequence {
+        events: s.a.sref_vec(all_events),
     }))
 }
 
 fn parse_macro_release_cancel(
     ac_params: &[SExpr],
-    parsed_state: &ParsedState,
+    s: &ParsedState,
 ) -> Result<&'static KanataAction> {
-    let macro_action = parse_macro(ac_params, parsed_state)?;
-    Ok(sref(Action::MultipleActions(sref(vec![
+    let macro_action = parse_macro(ac_params, s)?;
+    Ok(s.a.sref(Action::MultipleActions(s.a.sref_vec(vec![
         *macro_action,
-        Action::Custom(sref_slice(CustomAction::CancelMacroOnRelease)),
+        Action::Custom(s.a.sref_slice(CustomAction::CancelMacroOnRelease)),
     ]))))
 }
 
 #[allow(clippy::type_complexity)] // return type is not pub
 fn parse_macro_item<'a>(
     acs: &'a [SExpr],
-    parsed_state: &ParsedState,
+    s: &ParsedState,
 ) -> Result<(
     Vec<SequenceEvent<&'static [&'static CustomAction]>>,
     &'a [SExpr],
@@ -1018,7 +1053,7 @@ fn parse_macro_item<'a>(
         let duration = u32::from(duration);
         return Ok((vec![SequenceEvent::Delay { duration }], &acs[1..]));
     }
-    match parse_action(&acs[0], parsed_state) {
+    match parse_action(&acs[0], s) {
         Ok(Action::KeyCode(kc)) => {
             // Should note that I tried `SequenceEvent::Tap` initially but it seems to be buggy
             // so I changed the code to use individual press and release. The SequenceEvent
@@ -1062,7 +1097,7 @@ fn parse_macro_item<'a>(
             let mut submacro_remainder = submacro;
             let mut events;
             while !submacro_remainder.is_empty() {
-                (events, submacro_remainder) = parse_macro_item(submacro_remainder, parsed_state)?;
+                (events, submacro_remainder) = parse_macro_item(submacro_remainder, s)?;
                 all_events.append(&mut events);
             }
 
@@ -1137,53 +1172,45 @@ fn parse_mod_prefix(mods: &str) -> Result<(Vec<KeyCode>, &str)> {
     Ok((key_stack, rem))
 }
 
-fn parse_unicode(ac_params: &[SExpr]) -> Result<&'static KanataAction> {
+fn parse_unicode(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
     const ERR_STR: &str = "unicode expects exactly one unicode character as an argument";
     if ac_params.len() != 1 {
         bail!(ERR_STR)
     }
     match &ac_params[0] {
-        SExpr::Atom(s) => {
-            if s.t.chars().count() != 1 {
+        SExpr::Atom(a) => {
+            if a.t.chars().count() != 1 {
                 bail!(ERR_STR)
             }
-            Ok(sref(Action::Custom(sref_slice(CustomAction::Unicode(
-                s.t.chars().next().unwrap(),
-            )))))
+            Ok(s.a.sref(Action::Custom(
+                s.a.sref_slice(CustomAction::Unicode(a.t.chars().next().unwrap())),
+            )))
         }
         _ => bail!(ERR_STR),
     }
 }
 
-fn parse_cmd(ac_params: &[SExpr], is_cmd_enabled: bool) -> Result<&'static KanataAction> {
+fn parse_cmd(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
     const ERR_STR: &str = "cmd expects one or more strings";
-    if !is_cmd_enabled {
+    if !s.is_cmd_enabled {
         bail!("cmd is not enabled but cmd action is specified somewhere");
     }
     if ac_params.is_empty() {
         bail!(ERR_STR);
     }
-    Ok(sref(Action::Custom(sref_slice(CustomAction::Cmd(
-        Box::leak(
-            ac_params
-                .iter()
-                .try_fold(vec![], |mut v, p| {
-                    if let SExpr::Atom(s) = p {
-                        v.push(s.t.trim_matches('"').to_owned());
-                        Ok(v)
-                    } else {
-                        bail!("{}, found a list", ERR_STR);
-                    }
-                })?
-                .into_boxed_slice(),
-        ),
+    Ok(s.a.sref(Action::Custom(s.a.sref_slice(CustomAction::Cmd(
+        s.a.sref_vec(ac_params.iter().try_fold(vec![], |mut v, p| {
+            if let SExpr::Atom(a) = p {
+                v.push(a.t.trim_matches('"').to_owned());
+                Ok(v)
+            } else {
+                bail!("{}, found a list", ERR_STR);
+            }
+        })?),
     )))))
 }
 
-fn parse_one_shot(
-    ac_params: &[SExpr],
-    parsed_state: &ParsedState,
-) -> Result<&'static KanataAction> {
+fn parse_one_shot(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "one-shot expects a timeout (number) followed by an action";
     if ac_params.len() != 2 {
         bail!(ERR_MSG);
@@ -1201,17 +1228,16 @@ fn parse_one_shot(
         _ => bail!(ERR_MSG),
     };
 
-    let action = parse_action(&ac_params[1], parsed_state)?;
+    let action = parse_action(&ac_params[1], s)?;
     if !matches!(
         action,
         Action::Layer(..) | Action::KeyCode(..) | Action::MultipleKeyCodes(..)
     ) {
-        dbg!(action);
         bail!("one-shot is only allowed to contain layer-toggle, a keycode, or a chord");
     }
 
     let end_config = OneShotEndConfig::EndOnFirstPress;
-    Ok(sref(Action::OneShot(sref(OneShot {
+    Ok(s.a.sref(Action::OneShot(s.a.sref(OneShot {
         timeout,
         action,
         end_config,
@@ -1220,7 +1246,7 @@ fn parse_one_shot(
 
 fn parse_tap_dance(
     ac_params: &[SExpr],
-    parsed_state: &ParsedState,
+    s: &ParsedState,
     config: TapDanceConfig,
 ) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "tap-dance expects a timeout (number) followed by a list of actions";
@@ -1243,22 +1269,22 @@ fn parse_tap_dance(
         SExpr::List(tap_dance_actions) => {
             let mut actions = Vec::new();
             for expr in &tap_dance_actions.t {
-                let ac = parse_action(expr, parsed_state)?;
+                let ac = parse_action(expr, s)?;
                 actions.push(ac);
             }
-            sref(actions.into_boxed_slice())
+            s.a.sref_vec(actions)
         }
         _ => bail!(ERR_MSG),
     };
 
-    Ok(sref(Action::TapDance(sref(TapDance {
+    Ok(s.a.sref(Action::TapDance(s.a.sref(TapDance {
         timeout,
         actions,
         config,
     }))))
 }
 
-fn parse_chord(ac_params: &[SExpr], parsed_state: &ParsedState) -> Result<&'static KanataAction> {
+fn parse_chord(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "chord expects a chords group name followed by an identifier";
     if ac_params.len() != 2 {
         bail!(ERR_MSG);
@@ -1268,7 +1294,7 @@ fn parse_chord(ac_params: &[SExpr], parsed_state: &ParsedState) -> Result<&'stat
         SExpr::Atom(s) => &s.t,
         _ => bail!(ERR_MSG),
     };
-    let group = match parsed_state.chord_groups.get(name) {
+    let group = match s.chord_groups.get(name) {
         Some(t) => t,
         None => bail!("Referenced unknown chord group `{}`.", name),
     };
@@ -1288,56 +1314,53 @@ fn parse_chord(ac_params: &[SExpr], parsed_state: &ParsedState) -> Result<&'stat
     // We don't yet know at this point what the entire chords group will look like nor at which
     // coords this action will end up. So instead we store a dummy action which will be properly
     // resolved in `resolve_chord_groups`.
-    Ok(sref(Action::Chords(sref(ChordsGroup {
+    Ok(s.a.sref(Action::Chords(s.a.sref(ChordsGroup {
         timeout: group.timeout,
-        coords: sref([((0, group.id), chord_keys)]),
-        chords: sref([]),
+        coords: s.a.sref_vec(vec![((0, group.id), chord_keys)]),
+        chords: s.a.sref_vec(vec![]),
     }))))
 }
 
-fn parse_release_key(
-    ac_params: &[SExpr],
-    parsed_state: &ParsedState,
-) -> Result<&'static KanataAction> {
+fn parse_release_key(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "release-key expects exactly one keycode (e.g. lalt)";
     if ac_params.len() != 1 {
         bail!(ERR_MSG);
     }
-    let ac = parse_action(&ac_params[0], parsed_state)?;
+    let ac = parse_action(&ac_params[0], s)?;
     match ac {
-        Action::KeyCode(kc) => Ok(sref(Action::ReleaseState(ReleasableState::KeyCode(*kc)))),
+        Action::KeyCode(kc) => {
+            Ok(s.a.sref(Action::ReleaseState(ReleasableState::KeyCode(*kc))))
+        }
         _ => bail!("{}, got {:?}", ERR_MSG, ac),
     }
 }
 
-fn parse_release_layer(
-    ac_params: &[SExpr],
-    parsed_state: &ParsedState,
-) -> Result<&'static KanataAction> {
+fn parse_release_layer(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "release-key expects exactly one layer name (e.g. arrows)";
     if ac_params.len() != 1 {
         bail!(ERR_MSG);
     }
-    Ok(sref(Action::ReleaseState(ReleasableState::Layer(
-        layer_idx(ac_params, &parsed_state.layer_idxs)? * 2 + 1,
+    Ok(s.a.sref(Action::ReleaseState(ReleasableState::Layer(
+        layer_idx(ac_params, &s.layer_idxs)? * 2 + 1,
     ))))
 }
 
-fn parse_defsrc_layer(defsrc: &[SExpr], mapping_order: &[usize]) -> [KanataAction; KEYS_IN_ROW] {
+fn parse_defsrc_layer(
+    defsrc: &[SExpr],
+    mapping_order: &[usize],
+    s: &ParsedState,
+) -> [KanataAction; KEYS_IN_ROW] {
     let mut layer = [KanataAction::Trans; KEYS_IN_ROW];
 
     // These can be default (empty) since the defsrc layer definitely won't use it.
     for (i, ac) in defsrc.iter().skip(1).enumerate() {
-        let ac = parse_action(ac, &Default::default()).unwrap();
+        let ac = parse_action(ac, s).unwrap();
         layer[mapping_order[i]] = *ac;
     }
     layer
 }
 
-fn parse_chord_groups<'a>(
-    exprs: &[&'a Vec<SExpr>],
-    parsed_state: &mut ParsedState<'a>,
-) -> Result<()> {
+fn parse_chord_groups(exprs: &[&Vec<SExpr>], s: &mut ParsedState) -> Result<()> {
     const MSG: &str = "Incorrect number of elements found in defchords; should be group name, followed by timeout, followed by keys-action pairs.";
     for expr in exprs {
         let mut subexprs = check_first_expr(expr.iter(), "defchords")?;
@@ -1349,7 +1372,7 @@ fn parse_chord_groups<'a>(
             Some(e) => parse_timeout(e)?,
             None => bail!(MSG),
         };
-        let id = match parsed_state.chord_groups.len().try_into() {
+        let id = match s.chord_groups.len().try_into() {
             Ok(id) => id,
             Err(_) => bail!("Maximum number of chord groups exceeded."),
         };
@@ -1392,27 +1415,19 @@ fn parse_chord_groups<'a>(
                 };
                 Ok(mask | (1 << index))
             })?;
-            if group.chords.insert(mask, action).is_some() {
+            if group.chords.insert(mask, action.clone()).is_some() {
                 bail!("Duplicate chord in group {}: {:?}", name, keys_expr);
             }
         }
-        if parsed_state
-            .chord_groups
-            .insert(name.to_owned(), group)
-            .is_some()
-        {
+        if s.chord_groups.insert(name.to_owned(), group).is_some() {
             bail!("Duplicate chords group: {}", name);
         }
     }
     Ok(())
 }
 
-fn resolve_chord_groups(layers: &mut KanataLayers, parsed_state: &mut ParsedState) -> Result<()> {
-    let mut chord_groups = parsed_state
-        .chord_groups
-        .values()
-        .cloned()
-        .collect::<Vec<_>>();
+fn resolve_chord_groups(layers: &mut KanataLayers, s: &ParsedState) -> Result<()> {
+    let mut chord_groups = s.chord_groups.values().cloned().collect::<Vec<_>>();
     chord_groups.sort_by_key(|group| group.id);
 
     for layer in layers.iter() {
@@ -1433,12 +1448,12 @@ fn resolve_chord_groups(layers: &mut KanataLayers, parsed_state: &mut ParsedStat
         }
 
         let chords = group.chords.iter().map(|(mask, action)| {
-            Ok((*mask, parse_action(action, parsed_state)?))
+            Ok((*mask, parse_action(action, s)?))
         }).collect::<Result<Vec<_>>>()?;
 
-        Ok(sref(ChordsGroup {
-            coords: Box::leak(group.coords.into_boxed_slice()),
-            chords: Box::leak(chords.into_boxed_slice()),
+        Ok(s.a.sref(ChordsGroup {
+            coords: s.a.sref_vec(group.coords),
+            chords: s.a.sref_vec(chords),
             timeout: group.timeout,
         }))
     }).collect::<Result<Vec<_>>>()?;
@@ -1446,7 +1461,7 @@ fn resolve_chord_groups(layers: &mut KanataLayers, parsed_state: &mut ParsedStat
     for layer in layers.iter_mut() {
         for row in layer.iter_mut() {
             for cell in row.iter_mut() {
-                if let Some(action) = fill_chords(&chord_groups, cell) {
+                if let Some(action) = fill_chords(&chord_groups, cell, s) {
                     *cell = action;
                 }
             }
@@ -1497,6 +1512,7 @@ fn find_chords_coords(chord_groups: &mut [ChordGroup], coord: (u8, u16), action:
 fn fill_chords(
     chord_groups: &[&'static ChordsGroup<&[&CustomAction]>],
     action: &KanataAction,
+    s: &ParsedState,
 ) -> Option<KanataAction> {
     match action {
         Action::Chords(ChordsGroup { coords, .. }) => {
@@ -1517,10 +1533,10 @@ fn fill_chords(
         | Action::ReleaseState(_)
         | Action::Custom(_) => None,
         Action::HoldTap(&hta @ HoldTapAction { tap, hold, .. }) => {
-            let new_tap = fill_chords(chord_groups, &tap);
-            let new_hold = fill_chords(chord_groups, &hold);
+            let new_tap = fill_chords(chord_groups, &tap, s);
+            let new_hold = fill_chords(chord_groups, &hold, s);
             if new_tap.is_some() || new_hold.is_some() {
-                Some(Action::HoldTap(sref(HoldTapAction {
+                Some(Action::HoldTap(s.a.sref(HoldTapAction {
                     hold: new_hold.unwrap_or(hold),
                     tap: new_tap.unwrap_or(tap),
                     ..hta
@@ -1530,9 +1546,9 @@ fn fill_chords(
             }
         }
         Action::OneShot(&os @ OneShot { action: ac, .. }) => {
-            fill_chords(chord_groups, ac).map(|ac| {
-                Action::OneShot(sref(OneShot {
-                    action: sref(ac),
+            fill_chords(chord_groups, ac, s).map(|ac| {
+                Action::OneShot(s.a.sref(OneShot {
+                    action: s.a.sref(ac),
                     ..os
                 }))
             })
@@ -1540,7 +1556,7 @@ fn fill_chords(
         Action::MultipleActions(actions) => {
             let new_actions = actions
                 .iter()
-                .map(|ac| fill_chords(chord_groups, ac))
+                .map(|ac| fill_chords(chord_groups, ac, s))
                 .collect::<Vec<_>>();
             if new_actions.iter().any(|it| it.is_some()) {
                 let new_actions = new_actions
@@ -1548,9 +1564,7 @@ fn fill_chords(
                     .zip(*actions)
                     .map(|(new_ac, ac)| new_ac.unwrap_or(*ac))
                     .collect::<Vec<_>>();
-                Some(Action::MultipleActions(Box::leak(
-                    new_actions.into_boxed_slice(),
-                )))
+                Some(Action::MultipleActions(s.a.sref_vec(new_actions)))
             } else {
                 None
             }
@@ -1558,16 +1572,16 @@ fn fill_chords(
         Action::TapDance(&td @ TapDance { actions, .. }) => {
             let new_actions = actions
                 .iter()
-                .map(|ac| fill_chords(chord_groups, ac))
+                .map(|ac| fill_chords(chord_groups, ac, s))
                 .collect::<Vec<_>>();
             if new_actions.iter().any(|it| it.is_some()) {
                 let new_actions = new_actions
                     .iter()
                     .zip(actions)
-                    .map(|(new_ac, ac)| new_ac.map(sref).unwrap_or(*ac))
+                    .map(|(new_ac, ac)| new_ac.map(|v| s.a.sref(v)).unwrap_or(*ac))
                     .collect::<Vec<_>>();
-                Some(Action::TapDance(sref(TapDance {
-                    actions: Box::leak(new_actions.into_boxed_slice()),
+                Some(Action::TapDance(s.a.sref(TapDance {
+                    actions: s.a.sref_vec(new_actions),
                     ..td
                 })))
             } else {
@@ -1577,7 +1591,7 @@ fn fill_chords(
     }
 }
 
-fn parse_fake_keys(exprs: &[&Vec<SExpr>], parsed_state: &mut ParsedState) -> Result<()> {
+fn parse_fake_keys(exprs: &[&Vec<SExpr>], s: &mut ParsedState) -> Result<()> {
     for expr in exprs {
         let mut subexprs = check_first_expr(expr.iter(), "deffakekeys")?;
         // Read k-v pairs from the configuration
@@ -1593,57 +1607,49 @@ fn parse_fake_keys(exprs: &[&Vec<SExpr>], parsed_state: &mut ParsedState) -> Res
                     key_name
                 ),
             };
-            let action = parse_action(action, parsed_state)?;
-            let idx = parsed_state.fake_keys.len();
+            let action = parse_action(action, s)?;
+            let idx = s.fake_keys.len();
             log::trace!("inserting {key_name}->{idx}:{action:?}");
-            if parsed_state
-                .fake_keys
-                .insert(key_name.into(), (idx, action))
-                .is_some()
-            {
+            if s.fake_keys.insert(key_name.into(), (idx, action)).is_some() {
                 bail!("Duplicate fake key: {}", key_name);
             }
         }
     }
-    if parsed_state.fake_keys.len() > KEYS_IN_ROW {
+    if s.fake_keys.len() > KEYS_IN_ROW {
         bail!(
             "Maximum number of fake keys is {KEYS_IN_ROW}, found {}",
-            parsed_state.fake_keys.len()
+            s.fake_keys.len()
         );
     }
     Ok(())
 }
 
-fn parse_fake_key_op(
-    ac_params: &[SExpr],
-    parsed_state: &ParsedState,
-) -> Result<&'static KanataAction> {
-    let (coord, action) = parse_fake_key_op_coord_action(ac_params, parsed_state)?;
-    Ok(sref(Action::Custom(sref_slice(CustomAction::FakeKey {
-        coord,
-        action,
-    }))))
+fn parse_fake_key_op(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
+    let (coord, action) = parse_fake_key_op_coord_action(ac_params, s)?;
+    Ok(s.a.sref(Action::Custom(
+        s.a.sref_slice(CustomAction::FakeKey { coord, action }),
+    )))
 }
 
 fn parse_on_release_fake_key_op(
     ac_params: &[SExpr],
-    parsed_state: &ParsedState,
+    s: &ParsedState,
 ) -> Result<&'static KanataAction> {
-    let (coord, action) = parse_fake_key_op_coord_action(ac_params, parsed_state)?;
-    Ok(sref(Action::Custom(sref_slice(
-        CustomAction::FakeKeyOnRelease { coord, action },
-    ))))
+    let (coord, action) = parse_fake_key_op_coord_action(ac_params, s)?;
+    Ok(s.a.sref(Action::Custom(
+        s.a.sref_slice(CustomAction::FakeKeyOnRelease { coord, action }),
+    )))
 }
 
 fn parse_fake_key_op_coord_action(
     ac_params: &[SExpr],
-    parsed_state: &ParsedState,
+    s: &ParsedState,
 ) -> Result<(Coord, FakeKeyAction)> {
     const ERR_MSG: &str = "fake-key-op expects two parameters: <fake key name> <operation>\n\tvalid operations: tap, press, release";
     if ac_params.len() != 2 {
         bail!("{ERR_MSG}");
     }
-    let y = match parsed_state.fake_keys.get(match &ac_params[0] {
+    let y = match s.fake_keys.get(match &ac_params[0] {
         SExpr::Atom(fake_key_name) => &fake_key_name.t,
         _ => bail!(
             "{ERR_MSG}\n\tinvalid first parameter (list): {:?}",
@@ -1674,15 +1680,22 @@ fn get_fake_key_coords<T: Into<usize>>(y: T) -> (u8, u16) {
     (1, y as u16)
 }
 
-fn parse_fake_key_delay(ac_params: &[SExpr]) -> Result<&'static KanataAction> {
-    parse_delay(ac_params, false)
+fn parse_fake_key_delay(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
+    parse_delay(ac_params, false, s)
 }
 
-fn parse_on_release_fake_key_delay(ac_params: &[SExpr]) -> Result<&'static KanataAction> {
-    parse_delay(ac_params, true)
+fn parse_on_release_fake_key_delay(
+    ac_params: &[SExpr],
+    s: &ParsedState,
+) -> Result<&'static KanataAction> {
+    parse_delay(ac_params, true, s)
 }
 
-fn parse_delay(ac_params: &[SExpr], is_release: bool) -> Result<&'static KanataAction> {
+fn parse_delay(
+    ac_params: &[SExpr],
+    is_release: bool,
+    s: &ParsedState,
+) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "fakekey-delay expects a single number (ms, 0-65535)";
     let delay = ac_params[0]
         .atom()
@@ -1690,13 +1703,17 @@ fn parse_delay(ac_params: &[SExpr], is_release: bool) -> Result<&'static KanataA
         .transpose()
         .map_err(|e| anyhow!("{ERR_MSG}: {e}"))?
         .ok_or_else(|| anyhow!("{ERR_MSG}"))?;
-    Ok(sref(Action::Custom(sref_slice(match is_release {
+    Ok(s.a.sref(Action::Custom(s.a.sref_slice(match is_release {
         false => CustomAction::Delay(delay),
         true => CustomAction::DelayOnRelease(delay),
     }))))
 }
 
-fn parse_mwheel(ac_params: &[SExpr], direction: MWheelDirection) -> Result<&'static KanataAction> {
+fn parse_mwheel(
+    ac_params: &[SExpr],
+    direction: MWheelDirection,
+    s: &ParsedState,
+) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "mwheel expects two parameters: <interval (ms)> <distance>";
     if ac_params.len() != 2 {
         bail!("{ERR_MSG}");
@@ -1721,16 +1738,18 @@ fn parse_mwheel(ac_params: &[SExpr], direction: MWheelDirection) -> Result<&'sta
             _ => None,
         })
         .ok_or_else(|| anyhow!("{ERR_MSG}: distance should be 1-30000"))?;
-    Ok(sref(Action::Custom(sref_slice(CustomAction::MWheel {
-        direction,
-        interval,
-        distance,
-    }))))
+    Ok(s.a
+        .sref(Action::Custom(s.a.sref_slice(CustomAction::MWheel {
+            direction,
+            interval,
+            distance,
+        }))))
 }
 
 fn parse_move_mouse(
     ac_params: &[SExpr],
     direction: MoveDirection,
+    s: &ParsedState,
 ) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "movemouse expects two parameters: <interval (ms)> <distance (px)>";
     if ac_params.len() != 2 {
@@ -1756,16 +1775,18 @@ fn parse_move_mouse(
             _ => None,
         })
         .ok_or_else(|| anyhow!("{ERR_MSG}: distance should be 1-30000"))?;
-    Ok(sref(Action::Custom(sref_slice(CustomAction::MoveMouse {
-        direction,
-        interval,
-        distance,
-    }))))
+    Ok(s.a
+        .sref(Action::Custom(s.a.sref_slice(CustomAction::MoveMouse {
+            direction,
+            interval,
+            distance,
+        }))))
 }
 
 fn parse_move_mouse_accel(
     ac_params: &[SExpr],
     direction: MoveDirection,
+    s: &ParsedState,
 ) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "movemouse-accel expects four parameters: <interval (ms)> <acceleration time (ms)> <min_distance> <max_distance>";
     if ac_params.len() != 4 {
@@ -1812,7 +1833,7 @@ fn parse_move_mouse_accel(
             "{ERR_MSG}: min_distance should be less than max_distance"
         ));
     }
-    Ok(sref(Action::Custom(sref_slice(
+    Ok(s.a.sref(Action::Custom(s.a.sref_slice(
         CustomAction::MoveMouseAccel {
             direction,
             interval,
@@ -1823,7 +1844,10 @@ fn parse_move_mouse_accel(
     ))))
 }
 
-fn parse_dynamic_macro_record(ac_params: &[SExpr]) -> Result<&'static KanataAction> {
+fn parse_dynamic_macro_record(
+    ac_params: &[SExpr],
+    s: &ParsedState,
+) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "dynamic-macro-record expects 1 parameter: <macro ID (number 0-65535)>";
     if ac_params.len() != 1 {
         bail!("{ERR_MSG}");
@@ -1834,12 +1858,12 @@ fn parse_dynamic_macro_record(ac_params: &[SExpr]) -> Result<&'static KanataActi
         .transpose()
         .map_err(|e| anyhow!("{ERR_MSG}: {e}"))?
         .ok_or_else(|| anyhow!("{ERR_MSG}: macro ID should be 1-65535"))?;
-    return Ok(sref(Action::Custom(sref_slice(
-        CustomAction::DynamicMacroRecord(key),
-    ))));
+    return Ok(s.a.sref(Action::Custom(
+        s.a.sref_slice(CustomAction::DynamicMacroRecord(key)),
+    )));
 }
 
-fn parse_dynamic_macro_play(ac_params: &[SExpr]) -> Result<&'static KanataAction> {
+fn parse_dynamic_macro_play(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "dynamic-macro-play expects 1 parameter: <macro ID (number 0-65535)>";
     if ac_params.len() != 1 {
         bail!("{ERR_MSG}");
@@ -1850,24 +1874,24 @@ fn parse_dynamic_macro_play(ac_params: &[SExpr]) -> Result<&'static KanataAction
         .transpose()
         .map_err(|e| anyhow!("{ERR_MSG}: {e}"))?
         .ok_or_else(|| anyhow!("{ERR_MSG}: macro ID should be 1-65535"))?;
-    return Ok(sref(Action::Custom(sref_slice(
-        CustomAction::DynamicMacroPlay(key),
-    ))));
+    return Ok(s.a.sref(Action::Custom(
+        s.a.sref_slice(CustomAction::DynamicMacroPlay(key)),
+    )));
 }
 
 /// Mutates `layers::LAYERS` using the inputs.
-fn parse_layers(parsed_state: &ParsedState) -> Result<Box<KanataLayers>> {
+fn parse_layers(s: &ParsedState) -> Result<Box<KanataLayers>> {
     let mut layers_cfg = new_layers();
-    for (layer_level, layer) in parsed_state.layer_exprs.iter().enumerate() {
+    for (layer_level, layer) in s.layer_exprs.iter().enumerate() {
         // skip deflayer and name
         for (i, ac) in layer.iter().skip(2).enumerate() {
-            let ac = parse_action(ac, parsed_state)?;
-            layers_cfg[layer_level * 2][0][parsed_state.mapping_order[i]] = *ac;
-            layers_cfg[layer_level * 2 + 1][0][parsed_state.mapping_order[i]] = *ac;
+            let ac = parse_action(ac, s)?;
+            layers_cfg[layer_level * 2][0][s.mapping_order[i]] = *ac;
+            layers_cfg[layer_level * 2 + 1][0][s.mapping_order[i]] = *ac;
         }
         for (i, (layer_action, defsrc_action)) in layers_cfg[layer_level * 2][0]
             .iter_mut()
-            .zip(parsed_state.defsrc_layer)
+            .zip(s.defsrc_layer)
             .enumerate()
         {
             if *layer_action == Action::Trans {
@@ -1884,7 +1908,7 @@ fn parse_layers(parsed_state: &ParsedState) -> Result<Box<KanataLayers>> {
                     .unwrap_or(Action::Trans);
             }
         }
-        for (y, action) in parsed_state.fake_keys.values() {
+        for (y, action) in s.fake_keys.values() {
             let (x, y) = get_fake_key_coords(*y);
             layers_cfg[layer_level * 2][x as usize][y as usize] = **action;
         }
@@ -1892,7 +1916,7 @@ fn parse_layers(parsed_state: &ParsedState) -> Result<Box<KanataLayers>> {
     Ok(layers_cfg)
 }
 
-fn parse_sequences(exprs: &[&Vec<SExpr>], parsed_state: &ParsedState) -> Result<KeySeqsToFKeys> {
+fn parse_sequences(exprs: &[&Vec<SExpr>], s: &ParsedState) -> Result<KeySeqsToFKeys> {
     const ERR_MSG: &str = "defseq expects pairs of parameters: <fake_key_name> <key_list>";
     let mut sequences = Trie::new();
     for expr in exprs {
@@ -1904,7 +1928,7 @@ fn parse_sequences(exprs: &[&Vec<SExpr>], parsed_state: &ParsedState) -> Result<
                 .ok_or_else(|| anyhow!(ERR_MSG))?
                 .atom()
                 .ok_or_else(|| anyhow!("{ERR_MSG}: got a list for fake_key_name"))?;
-            if !parsed_state.fake_keys.contains_key(fake_key) {
+            if !s.fake_keys.contains_key(fake_key) {
                 bail!("{ERR_MSG}: {fake_key} is not the name of a fake key");
             }
             let key_seq = subexprs
@@ -1933,8 +1957,7 @@ fn parse_sequences(exprs: &[&Vec<SExpr>], parsed_state: &ParsedState) -> Result<
             }
             sequences.insert(
                 keycode_seq,
-                parsed_state
-                    .fake_keys
+                s.fake_keys
                     .get(fake_key)
                     .map(|(y, _)| get_fake_key_coords(*y))
                     .unwrap(),
@@ -2016,6 +2039,6 @@ fn add_key_output_from_action_to_key_pos(
 }
 
 /// Create a layout from `layers::LAYERS`.
-fn create_layout(layers: Box<KanataLayers>) -> KanataLayout {
-    Layout::new(Box::leak(layers))
+fn create_layout(layers: Box<KanataLayers>, a: Arc<Allocations>) -> KanataLayout {
+    KanataLayout::new(Layout::new(a.bref(layers)), a)
 }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -158,7 +158,7 @@ pub use linux::*;
 impl Kanata {
     /// Create a new configuration from a file.
     pub fn new(args: &ValidatedArgs) -> Result<Self> {
-        let cfg = cfg::Cfg::new_from_file(&args.path)?;
+        let cfg = cfg::new_from_file(&args.path)?;
 
         #[cfg(all(feature = "interception_driver", target_os = "windows"))]
         let (kbd_out_tx, kbd_out_rx) = crossbeam_channel::unbounded();
@@ -924,7 +924,7 @@ impl Kanata {
     }
 
     fn do_live_reload(&mut self) -> Result<()> {
-        let cfg = cfg::Cfg::new_from_file(&self.cfg_path)?;
+        let cfg = cfg::new_from_file(&self.cfg_path)?;
         set_altgr_behaviour(&cfg).map_err(|e| anyhow!("failed to set altgr behaviour {e})"))?;
         self.sequence_timeout = cfg
             .items

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -52,10 +52,7 @@ impl Kanata {
         let mut can_block = false;
         loop {
             let dev = match can_block {
-                true => {
-                    dbg!(can_block);
-                    intrcptn.wait()
-                }
+                true => intrcptn.wait(),
                 false => intrcptn.wait_with_timeout(std::time::Duration::from_millis(1)),
             };
             if dev > 0 {


### PR DESCRIPTION
This commit fixes the months-old known issue where live reload leaks memory. This is done by tracking "leaked" allocations and freeing them when the layout is dropped.

In the case that a configuration error is found and the layout is not created, the code will clean up those unused allocations as well.

Naturally, this makes use of unsafe. The code has been tested in valgrind with no reported memory violations or leaks.