### PR TITLE
feat(linux): notify systemd when kanata has finished starting up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "parking_lot",
  "radix_trie",
  "rustc-hash",
+ "sd-notify",
  "serde",
  "serde_json",
  "serial_test",
@@ -638,6 +639,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sd-notify"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621e3680f3e07db4c9c2c3fb07c6223ab2fab2e54bd3c04c3ae037990f428c32"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ signal-hook = "0.3.14"
 inotify = { version = "0.10.0", default_features = false }
 mio = { version = "0.8.4", features = ["os-poll", "os-ext"] }
 nix = { version = "0.26.1", features = ["ioctl"] }
+sd-notify = "0.4.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 encode_unicode = "0.3.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,9 @@ fn main_impl() -> Result<()> {
         Kanata::start_notification_loop(nrx, server.connections);
     }
 
+    #[cfg(target_os = "linux")]
+    sd_notify::notify(true, &[sd_notify::NotifyState::Ready])?;
+
     Kanata::event_loop(kanata_arc, tx)?;
 
     Ok(())


### PR DESCRIPTION
To use this feature, set Type=notify in the systemd service.

An example use case: a tcp client connects to kanata when it receives a notification using dbus which says kanata becomes active. Without this patch, the client will fail to do so because kanata only starts to listen to clients about 2s after it is started.