### PR TITLE
Fix a mistake in docs.

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -437,7 +437,7 @@ There is an option for Windows to help mitigate the strange behaviour of AltGr
 non-US layouts. You can use one of the listed values to change what kanata does
 with the key:
 
-* `cancel-lctl-release`
+* `cancel-lctl-press`
 ** This will remove the `lctl` press that is generated alonside `ralt`
 * `add-lctl-release`
 ** This adds an `lctl` release when `ralt` is released


### PR DESCRIPTION
```
[ERROR] Invalid value for windows-altgr: cancel-lctl-release. Valid values are cancel-lctl-press,add-lctl-release
```