### PR TITLE
Update key_override.rs

### DIFF
--- a/src/cfg/key_override.rs
+++ b/src/cfg/key_override.rs
@@ -107,9 +107,7 @@ impl Overrides {
         oscs_to_add: &mut Vec<OsCode>,
         oscs_to_remove: &mut Vec<OsCode>,
     ) {
-        let Some(ovds) = self.overrides_by_osc.get(&active_osc) else {
-            return;
-        };
+       if let Some(ovds) = self.overrides_by_osc.get(&active_osc){
         let mut cur_chord_size = 0;
         if let Some(ovd) = ovds
             .iter()
@@ -134,7 +132,8 @@ impl Overrides {
             ovd.add_override_keys(oscs_to_add);
             ovd.add_removed_keys(oscs_to_remove);
         }
-    }
+    } else { return; }
+  }         
 }
 
 /// A global key override.


### PR DESCRIPTION
I could not compile the `let_else` and replaced it with `if let else`  Your code looked cleaner, but I don't know how to install those nightly releases of rustc

```
   Compiling kanata v1.2.0-prerelease-1 (C:\path\kanata)                                          
error[E0658]: `let...else` statements are unstable                                                
   --> src\cfg\key_override.rs:110:9                                                              
    |                                                                                             
110 | /         let Some(ovds) = self.overrides_by_osc.get(&active_osc) else {                    
111 | |             return;                                                                       
112 | |         };                                                                                
    | |__________^                                                                                
    |                                                                                             
    = note: see issue #87335 <https://github.com/rust-lang/rust/issues/87335> for more information
```