### PR TITLE
feat: add `-timeout` variants of tap-hold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,9 +283,7 @@ dependencies = [
 
 [[package]]
 name = "kanata-keyberon"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960d066dca7a9121f331cd488f7e73fb4d63ebcd648678ed8089f1ee66999c75"
+version = "0.9.0"
 dependencies = [
  "arraydeque",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = { version = "1", features = ["alloc"], default_features = false }
 radix_trie = "0.2"
 rustc-hash = "1.1.0"
 
-kanata-keyberon = "0.8.0"
+kanata-keyberon = "0.9.0"
 # Uncomment below and comment out above for testing local keyberon changes
 # kanata-keyberon = { path = "keyberon" }
 

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -2,6 +2,11 @@
 This is a sample configuration file that showcases every feature in kanata.
 If anything is confusing or hard to discover, please file an issue or
 contribute a pull request to help improve the document.
+
+This sample file has documentation but it is lower effort than the configuration
+guide. The configuration guide can be found at:
+
+https://github.com/jtroo/kanata/blob/main/docs/config.adoc
 |#
 
 ;; Single-line comments are prefixed by double-semicolon. A single semicolon
@@ -244,6 +249,15 @@ If you need help, you are welcome to ask.
   grl (tap-hold 200 200 grv @lay) ;; tap: grave  hold: layers layer
   .ms (tap-hold 200 200 . @mse)   ;; tap: .      hold: mouse layer
   ifk (tap-hold 200 200 i @fks)   ;; tap: i      hold: fake keys layer
+
+  ;; There are additional variants of tap-hold-press and tap-hold-release that
+  ;; activate the timeout action (the 5th parameter) when the action times out
+  ;; as opposed to the hold action being activated by other keys.
+
+  ;; tap: o    hold: arrows layer    timeout: backspace
+  oat (tap-hold-press-timeout   200 200 o @arr bspc)
+  ;; tap: e    hold: chords layer    timeout: esc
+  ect (tap-hold-release-timeout 200 200 e @chr esc)
 
   ;; tap for capslk, hold for lctl
   cap (tap-hold 200 200 caps lctl)

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1021,11 +1021,34 @@ even if the hold timeout hasn't expired yet
 These variants may be useful if you want more responsive tap-hold keys,
 but you should be wary of activating the hold action unintentionally.
 
+Example:
+
 ----
 (defalias
   anm (tap-hold         200 200 a @num) ;; tap: a      hold: numbers layer
   oar (tap-hold-press   200 200 o @arr) ;; tap: o      hold: arrows layer
   ech (tap-hold-release 200 200 e @chr) ;; tap: e      hold: chords layer
+)
+----
+
+There are further additional variants of `tap-hold-press` and `tap-hold-release`:
+
+. `tap-hold-press-timeout`
+. `tap-hold-release-timeout`
+
+These variants take a 5th parameter, in addition to the same 4 as the other
+variants. The 5th parameter is another action, which will activate if the hold
+timeout expires as opposed to being triggered by other key actions, whereas the
+non `-timeout` variants will activate the hold action in both cases.
+
+Example:
+
+----
+(defalias
+  ;; tap: o    hold: arrows layer    timeout: backspace
+  oat (tap-hold-press-timeout   200 200 o @arr bspc)
+  ;; tap: e    hold: chords layer    timeout: esc
+  ect (tap-hold-release-timeout 200 200 e @chr esc)
 )
 ----
 

--- a/keyberon/Cargo.toml
+++ b/keyberon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanata-keyberon"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>", "Robin Krahl <robin.krahl@ireas.org>", "jtroo <j.andreitabs@gmail.com>"]
 edition = "2018"
 description = "Pure Rust keyboard firmware. Fork intended for use with kanata."

--- a/keyberon/src/action.rs
+++ b/keyberon/src/action.rs
@@ -161,6 +161,8 @@ where
     pub hold: Action<'a, T>,
     /// The tap action.
     pub tap: Action<'a, T>,
+    /// The timeout action
+    pub timeout_action: Action<'a, T>,
     /// Behavior configuration.
     pub config: HoldTapConfig,
     /// Configuration of the tap and hold holds the tap action.


### PR DESCRIPTION
This commit adds the `tap-hold-press-timeout` and
`tap-hold-release-timeout` actions, which add a third timeout action that activates instead of tho hold action if the timeout expires as opposed to the hold action being activated by other keys.

Closes #314 