### PR TITLE
feat: add configurable replay delay

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -94,6 +94,12 @@ If you need help, you are welcome to ask.
   ;; entry. If this defcfg item is not defined, the log will not print.
   ;;
   ;; windows-interception-mouse-hwid "70, 0, 90, 0, 20"
+
+  ;; dynamic-macro-delay-between-replay-actions customizes the number of ticks
+  ;; (approx 1ms) between each replay action of a dynamic macro. The default
+  ;; value is 5. This may need to be increased if some state changes, e.g. a
+  ;; layer change is not happening at the right time.
+  dynamic-macro-delay-between-replay-actions 5
 )
 
 ;; deflocalkeys-* enables you to define and use key names that match your locale

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -309,6 +309,21 @@ Example:
 )
 ----
 
+=== dynamic-macro-delay-between-replay-actions
+
+
+This option customizes the number of milliseconds between each replay action of
+a dynamic macro. The default value is 5. This may need to be increased if some
+state changes, e.g. a layer change, is not happening at the right time.
+
+Example:
+
+----
+(defcfg
+  dynamic-macro-delay-between-replay-actions 5
+)
+----
+
 === Linux only: linux-dev
 <<table-of-contents,Back to ToC>>
 
@@ -473,8 +488,11 @@ a non-applicable operating system.
   sequence-input-mode visible-backspaced
   linux-dev /dev/input/dev1:/dev/input/dev2
   linux-continue-if-no-dev-found yes
+  linux-unicode-u-code v
+  linux-unicode-termination space
   windows-altgr add-lctl-release
   windows-interception-mouse-hwid "70, 0, 60, 0"
+  dynamic-macro-delay-between-replay-actions 5
 )
 ----
 


### PR DESCRIPTION
This commit allows an option to configure dynamic macro replay delay. The reason this exists is that the default 5 ticks of delay may not be sufficient to the keyberon state machine to finish a state transition between actions, in which case the user might need to increase the delay value.

Closes #300 