### PR TITLE
refactor: comments, pub

### DIFF
--- a/src/kanata/linux.rs
+++ b/src/kanata/linux.rs
@@ -26,11 +26,11 @@ impl Kanata {
             let events = kbd_in.read().map_err(|e| anyhow!("failed read: {}", e))?;
             log::trace!("{events:?}");
 
-            // Pass-through non-key events
             for in_event in events.into_iter() {
                 let key_event = match KeyEvent::try_from(in_event) {
                     Ok(ev) => ev,
                     _ => {
+                        // Pass-through non-key events
                         let mut kanata = kanata.lock();
                         kanata
                             .kbd_out
@@ -40,9 +40,10 @@ impl Kanata {
                     }
                 };
 
+                check_for_exit(&key_event);
+
                 // Check if this keycode is mapped in the configuration. If it hasn't been mapped, send
                 // it immediately.
-                check_for_exit(&key_event);
                 if !MAPPED_KEYS.lock().contains(&key_event.code) {
                     let mut kanata = kanata.lock();
                     kanata

--- a/src/kanata/windows/llhook.rs
+++ b/src/kanata/windows/llhook.rs
@@ -37,7 +37,6 @@ impl Kanata {
             };
 
             check_for_exit(&key_event);
-            // unwrap is safe because the KeyEvent conversion above would've returned false otherwise
             let oscode = OsCode::from(input_event.code);
             if !MAPPED_KEYS.lock().contains(&oscode) {
                 return false;

--- a/src/oskbd/windows/interception.rs
+++ b/src/oskbd/windows/interception.rs
@@ -73,7 +73,7 @@ impl InputEvent {
 }
 
 thread_local! {
-    pub static INTRCPTN: Interception = Interception::new().expect("interception driver should init: have you completed the interception driver installation?");
+    static INTRCPTN: Interception = Interception::new().expect("interception driver should init: have you completed the interception driver installation?");
 }
 
 /// Handle for writing keys to the OS.


### PR DESCRIPTION
Move some comments to be next to the appropriate code, delete a comment that no longer made sense. Remove an unnecessary pub variable.