### PR TITLE
feat: tap-hold-release-keys

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -262,6 +262,12 @@ If you need help, you are welcome to ask.
   ;; tap: e    hold: chords layer    timeout: esc
   ect (tap-hold-release-timeout 200 200 e @chr esc)
 
+  ;; There is another variant of `tap-hold-release` that takes a 5th parameter
+  ;; that is a list of keys that will trigger an early tap.
+
+  ;; tap: u    hold: misc layer      early tap if any of: (a o e) are pressed
+  umk (tap-hold-release-keys 200 200 u @msc (a o e))
+
   ;; tap for capslk, hold for lctl
   cap (tap-hold 200 200 caps lctl)
 

--- a/cfg_samples/minimal.kbd
+++ b/cfg_samples/minimal.kbd
@@ -26,21 +26,6 @@ configuration entries.
   process-unmapped-keys yes
 )
 
-
-#|
-The defsrc entry below chooses which keys are remappable by kanata. The
-deflayer entries that follow change the behaviour of the corresponding keys in
-the order that they appear in defsrc. Note that any extra spaces or newlines
-are ignored — defsrc and deflayer are treated as lists of keys/actions that are
-separated by 1 or more whitespace characters.
-
-The reason for mapping the Shift keys is so that they get processed correctly
-by kanata for tap-hold keys.  However, you can add
-the line below to defcfg above to tell kanata to process all keys:
-
-  process-unmapped-keys yes
-|#
-
 (defsrc
   caps grv         i
               j    k    l

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1090,6 +1090,12 @@ variants. The 5th parameter is another action, which will activate if the hold
 timeout expires as opposed to being triggered by other key actions, whereas the
 non `-timeout` variants will activate the hold action in both cases.
 
+- `tap-hold-release-keys`
+
+This variant takes a 5th parameter which is a list of keys that trigger an
+early tap when they are pressed while the `tap-hold-release-keys` action is
+waiting.
+
 Example:
 
 ----
@@ -1098,6 +1104,8 @@ Example:
   oat (tap-hold-press-timeout   200 200 o @arr bspc)
   ;; tap: e    hold: chords layer    timeout: esc
   ect (tap-hold-release-timeout 200 200 e @chr esc)
+  ;; tap: u    hold: misc layer      early tap if any of: (a o e) are pressed
+  umk (tap-hold-release-keys 200 200 u @msc (a o e))
 )
 ----
 

--- a/src/cfg/custom_tap_hold.rs
+++ b/src/cfg/custom_tap_hold.rs
@@ -1,0 +1,32 @@
+use kanata_keyberon::layout::{Event, QueuedIter, WaitingAction};
+
+use crate::keys::OsCode;
+
+use super::alloc::Allocations;
+
+/// Returns a closure that can be used in `HoldTapConfig::Custom`, which will return early with a
+/// Tap action in the case that any of `keys` are pressed. Otherwise it behaves as
+/// `HoldTapConfig::PermissiveHold` would.
+pub(crate) fn custom_tap_hold_release(
+    keys: &[OsCode],
+    a: &Allocations,
+) -> &'static (dyn Fn(QueuedIter) -> Option<WaitingAction> + Send + Sync) {
+    let keys = a.sref_vec(Vec::from_iter(keys.iter().copied()));
+    a.sref(move |mut queued: QueuedIter| -> Option<WaitingAction> {
+        while let Some(q) = queued.next() {
+            if q.event().is_press() {
+                let (i, j) = q.event().coord();
+                // If any key matches the input, do a tap right away.
+                if keys.iter().copied().map(u16::from).any(|j2| j2 == j) {
+                    return Some(WaitingAction::Tap);
+                }
+                // Otherwise do the PermissiveHold algorithm.
+                let target = Event::Release(i, j);
+                if queued.clone().copied().any(|q| q.event() == target) {
+                    return Some(WaitingAction::Hold);
+                }
+            }
+        }
+        None
+    })
+}


### PR DESCRIPTION
This commit adds another tap-hold variant that makes use of keyberon's `HoldTapConfig::Custom` variant for the tap hold configuration. The custom variant is used to activate an early tap when any key in the given list is pressed. The goal of this variant is to reduce rolling errors on the same hand when using home-row tap-hold keys.

An unrelated fly-by fix to the minimal.kbd configuration file is added. There was some unintended leftover text that is now deleted.