### PR TITLE
fix: bail on duplicate layer name

### DIFF
--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -709,7 +709,7 @@ type LayerIndexes = HashMap<String, usize>;
 type Aliases = HashMap<String, &'static KanataAction>;
 
 /// Returns layer names and their indexes into the keyberon layout. This also checks that all
-/// layers have the same number of items as the defsrc.
+/// layers have the same number of items as the defsrc. Also ensures that there are no duplicate layer names.
 fn parse_layer_indexes(exprs: &[Spanned<Vec<SExpr>>], expected_len: usize) -> Result<LayerIndexes> {
     let mut layer_indexes = HashMap::default();
     for (i, expr) in exprs.iter().enumerate() {
@@ -721,6 +721,9 @@ fn parse_layer_indexes(exprs: &[Spanned<Vec<SExpr>>], expected_len: usize) -> Re
             .atom(None)
             .ok_or_else(|| anyhow_expr!(layer_expr, "layer name after deflayer must be a string"))?
             .to_owned();
+        if layer_indexes.get(&layer_name).is_some() {
+            bail_expr!(layer_expr, "duplicate layer name: {}", layer_name);
+        }
         let num_actions = subexprs.count();
         if num_actions != expected_len {
             bail_span!(


### PR DESCRIPTION
Fixes #399

Duplicate layer names now cause an error:

```
16:43:18 [ERROR] 
  × Error in configuration file
   ╭─[/home/rszyma/.config/kanata/test.kbd:2:1]
 2 │ (deflayer test 1 2 @alias)
 3 │ (deflayer test 4 5 6)
   ·           ──┬─
   ·             ╰── Error here
 4 │ (defalias
   ╰────
  help: duplicate layer name: test
        
        For more info, see the configuration guide or ask in GitHub discussions.
            guide : https://github.com/jtroo/kanata/blob/main/docs/config.adoc
            ask   : https://github.com/jtroo/kanata/discussions

16:43:18 [ERROR] failed to parse file
```