### PR TITLE
[WIP] Adds include statement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "radix_trie",
+ "regex",
  "rustc-hash",
  "sd-notify",
  "serde",
@@ -756,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.2"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ dirs = "5.0.1"
 # Otherwise any changes to the local files will not reflect in the compiled
 # binary.
 kanata-keyberon = { path = "keyberon" }
+regex = "1.8.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = "=0.12.0"


### PR DESCRIPTION
Closes #448.

This adds support for `(include <path>)`. It simply inlines the mentioned file, replacing the `include` statement itself.

I encourage feedback on not only the feature, but the conventions and style and whatnot.

> NOTE: This is incomplete. I just wanted to get the main ideas on paper.

Here is everything I think needs to happen (in rough priority order):
- [x] add support for `(include)`
- [x] support absolute paths
- [x] support relative paths
- [ ] work on the sad-paths (pun? somewhere in there?)
- [ ] vet shifting error line numbers to account for injected code (as mentioned [here](https://github.com/jtroo/kanata/issues/448#issuecomment-1595662912))
- [ ] add docs
- [ ] add tests
- [ ] add sample config