### PR TITLE
doc: adjust build/install instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ miette = { version = "5.5.0", features = ["fancy"] }
 thiserror = "1.0.38"
 
 kanata-keyberon = "0.13.0"
-# Uncomment below and comment out above for testing local keyberon changes
+# Uncomment below and comment out above for testing local keyberon changes.
+# Otherwise any changes to the local files will not reflect in the compiled
+# binary.
 # kanata-keyberon = { path = "keyberon" }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -47,9 +47,18 @@ to suit your exact needs and workflows.
 
 ## Usage
 
+Running kanata currently does not start it in a background process.
+You will need to keep the window that starts kanata running to keep kanata active.
+Some tips for running kanata in the background:
+
+- Windows: https://github.com/jtroo/kanata/discussions/193
+- Linux: https://github.com/jtroo/kanata/discussions/130
+
 ### Pre-built executables
 
-See the [releases page](https://github.com/jtroo/kanata/releases) for executables.
+See the
+[releases page](https://github.com/jtroo/kanata/releases)
+for executables and instructions.
 
 ### Build it yourself
 
@@ -58,12 +67,8 @@ Rust toolchain using `rustup`, e.g. by using the instructions from the
 [official website](https://www.rust-lang.org/learn/get-started),
 you can get the latest stable toolchain with `rustup update stable`.
 
-Running kanata currently does not start it in a background process. You will
-need to keep the window it is running in open to keep it running. Some tips for
-running kanata in the background:
-
-- Windows: https://github.com/jtroo/kanata/discussions/193
-- Linux: https://github.com/jtroo/kanata/discussions/130
+<details>
+<summary>Instructions</summary>
 
 Using `cargo install`:
 
@@ -99,11 +104,52 @@ release assets also have a `kanata.kbd` file that is tested to work with that
 release. All key names can be found in the [keys module](./src/keys/mod.rs),
 and you can also define your own key names.
 
+</details>
+
+### Feature flags
+
+When either building yourself or using `cargo install`,
+you can add feature flags that
+enable functionality that is turned-off by default.
+
+<details>
+<summary>Instructions</summary>
+
+If you want to enable the `cmd` actions,
+add the flag `--features cmd`.
+For example:
+
+```
+cargo build --release --features cmd
+cargo install --features cmd
+```
+
+On Windows,
+if you want to compile a binary that uses the Interception driver,
+you should add the flag `--features interception_driver`.
+For example:
+
+```
+cargo build --release --features interception_driver
+cargo install --features interception_driver
+```
+
+To combine multiple flags,
+use a single `--features` flag
+and use a comma to separate the features.
+For example:
+
+```
+cargo build --release --features cmd,interception_driver
+cargo install --features cmd,interception_driver
+```
+</details>
+
 ## Other installation methods
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/kanata.svg)](https://repology.org/project/kanata/versions)
 
-## Features
+## Notable features
 
 - Human readable configuration file.
   - [Minimal example](./cfg_samples/minimal.kbd)
@@ -135,6 +181,11 @@ otherwise.
 [Here's a basic low-effort design doc of kanata](./docs/design.md)
 
 [*]: https://www.gnu.org/licenses/identify-licenses-clearly.html
+
+If you want to test changes in the keyberon library code,
+you should change the top-level `Cargo.toml` file.
+Look at the comments around the `kanata-keyberon` dependency
+to understand what changes to make.
 
 ## How you can help
 

--- a/cfg_samples/minimal.kbd
+++ b/cfg_samples/minimal.kbd
@@ -6,7 +6,7 @@ act as backtick/grave on quick tap, but change ijkl keys to arrow keys on hold.
 This text between the two pipe+octothorpe sequences is a multi-line comment.
 |#
 
-;; Double-semicolons are single-line comments.
+;; Text after double-semicolons are single-line comments.
 
 #|
 One defcfg entry may be added, which is used for configuration key-pairs. These

--- a/cfg_samples/simple.kbd
+++ b/cfg_samples/simple.kbd
@@ -62,7 +62,6 @@
 
   ;; tap for capslk, hold for lctl
   cap (tap-hold 200 200 caps lctl)
-  bad (tap-hold 200 200 caps lctl)
 )
 
 ;; The `lrld` action stands for "live reload". This will re-parse everything

--- a/docs/release-template.md
+++ b/docs/release-template.md
@@ -1,6 +1,11 @@
-## Changelog (since <previous_version_here>)
+## Changelog (since <TODO: previous_version_here>)
 
-- <fill this out>
+<details>
+<summary>Change log</summary>
+
+- TODO: fill this out
+
+</details>
 
 ## Sample configuration file
 
@@ -14,14 +19,11 @@ You need to run `kanata.exe` via `cmd` or `powershell` to use a different config
 
 `kanata.exe --cfg <cfg_file>`
 
-You can also set up a [toolbar shortcut](https://github.com/jtroo/kanata/wiki/Toolbar-shortcut-for-Windows-10).
-
 ## Linux
 
 Download `kanata`.
 
-Run it in a terminal and point it to a valid configuration file. Kanata does not start a background process, so the window needs to stay open after startup. See [this discussion](https://github.com/jtroo/kanata/discussions/130) for how to set up kanata with systemd.
-
+Run it in a terminal and point it to a valid configuration file.  Kanata does not start a background process, so the window needs to stay open after startup. See [this discussion](https://github.com/jtroo/kanata/discussions/130) for how to set up kanata with systemd.
 ```
 chmod +x kanata   # may be downloaded without executable permissions
 sudo ./kanata --cfg <cfg_file>`
@@ -31,11 +33,19 @@ To avoid requiring `sudo`, [follow the instructions here](https://github.com/jtr
 
 ## cmd_allowed variants
 
+<details>
+<summary>Explanation</summary>
+
 The binaries with the name `cmd_allowed` are conditionally compiled with the `cmd` action enabled.
 
 Using the regular binaries, there is no way to get the `cmd` action to work. This action is restricted behind conditional compilation because I consider the action to be a security risk that should be explicitly opted into and completely forbidden by default.
 
+</details>
+
 ## wintercept variants
+
+<details>
+<summary>Explanation and instructions</summary>
 
 ### Warning: known issue
 
@@ -67,8 +77,15 @@ C:\Users\my_user\Documents\
     interception.dll
 ```
 
+</details>
+
 ## sha256 checksums
 
+<details>
+<summary>sums</summary>
+
 ```
-<fill this out>
+TODO: fill this out
 ```
+
+</details>


### PR DESCRIPTION
Add section on feature flags and shorten by default using collapsible html.

Closes #347 