### PR TITLE
refactor: free allocated memory on layout drop (v2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ interception = { version = "0.1.2", optional = true }
 
 [features]
 cmd = []
-interception_driver = [ "interception" ]
+interception_driver = ["interception"]
 
 [profile.release]
 opt-level = "z"

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -358,16 +358,6 @@ If you need help, you are welcome to ask.
 ;; Upon a successful reload, the kanata state will begin on the default base layer
 ;; in the configuration. E.g. in this example configuration, you would start on
 ;; the qwerty layer.
-;;
-;; WARNING: live reload leaks memory. This should not be a major problem though.
-;; Here are the measurements of memory consumption on Windows for version 1.0.0:
-;; - 20 reloads: 15.4 MB memory consumed
-;; - 50 reloads: 20.4 MB memory consumed
-;; So about 170 KB used per live reload. You'll probably be fine.
-;;
-;; Note: version 1.0.3 has probably doubled the amount of memory leaked per
-;; reload, though it has not been measured. In practice it's still negligible
-;; compared to a browser for example.
 (deflayer layers
   _    @qwr @dvk lrld @td2 _    _    _    _    _    _    _    _    _
   _    _    _    _    _    _    _    _    _    _    _    _    _    _

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -515,17 +515,6 @@ You can put the `+lrld+` action onto a key to live-reload your configuration
 file. If kanata can't parse the file, it will continue using the previous
 configuration.
 
-It should be noted that the live reload action currently leaks memory. In
-practice this should not matter. Some measurements on Windows for version
-1.0.0:
-
-* 20 reloads: 15.4 MB memory consumed
-* 50 reloads: 20.4 MB memory consumed
-
-This is about 170 KB used per live reload. In more recent versions the memory
-usage per reload has likely more than doubled, but even still, in practice this
-is negligible memory usage compared to other applications like a browser.
-
 Example:
 
 ----

--- a/src/cfg/alloc.rs
+++ b/src/cfg/alloc.rs
@@ -1,0 +1,95 @@
+//! This module contains helpers for tracking and freeing allocations done as part of parsing the
+//! kanata configuration and creating the keyberon layout.
+//!
+//! # Safety
+//!
+//! This module is not threadsafe - multiple configurations must not parse in parallel. A lock
+//! should be implemented around config generation.
+
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use std::cell::Cell;
+
+static NEW_ALLOCATIONS: Lazy<Mutex<Cell<Vec<usize>>>> = Lazy::new(|| Mutex::new(Cell::new(vec![])));
+
+/// Contains all of the allocations made since the previous call to `claim_new_allocations`, or
+/// since beginning of the program if no previous call has been done yet.
+pub(crate) struct Allocations {
+    allocations: Vec<usize>,
+}
+
+impl Drop for Allocations {
+    fn drop(&mut self) {
+        log::debug!("freeing allocations of length {}", self.allocations.len());
+        for p in self.allocations.iter().rev().copied() {
+            unsafe { drop(Box::from_raw(p as *mut usize)) };
+        }
+    }
+}
+
+/// Useful to free allocations made as part of parsing an invalid configuration.
+///
+/// # Safety
+///
+/// Ensure that nothing's actually referencing these allocations anymore.
+pub(super) unsafe fn free_new_allocations() {
+    let mut new = NEW_ALLOCATIONS.lock();
+    for p in new.get_mut().iter().rev().copied() {
+        drop(Box::from_raw(p as *mut usize));
+    }
+    new.get_mut().clear();
+    new.get_mut().shrink_to_fit();
+}
+
+/// Use to take ownership of allocations for dropping them with the associated object.
+///
+/// # Safety
+///
+/// Ensure that the claimed allocations are dropped as part of dropping the object that's actually
+/// using these allocations.
+pub(super) unsafe fn claim_new_allocations() -> Allocations {
+    let mut new = NEW_ALLOCATIONS.lock();
+    log::debug!("allocation lengths, active: {}", new.get_mut().len());
+    let mut allocations = new.replace(vec![]);
+    allocations.shrink_to_fit();
+    Allocations { allocations }
+}
+
+/// Returns a `&'static T` by leaking the existing box.
+pub(super) fn bref<T>(v: Box<T>) -> &'static T {
+    let p = Box::into_raw(v);
+    if (p as usize) < 16 {
+        panic!("bref bad ptr");
+    }
+    NEW_ALLOCATIONS.lock().get_mut().push(p as usize);
+    Box::leak(unsafe { Box::from_raw(p) })
+}
+
+/// Returns a `&'static T` by leaking a newly created Box of `v`.
+pub(super) fn sref<T>(v: T) -> &'static T {
+    let p = Box::into_raw(Box::new(v));
+    if (p as usize) < 16 {
+        panic!("sref bad ptr");
+    }
+    NEW_ALLOCATIONS.lock().get_mut().push(p as usize);
+    Box::leak(unsafe { Box::from_raw(p) })
+}
+
+fn bref_slice<T>(v: Box<[T]>) -> &'static [T] {
+    // An empty slice has no backing allocation. `Box<[T]>` is a fat pointer so the leaked return
+    // will contain a length of 0 and an invalid pointer.
+    if !v.is_empty() {
+        NEW_ALLOCATIONS.lock().get_mut().push(v.as_ptr() as usize);
+    }
+    Box::leak(v)
+}
+
+/// Returns a &'static [&'static T] from a `Vec<T>` by converting to a boxed slice and leaking it.
+pub(super) fn sref_vec<T>(v: Vec<T>) -> &'static [T] {
+    bref_slice(v.into_boxed_slice())
+}
+
+/// Returns a `&'static [&'static T]` by leaking a newly created box and boxed slice of `v`.
+pub(super) fn sref_slice<T>(v: T) -> &'static [&'static T] {
+    bref_slice(vec![sref(v)].into_boxed_slice())
+}

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -158,7 +158,7 @@ pub use linux::*;
 impl Kanata {
     /// Create a new configuration from a file.
     pub fn new(args: &ValidatedArgs) -> Result<Self> {
-        let cfg = cfg::Cfg::new_from_file(&args.path)?;
+        let cfg = cfg::new_from_file(&args.path)?;
 
         #[cfg(all(feature = "interception_driver", target_os = "windows"))]
         let (kbd_out_tx, kbd_out_rx) = crossbeam_channel::unbounded();
@@ -924,7 +924,7 @@ impl Kanata {
     }
 
     fn do_live_reload(&mut self) -> Result<()> {
-        let cfg = cfg::Cfg::new_from_file(&self.cfg_path)?;
+        let cfg = cfg::new_from_file(&self.cfg_path)?;
         set_altgr_behaviour(&cfg).map_err(|e| anyhow!("failed to set altgr behaviour {e})"))?;
         self.sequence_timeout = cfg
             .items

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -52,10 +52,7 @@ impl Kanata {
         let mut can_block = false;
         loop {
             let dev = match can_block {
-                true => {
-                    dbg!(can_block);
-                    intrcptn.wait()
-                }
+                true => intrcptn.wait(),
                 false => intrcptn.wait_with_timeout(std::time::Duration::from_millis(1)),
             };
             if dev > 0 {


### PR DESCRIPTION
This commit fixes the months-old known issue where live reload leaks memory. This is done by tracking "leaked" allocations and freeing them when the layout is dropped.

In the case that a configuration error is found and the layout is not created, the code will clean up those unused allocations as well.

Naturally, this makes use of unsafe. The code has been tested in valgrind with no reported memory violations or leaks.