### PR TITLE
fix(windows): reduce blast radius of sft-arrow workaround

### DIFF
--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -396,6 +396,7 @@ impl KbdOut {
 
     /// Send using C-S-u + <unicode hex number> + spc
     pub fn send_unicode(&mut self, c: char) -> Result<(), io::Error> {
+        log::debug!("sending unicode {c}");
         let hex = format!("{:x}", c as u32);
         self.press_key(OsCode::KEY_LEFTCTRL)?;
         self.press_key(OsCode::KEY_LEFTSHIFT)?;

--- a/src/oskbd/windows/mod.rs
+++ b/src/oskbd/windows/mod.rs
@@ -21,6 +21,7 @@ pub use self::interception::*;
 pub use interception_convert::*;
 
 fn send_uc(c: char, up: bool) {
+    log::debug!("sending unicode {c}");
     let mut inputs: [INPUT; 2] = unsafe { mem::zeroed() };
 
     let n_inputs = inputs


### PR DESCRIPTION
This commit makes changes to the blast radius of the workaround for issue #138:

> Shift and arrows interact weirdly on a layer

Discovered in this issue was a problem where activating shift on keys other than the physical shift keys, and then also pressing arrow keys, caused stuck-shift behaviour. The fault is, as is typical, Windows' weird behaviour. The workaround added was to release all shift key states if a single shift key state was found to no longer exist, when comparing the previous keyberon state to the current one.

In some cases, this release of shift causes an earlier release of shift than is desired, because some other key activated shift. This commit reduces the blast radius of the shift state releases to only states with the physical lsft key. In hindsight, Windows' weird behaviour only would have affected the physical lsft key's coordinate anyway, so this is a good change to make. In addition, this issue only affects the LLHOOK mechanism and not Interception, so the code is conditionally compiled out for the Interception driver as well.

Fixes #346