### PR TITLE
Feat: add `include` block

### DIFF
--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -998,7 +998,9 @@ fn parse_action(expr: &SExpr, s: &ParsedState) -> Result<&'static KanataAction> 
         })
         .map_err(|mut e| {
             if e.err_span.is_none() {
-                e.err_span = Some(expr_err_span(expr))
+                e.err_span = Some(expr_err_span(expr));
+                e.file_name = Some(expr.span().file_name());
+                e.file_content = Some(expr.span().file_content());
             }
             e
         })

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -250,7 +250,7 @@ fn parse_cfg_raw(
 )> {
     let text = std::fs::read_to_string(p).map_err(|e| miette::miette!("{e}"))?;
     let cfg_filename = p.to_string_lossy().to_string();
-    parse_cfg_raw_string(&text, s, &cfg_filename).map_err(|e| error_with_source(e, &text))
+    parse_cfg_raw_string(&text, s, &cfg_filename).map_err(error_with_source)
 }
 
 #[allow(clippy::type_complexity)] // return type is not pub

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -430,7 +430,7 @@ fn parse_cfg_raw_string(
     let layer_strings = spanned_root_exprs
         .iter()
         .filter(|expr| deflayer_filter(&&expr.t))
-        .map(|expr| text[expr.span.clone()].to_string())
+        .map(|expr| expr.span.file_content()[expr.span.clone()].to_string())
         .flat_map(|s| {
             // Duplicate the same layer for `layer_strings` because the keyberon layout itself has
             // two versions of each layer.

--- a/src/cfg/sexpr.rs
+++ b/src/cfg/sexpr.rs
@@ -291,7 +291,7 @@ impl<'a> Lexer<'a> {
     }
 }
 
-type TopLevel = Spanned<Vec<SExpr>>;
+pub type TopLevel = Spanned<Vec<SExpr>>;
 
 pub fn parse(cfg: &str, file_name: &str) -> Result<Vec<TopLevel>, CfgError> {
     parse_(cfg, file_name).map_err(transform_error)

--- a/src/cfg/sexpr.rs
+++ b/src/cfg/sexpr.rs
@@ -384,7 +384,7 @@ pub fn transform_error(e: ParseError) -> CfgError {
     CfgError {
         err_span: Some(span_start_len(start, len)),
         help_msg: e.t,
-        file_name: e.span.file_name(),
-        file_content: e.span.file_content(),
+        file_name: Some(e.span.file_name()),
+        file_content: Some(e.span.file_content()),
     }
 }

--- a/src/cfg/tests.rs
+++ b/src/cfg/tests.rs
@@ -141,7 +141,7 @@ fn parse_action_vars() {
 "#;
     parse_cfg_raw_string(source, &mut s, "test")
         .map_err(|e| {
-            eprintln!("{:?}", error_with_source(e, source));
+            eprintln!("{:?}", error_with_source(e));
             ""
         })
         .unwrap();
@@ -162,7 +162,7 @@ fn parse_delegate_to_default_layer_yes() {
 "#;
     let res = parse_cfg_raw_string(source, &mut s, "test")
         .map_err(|e| {
-            eprintln!("{:?}", error_with_source(e, source));
+            eprintln!("{:?}", error_with_source(e));
             ""
         })
         .unwrap();
@@ -187,7 +187,7 @@ fn parse_delegate_to_default_layer_yes_but_base_transparent() {
 "#;
     let res = parse_cfg_raw_string(source, &mut s, "test")
         .map_err(|e| {
-            eprintln!("{:?}", error_with_source(e, source));
+            eprintln!("{:?}", error_with_source(e));
             ""
         })
         .unwrap();
@@ -212,7 +212,7 @@ fn parse_delegate_to_default_layer_no() {
 "#;
     let res = parse_cfg_raw_string(source, &mut s, "test")
         .map_err(|e| {
-            eprintln!("{:?}", error_with_source(e, source));
+            eprintln!("{:?}", error_with_source(e));
             ""
         })
         .unwrap();

--- a/src/cfg/tests.rs
+++ b/src/cfg/tests.rs
@@ -300,7 +300,7 @@ fn disallow_nested_tap_hold() {
         Err(poisoned) => poisoned.into_inner(),
     };
     match new_from_file(&std::path::PathBuf::from("./test_cfgs/nested_tap_hold.kbd"))
-        .map_err(|e| format!("{e:?}"))
+        .map_err(|e| format!("{}", e.help().unwrap()))
     {
         Ok(_) => panic!("invalid nested tap-hold in tap action was Ok'd"),
         Err(e) => assert!(e.contains("tap-hold"), "real e: {e}"),
@@ -342,7 +342,7 @@ fn disallow_multiple_waiting_actions() {
         Err(poisoned) => poisoned.into_inner(),
     };
     match new_from_file(&std::path::PathBuf::from("./test_cfgs/bad_multi.kbd"))
-        .map_err(|e| format!("{e:?}"))
+        .map_err(|e| format!("{}", e.help().unwrap()))
     {
         Ok(_) => panic!("invalid multiple waiting actions Ok'd"),
         Err(e) => assert!(e.contains("Cannot combine multiple")),

--- a/src/kanata/cmd.rs
+++ b/src/kanata/cmd.rs
@@ -170,7 +170,7 @@ pub(super) fn keys_for_cmd_output(cmd_and_args: &[String]) -> impl Iterator<Item
     };
     log::debug!("{LP} stderr: {}", String::from_utf8_lossy(&output.stderr));
     let stdout = String::from_utf8_lossy(&output.stdout);
-    match parse(&stdout) {
+    match parse(&stdout, "cmd") {
         Ok(lists) => match lists.len() {
             0 => {
                 log::warn!("{LP} got zero top-level S-expression from cmd, expected 1:\n{stdout}");
@@ -187,7 +187,7 @@ pub(super) fn keys_for_cmd_output(cmd_and_args: &[String]) -> impl Iterator<Item
         Err(e) => {
             log::warn!(
                 "{LP} could not parse an S-expression from cmd:\n{stdout}\n{}",
-                e.0
+                e.help_msg
             );
             empty()
         }


### PR DESCRIPTION
Implements #448, obsoletes #456 

Added `file_name` to `Span` as discussed here: https://github.com/jtroo/kanata/pull/456#issuecomment-1599163145

Also added `file_content` to `Span` in similar fashion to `file_name`. I needed to change the way source is provided for `miette`, because errors can now come from different files. Adding another field to `Span` was the easiest way to do this. It shouldn't cause any problems with memory though, because it uses `Rc<str>`.

Removed `cfg_filename` and `cfg_text` from `ParsedState`, since these fields are not really needed anymore.

Some notes regarding the new `include` block:
- Absolute include paths should work.
- Relative include paths have set CWD the same as main config.
- All possible errors I could think of are handled and printed to user.
- If an error originates from imported file, a correct line and source will be shown for that file in error report
- It only works on top-level (same as `defsrc` for example) (inline includes can be implemented in the future)
- Includes within included files don't work (can be implemented in the future)
- Multiple files can be included by using multiple `include` blocks

I didn't add any sample configs and haven't changed docs yet, but that can be done later.

Ah, and you may want to check if I didn't mess up somewhere 
with accidentally using too much memory (I'm quite new to rust).