### PR TITLE
doc: remove an advantage of kmonad

### DIFF
--- a/docs/kmonad_comparison.md
+++ b/docs/kmonad_comparison.md
@@ -6,7 +6,6 @@ The kmonad project is the closest alternative for this project.
 
 - MacOS support
 - Different features
-- Has a NixOS module
 
 ## Why I built and use kanata
 


### PR DESCRIPTION
kanata also has a NixOS module. It's even in the nixpkgs[1], which I would say is an advantage over kmonad.

[1]: https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/hardware/kanata.nix