### PR TITLE
refactor: reduce size of KanataAction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,9 +283,7 @@ dependencies = [
 
 [[package]]
 name = "kanata-keyberon"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34dab255d867c493d64d8278c6dd0b59b1c2de9938f75177ca8ace248ca579d"
+version = "0.10.0"
 dependencies = [
  "arraydeque",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ serde_json = { version = "1", features = ["alloc"], default_features = false }
 radix_trie = "0.2"
 rustc-hash = "1.1.0"
 
-kanata-keyberon = "0.9.0"
+# kanata-keyberon = "0.10.0"
 # Uncomment below and comment out above for testing local keyberon changes
-# kanata-keyberon = { path = "keyberon" }
+kanata-keyberon = { path = "keyberon" }
 
 [dev-dependencies]
 serial_test = { version = "1", default_features = false }

--- a/keyberon/Cargo.toml
+++ b/keyberon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanata-keyberon"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>", "Robin Krahl <robin.krahl@ireas.org>", "jtroo <j.andreitabs@gmail.com>"]
 edition = "2018"
 description = "Pure Rust keyboard firmware. Fork intended for use with kanata."

--- a/keyberon/src/action.rs
+++ b/keyberon/src/action.rs
@@ -311,9 +311,9 @@ where
     /// Multiple key codes sent at the same time, as if these keys
     /// were pressed at the same time. Useful to send a shifted key,
     /// or complex shortcuts like Ctrl+Alt+Del in a single key press.
-    MultipleKeyCodes(&'a [KeyCode]),
+    MultipleKeyCodes(&'a &'a [KeyCode]),
     /// Multiple actions sent at the same time.
-    MultipleActions(&'a [Action<'a, T>]),
+    MultipleActions(&'a &'a [Action<'a, T>]),
     /// While pressed, change the current layer. That's the classic
     /// Fn key. If several layer actions are hold at the same time,
     /// the last pressed defines the current layer.
@@ -324,7 +324,7 @@ where
     /// A sequence of SequenceEvents
     Sequence {
         /// An array of SequenceEvents that will be triggered (in order)
-        events: &'a [SequenceEvent<'a, T>],
+        events: &'a &'a [SequenceEvent<'a, T>],
     },
     /// Cancels any running sequences
     CancelSequences,
@@ -403,10 +403,4 @@ pub const fn l<T>(layer: usize) -> Action<'static, T> {
 /// layout.
 pub const fn d<T>(layer: usize) -> Action<'static, T> {
     Action::DefaultLayer(layer)
-}
-
-/// A shortcut to create a `Action::MultipleKeyCodes`, useful to
-/// create compact layout.
-pub const fn m<T>(kcs: &[KeyCode]) -> Action<T> {
-    Action::MultipleKeyCodes(kcs)
 }

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -1051,7 +1051,7 @@ impl<'a, const C: usize, const R: usize, const L: usize, T: 'a + Copy + std::fmt
             }
             &MultipleKeyCodes(v) => {
                 self.last_press_tracker.coord = coord;
-                for &keycode in v {
+                for &keycode in *v {
                     let _ = self.states.push(NormalKey { coord, keycode });
                 }
                 if !is_oneshot {
@@ -1061,7 +1061,7 @@ impl<'a, const C: usize, const R: usize, const L: usize, T: 'a + Copy + std::fmt
             &MultipleActions(v) => {
                 self.last_press_tracker.coord = coord;
                 let mut custom = CustomEvent::NoEvent;
-                for action in v {
+                for action in *v {
                     custom.update(self.do_action(action, coord, delay, is_oneshot));
                 }
                 return custom;
@@ -1127,7 +1127,7 @@ mod test {
     use super::{Event::*, Layout, *};
     use crate::action::Action::*;
     use crate::action::HoldTapConfig;
-    use crate::action::{k, l, m};
+    use crate::action::{k, l};
     use crate::key_code::KeyCode;
     use crate::key_code::KeyCode::*;
     use std::collections::BTreeSet;
@@ -1160,7 +1160,7 @@ mod test {
                     tap_hold_interval: 0,
                 }),
             ]],
-            [[Trans, m([LCtrl, Enter].as_slice())]],
+            [[Trans, MultipleKeyCodes(&[LCtrl, Enter].as_slice())]],
         ];
         let mut layout = Layout::new(&LAYERS);
         assert_eq!(CustomEvent::NoEvent, layout.tick());
@@ -1212,7 +1212,7 @@ mod test {
                     tap_hold_interval: 0,
                 }),
             ]],
-            [[Trans, m([LCtrl, Enter].as_slice())]],
+            [[Trans, MultipleKeyCodes(&[LCtrl, Enter].as_slice())]],
         ];
         let mut layout = Layout::new(&LAYERS);
         assert_eq!(CustomEvent::NoEvent, layout.tick());
@@ -2497,11 +2497,13 @@ mod test {
     fn release_state() {
         static LAYERS: Layers<2, 1, 2> = [
             [[
-                MultipleActions(&[KeyCode(LCtrl), Layer(1)]),
-                MultipleActions(&[KeyCode(LAlt), Layer(1)]),
+                MultipleActions(&(&[KeyCode(LCtrl), Layer(1)] as _)),
+                MultipleActions(&(&[KeyCode(LAlt), Layer(1)] as _)),
             ]],
             [[
-                MultipleActions(&[ReleaseState(ReleasableState::KeyCode(LAlt)), KeyCode(Space)]),
+                MultipleActions(
+                    &(&[ReleaseState(ReleasableState::KeyCode(LAlt)), KeyCode(Space)] as _),
+                ),
                 ReleaseState(ReleasableState::Layer(1)),
             ]],
         ];

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -64,10 +64,11 @@ use sexpr::SExpr;
 
 use self::sexpr::Spanned;
 
-pub type KanataAction = Action<'static, &'static [&'static CustomAction]>;
-type KLayout = Layout<'static, KEYS_IN_ROW, 2, ACTUAL_NUM_LAYERS, &'static [&'static CustomAction]>;
+pub type KanataAction = Action<'static, &'static &'static [&'static CustomAction]>;
+type KLayout =
+    Layout<'static, KEYS_IN_ROW, 2, ACTUAL_NUM_LAYERS, &'static &'static [&'static CustomAction]>;
 pub type BorrowedKLayout<'a> =
-    Layout<'a, KEYS_IN_ROW, 2, ACTUAL_NUM_LAYERS, &'a [&'a CustomAction]>;
+    Layout<'a, KEYS_IN_ROW, 2, ACTUAL_NUM_LAYERS, &'a &'a [&'a CustomAction]>;
 pub type KeySeqsToFKeys = Trie<Vec<u16>, (u8, u16)>;
 
 pub struct KanataLayout {
@@ -788,83 +789,83 @@ fn parse_action_atom(ac: &Spanned<String>, s: &ParsedState) -> Result<&'static K
         "_" => return Ok(s.a.sref(Action::Trans)),
         "XX" => return Ok(s.a.sref(Action::NoOp)),
         "lrld" => {
-            return Ok(s
-                .a
-                .sref(Action::Custom(s.a.sref_slice(CustomAction::LiveReload))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref(s.a.sref_slice(CustomAction::LiveReload)),
+            )))
         }
         "lrld-next" | "lrnx" => {
-            return Ok(s
-                .a
-                .sref(Action::Custom(s.a.sref_slice(CustomAction::LiveReloadNext))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref(s.a.sref_slice(CustomAction::LiveReloadNext)),
+            )))
         }
         "lrld-prev" | "lrpv" => {
-            return Ok(s
-                .a
-                .sref(Action::Custom(s.a.sref_slice(CustomAction::LiveReloadPrev))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref(s.a.sref_slice(CustomAction::LiveReloadPrev)),
+            )))
         }
         "sldr" => {
-            return Ok(s
-                .a
-                .sref(Action::Custom(s.a.sref_slice(CustomAction::SequenceLeader))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref(s.a.sref_slice(CustomAction::SequenceLeader)),
+            )))
         }
         "mlft" | "mouseleft" => {
             return Ok(s.a.sref(Action::Custom(
-                s.a.sref_slice(CustomAction::Mouse(Btn::Left)),
+                s.a.sref(s.a.sref_slice(CustomAction::Mouse(Btn::Left))),
             )))
         }
         "mrgt" | "mouseright" => {
             return Ok(s.a.sref(Action::Custom(
-                s.a.sref_slice(CustomAction::Mouse(Btn::Right)),
+                s.a.sref(s.a.sref_slice(CustomAction::Mouse(Btn::Right))),
             )))
         }
         "mmid" | "mousemid" => {
             return Ok(s.a.sref(Action::Custom(
-                s.a.sref_slice(CustomAction::Mouse(Btn::Mid)),
+                s.a.sref(s.a.sref_slice(CustomAction::Mouse(Btn::Mid))),
             )))
         }
         "mfwd" | "mouseforward" => {
             return Ok(s.a.sref(Action::Custom(
-                s.a.sref_slice(CustomAction::Mouse(Btn::Forward)),
+                s.a.sref(s.a.sref_slice(CustomAction::Mouse(Btn::Forward))),
             )))
         }
         "mbck" | "mousebackward" => {
             return Ok(s.a.sref(Action::Custom(
-                s.a.sref_slice(CustomAction::Mouse(Btn::Backward)),
+                s.a.sref(s.a.sref_slice(CustomAction::Mouse(Btn::Backward))),
             )))
         }
         "mltp" | "mousetapleft" => {
             return Ok(s.a.sref(Action::Custom(
-                s.a.sref_slice(CustomAction::MouseTap(Btn::Left)),
+                s.a.sref(s.a.sref_slice(CustomAction::MouseTap(Btn::Left))),
             )))
         }
         "mrtp" | "mousetapright" => {
             return Ok(s.a.sref(Action::Custom(
-                s.a.sref_slice(CustomAction::MouseTap(Btn::Right)),
+                s.a.sref(s.a.sref_slice(CustomAction::MouseTap(Btn::Right))),
             )))
         }
         "mmtp" | "mousetapmid" => {
             return Ok(s.a.sref(Action::Custom(
-                s.a.sref_slice(CustomAction::MouseTap(Btn::Mid)),
+                s.a.sref(s.a.sref_slice(CustomAction::MouseTap(Btn::Mid))),
             )))
         }
         "mftp" | "mousetapforward" => {
             return Ok(s.a.sref(Action::Custom(
-                s.a.sref_slice(CustomAction::MouseTap(Btn::Forward)),
+                s.a.sref(s.a.sref_slice(CustomAction::MouseTap(Btn::Forward))),
             )))
         }
         "mbtp" | "mousetapbackward" => {
             return Ok(s.a.sref(Action::Custom(
-                s.a.sref_slice(CustomAction::MouseTap(Btn::Backward)),
+                s.a.sref(s.a.sref_slice(CustomAction::MouseTap(Btn::Backward))),
             )))
         }
         "rpt" | "repeat" => {
-            return Ok(s
-                .a
-                .sref(Action::Custom(s.a.sref_slice(CustomAction::Repeat))))
+            return Ok(s.a.sref(Action::Custom(
+                s.a.sref(s.a.sref_slice(CustomAction::Repeat)),
+            )))
         }
         "dynamic-macro-record-stop" => {
             return Ok(s.a.sref(Action::Custom(
-                s.a.sref_slice(CustomAction::DynamicMacroRecordStop),
+                s.a.sref(s.a.sref_slice(CustomAction::DynamicMacroRecordStop)),
             )))
         }
         _ => {}
@@ -889,7 +890,7 @@ fn parse_action_atom(ac: &Spanned<String>, s: &ParsedState) -> Result<&'static K
             .ok_or_else(|| anyhow!("Could not parse: {ac:?}"))?
             .into(),
     );
-    Ok(s.a.sref(Action::MultipleKeyCodes(s.a.sref_vec(keys))))
+    Ok(s.a.sref(Action::MultipleKeyCodes(s.a.sref(s.a.sref_vec(keys)))))
 }
 
 /// Parse a `kanata_keyberon::action::Action` from a `SExpr::List`.
@@ -1083,7 +1084,7 @@ fn parse_multi(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAc
     }
 
     if !custom_actions.is_empty() {
-        actions.push(Action::Custom(s.a.sref_vec(custom_actions)));
+        actions.push(Action::Custom(s.a.sref(s.a.sref_vec(custom_actions))));
     }
 
     if actions
@@ -1104,7 +1105,7 @@ fn parse_multi(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAc
         bail!("cannot combine multiple tap-hold/tap-dance/chord: {ac_params:?}");
     }
 
-    Ok(s.a.sref(Action::MultipleActions(s.a.sref_vec(actions))))
+    Ok(s.a.sref(Action::MultipleActions(s.a.sref(s.a.sref_vec(actions)))))
 }
 
 #[test]
@@ -1139,7 +1140,7 @@ fn recursive_multi_is_flattened() {
         assert_eq!(
             parsed_multi[3],
             Action::Custom(
-                &[
+                &&[
                     &CustomAction::MouseTap(Btn::Mid),
                     &CustomAction::MouseTap(Btn::Left),
                     &CustomAction::MouseTap(Btn::Right),
@@ -1167,7 +1168,7 @@ fn parse_macro(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAc
     }
     all_events.shrink_to_fit();
     Ok(s.a.sref(Action::Sequence {
-        events: s.a.sref_vec(all_events),
+        events: s.a.sref(s.a.sref(s.a.sref_vec(all_events))),
     }))
 }
 
@@ -1176,10 +1177,10 @@ fn parse_macro_release_cancel(
     s: &ParsedState,
 ) -> Result<&'static KanataAction> {
     let macro_action = parse_macro(ac_params, s)?;
-    Ok(s.a.sref(Action::MultipleActions(s.a.sref_vec(vec![
+    Ok(s.a.sref(Action::MultipleActions(s.a.sref(s.a.sref_vec(vec![
         *macro_action,
-        Action::Custom(s.a.sref_slice(CustomAction::CancelMacroOnRelease)),
-    ]))))
+        Action::Custom(s.a.sref(s.a.sref_slice(CustomAction::CancelMacroOnRelease))),
+    ])))))
 }
 
 #[allow(clippy::type_complexity)] // return type is not pub
@@ -1187,7 +1188,7 @@ fn parse_macro_item<'a>(
     acs: &'a [SExpr],
     s: &ParsedState,
 ) -> Result<(
-    Vec<SequenceEvent<'static, &'static [&'static CustomAction]>>,
+    Vec<SequenceEvent<'static, &'static &'static [&'static CustomAction]>>,
     &'a [SExpr],
 )> {
     if let Ok(duration) = parse_timeout(&acs[0]) {
@@ -1323,9 +1324,9 @@ fn parse_unicode(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static Kanata
             if a.t.chars().count() != 1 {
                 bail!(ERR_STR)
             }
-            Ok(s.a.sref(Action::Custom(
+            Ok(s.a.sref(Action::Custom(s.a.sref(
                 s.a.sref_slice(CustomAction::Unicode(a.t.chars().next().unwrap())),
-            )))
+            ))))
         }
         _ => bail!(ERR_STR),
     }
@@ -1356,10 +1357,11 @@ fn parse_cmd(
             bail!("{}, found a list", ERR_STR);
         }
     })?;
-    Ok(s.a.sref(Action::Custom(s.a.sref_slice(match cmd_type {
-        CmdType::Standard => CustomAction::Cmd(cmd),
-        CmdType::OutputKeys => CustomAction::CmdOutputKeys(cmd),
-    }))))
+    Ok(s.a
+        .sref(Action::Custom(s.a.sref(s.a.sref_slice(match cmd_type {
+            CmdType::Standard => CustomAction::Cmd(cmd),
+            CmdType::OutputKeys => CustomAction::CmdOutputKeys(cmd),
+        })))))
 }
 
 fn parse_one_shot(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
@@ -1662,7 +1664,7 @@ fn find_chords_coords(chord_groups: &mut [ChordGroup], coord: (u8, u16), action:
 }
 
 fn fill_chords(
-    chord_groups: &[&'static ChordsGroup<&[&CustomAction]>],
+    chord_groups: &[&'static ChordsGroup<&&[&CustomAction]>],
     action: &KanataAction,
     s: &ParsedState,
 ) -> Option<KanataAction> {
@@ -1713,10 +1715,10 @@ fn fill_chords(
             if new_actions.iter().any(|it| it.is_some()) {
                 let new_actions = new_actions
                     .iter()
-                    .zip(*actions)
+                    .zip(**actions)
                     .map(|(new_ac, ac)| new_ac.unwrap_or(*ac))
                     .collect::<Vec<_>>();
-                Some(Action::MultipleActions(s.a.sref_vec(new_actions)))
+                Some(Action::MultipleActions(s.a.sref(s.a.sref_vec(new_actions))))
             } else {
                 None
             }
@@ -1779,7 +1781,7 @@ fn parse_fake_keys(exprs: &[&Vec<SExpr>], s: &mut ParsedState) -> Result<()> {
 fn parse_fake_key_op(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
     let (coord, action) = parse_fake_key_op_coord_action(ac_params, s)?;
     Ok(s.a.sref(Action::Custom(
-        s.a.sref_slice(CustomAction::FakeKey { coord, action }),
+        s.a.sref(s.a.sref_slice(CustomAction::FakeKey { coord, action })),
     )))
 }
 
@@ -1788,9 +1790,9 @@ fn parse_on_release_fake_key_op(
     s: &ParsedState,
 ) -> Result<&'static KanataAction> {
     let (coord, action) = parse_fake_key_op_coord_action(ac_params, s)?;
-    Ok(s.a.sref(Action::Custom(
+    Ok(s.a.sref(Action::Custom(s.a.sref(
         s.a.sref_slice(CustomAction::FakeKeyOnRelease { coord, action }),
-    )))
+    ))))
 }
 
 fn parse_fake_key_op_coord_action(
@@ -1854,10 +1856,11 @@ fn parse_delay(
         .map(str::parse::<u16>)
         .ok_or_else(|| anyhow!("{ERR_MSG}"))?
         .map_err(|e| anyhow!("{ERR_MSG}: {e}"))?;
-    Ok(s.a.sref(Action::Custom(s.a.sref_slice(match is_release {
-        false => CustomAction::Delay(delay),
-        true => CustomAction::DelayOnRelease(delay),
-    }))))
+    Ok(s.a
+        .sref(Action::Custom(s.a.sref(s.a.sref_slice(match is_release {
+            false => CustomAction::Delay(delay),
+            true => CustomAction::DelayOnRelease(delay),
+        })))))
 }
 
 fn parse_mwheel(
@@ -1885,12 +1888,13 @@ fn parse_mwheel(
             _ => None,
         })
         .ok_or_else(|| anyhow!("{ERR_MSG}: distance should be 1-30000"))?;
-    Ok(s.a
-        .sref(Action::Custom(s.a.sref_slice(CustomAction::MWheel {
+    Ok(s.a.sref(Action::Custom(s.a.sref(s.a.sref_slice(
+        CustomAction::MWheel {
             direction,
             interval,
             distance,
-        }))))
+        },
+    )))))
 }
 
 fn parse_move_mouse(
@@ -1918,12 +1922,13 @@ fn parse_move_mouse(
             _ => None,
         })
         .ok_or_else(|| anyhow!("{ERR_MSG}: distance should be 1-30000"))?;
-    Ok(s.a
-        .sref(Action::Custom(s.a.sref_slice(CustomAction::MoveMouse {
+    Ok(s.a.sref(Action::Custom(s.a.sref(s.a.sref_slice(
+        CustomAction::MoveMouse {
             direction,
             interval,
             distance,
-        }))))
+        },
+    )))))
 }
 
 fn parse_move_mouse_accel(
@@ -1969,7 +1974,7 @@ fn parse_move_mouse_accel(
             "{ERR_MSG}: min_distance should be less than max_distance"
         ));
     }
-    Ok(s.a.sref(Action::Custom(s.a.sref_slice(
+    Ok(s.a.sref(Action::Custom(s.a.sref(s.a.sref_slice(
         CustomAction::MoveMouseAccel {
             direction,
             interval,
@@ -1977,7 +1982,7 @@ fn parse_move_mouse_accel(
             min_distance,
             max_distance,
         },
-    ))))
+    )))))
 }
 
 fn parse_dynamic_macro_record(
@@ -1994,7 +1999,7 @@ fn parse_dynamic_macro_record(
         .ok_or_else(|| anyhow!("{ERR_MSG}: macro ID should be 1-65535"))?
         .map_err(|e| anyhow!("{ERR_MSG}: {e}"))?;
     return Ok(s.a.sref(Action::Custom(
-        s.a.sref_slice(CustomAction::DynamicMacroRecord(key)),
+        s.a.sref(s.a.sref_slice(CustomAction::DynamicMacroRecord(key))),
     )));
 }
 
@@ -2009,7 +2014,7 @@ fn parse_dynamic_macro_play(ac_params: &[SExpr], s: &ParsedState) -> Result<&'st
         .ok_or_else(|| anyhow!("{ERR_MSG}: macro ID should be 1-65535"))?
         .map_err(|e| anyhow!("{ERR_MSG}: {e}"))?;
     return Ok(s.a.sref(Action::Custom(
-        s.a.sref_slice(CustomAction::DynamicMacroPlay(key)),
+        s.a.sref(s.a.sref_slice(CustomAction::DynamicMacroPlay(key))),
     )));
 }
 
@@ -2115,7 +2120,7 @@ fn parse_arbitrary_code(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static
         })
         .ok_or_else(|| anyhow!("{ERR_MSG}: got {:?}", ac_params[0]))?;
     Ok(s.a.sref(Action::Custom(
-        s.a.sref_slice(CustomAction::SendArbitraryCode(code)),
+        s.a.sref(s.a.sref_slice(CustomAction::SendArbitraryCode(code))),
     )))
 }
 

--- a/src/kanata/windows/mod.rs
+++ b/src/kanata/windows/mod.rs
@@ -46,7 +46,7 @@ pub fn set_win_altgr_behaviour(cfg: &cfg::Cfg) -> Result<()> {
     Ok(())
 }
 
-fn state_filter(v: &State<'_, &[&CustomAction]>) -> Option<State<'static, ()>> {
+fn state_filter(v: &State<'_, &&[&CustomAction]>) -> Option<State<'static, ()>> {
     match v {
         State::NormalKey { keycode, coord } => Some(State::NormalKey::<()> {
             keycode: *keycode,

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -15,11 +15,11 @@ pub type KanataLayers = Layers<
     KEYS_IN_ROW,
     LAYER_COLUMNS,
     ACTUAL_NUM_LAYERS,
-    &'static [&'static CustomAction],
+    &'static &'static [&'static CustomAction],
 >;
 
-type Row =
-    [kanata_keyberon::action::Action<'static, &'static [&'static CustomAction]>; KEYS_IN_ROW];
+type Row = [kanata_keyberon::action::Action<'static, &'static &'static [&'static CustomAction]>;
+    KEYS_IN_ROW];
 
 pub fn new_layers() -> Box<KanataLayers> {
     let boxed_slice: Box<[[Row; LAYER_COLUMNS]]> = {


### PR DESCRIPTION
This commit adds an extra layer of indirection on all slices — which means they are regular pointers instead of fat pointers — to be able to reduce the size of KanataAction to 2 pointers instead of 3 pointers.

This has a performance penalty of an additional indirection for dereferencing slice actions. It also makes the code for creating actions even uglier than it already is. However, it has the performance gain of improving cache locality and reducing total memory footprint by 1/3. Overall it is not clear whether this is a win.