### PR TITLE
fix: release lock before sleeping

### DIFF
--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1257,6 +1257,7 @@ impl Kanata {
                                 (start.elapsed()).as_nanos()
                             );
 
+                            drop(k);
                             std::thread::sleep(time::Duration::from_millis(1));
                         }
                         Err(TryRecvError::Disconnected) => {


### PR DESCRIPTION
Otherwise the lock is held almost continously while any kind of keyberon timer is active. That (at least on Linux) prevents events which bypass kanata (such as mouse movement) from being forwarded in a timly manner (resulting in delayed and low-frequency mouse movement) because the event loop thread will be unable to acquire the lock it needs to output events.

How bad the effect is may depend on OS / kernel version / lock implementation. I've been running the same version of Kanata for a while but the issue has only recently (potentially related to OS updates) been noticeable for me (I put it up to other things in the beginning, so I don't remember exactly when it started happening), though now it is **very** noticeable.