### PR TITLE
fix: disallow multiple waiting actions

### DIFF
--- a/test_cfgs/bad_multi.kbd
+++ b/test_cfgs/bad_multi.kbd
@@ -1,0 +1,3 @@
+(defcfg)
+(defsrc 1)
+(deflayer base (multi (tap-hold 1 1 a b) (tap-dance 1 (a b c))))


### PR DESCRIPTION
This commit fixes the configuration parsing to reject multiple waiting actions to be combined in a single `multi`. (tap-dance, tap-hold-*, chord). This is done because such an action will always crash at runtime. The keyberon code cannot handle this type of action and such has an assertion to crash if encountered.

Closes #281 