### PR TITLE
feat: improve handling of long unmapped chord

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,8 +367,6 @@ dependencies = [
 [[package]]
 name = "kanata-keyberon"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de7ec55301163998777ef6f9976511e960d20e7c9215bca2c45eb12f179ab069"
 dependencies = [
  "arraydeque",
  "heapless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ rustc-hash = "1.1.0"
 miette = { version = "5.5.0", features = ["fancy"] }
 thiserror = "1.0.38"
 
-kanata-keyberon = "0.12.0"
+# kanata-keyberon = "0.12.0"
 # Uncomment below and comment out above for testing local keyberon changes
-# kanata-keyberon = { path = "keyberon" }
+kanata-keyberon = { path = "keyberon" }
 
 [dev-dependencies]
 serial_test = { version = "1", default_features = false }


### PR DESCRIPTION
This commit implements code to decompose a longer chord that doesn't have an action mapped into sub-chords that can potentially have actions and activate those actions if they exist.

This requires additional storage in keyberon to keep an action buffer since multiple actions, each with its own CustomEvent, may be activated by a chord decomposition all at once. Without the action buffer, all CustomEvents except the last would be consumed and certain kanata actions wouldn't activate as part of a chord decomposition (actions in the CustomAction enum).