### PR TITLE
[WIP] Added more tcpserver events

### DIFF
--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -389,9 +389,7 @@ impl Kanata {
     fn handle_key_event(&mut self, event: &KeyEvent) -> Result<()> {
         log::debug!("process recv ev {event:?}");
         if let Some(tx) = &self.ntx {
-            let result = tx.send(ServerMessage::KeyEvent(
-                tcp_server::KeyEvent::from_input(event),
-            ));
+            let result = tx.send(ServerMessage::from_input(event));
             if let Err(e) = result {
                 log::error!("Failed to send key event to server: {e}");
             }
@@ -1346,7 +1344,7 @@ impl Kanata {
             self.print_layer(cur_layer);
 
             if let Some(tx) = self.ntx.as_ref() {
-                match tx.send(ServerMessage::LayerChange { new, text: self.layer_info[cur_layer].cfg_text.clone() }) {
+                match tx.send(ServerMessage::LayerChange { new }) {
                     Ok(_) => {}
                     Err(error) => {
                         log::error!("could not send event notification: {}", error);
@@ -1549,7 +1547,7 @@ impl Kanata {
 fn press_key(key: OsCode, out: &mut KbdOut, x: &Option<Sender<ServerMessage>>) -> Result<()> {
     out.press_key(key)?;
     if let Some(tx) = x {
-        let err = tx.send(ServerMessage::KeyEvent(tcp_server::KeyEvent::from_output(&key, tcp_server::KeyAction::Press)));
+        let err = tx.send(ServerMessage::from_output(&key, tcp_server::KeyAction::Press));
         if let Err(e) = err {
             log::error!("could not send event notification: {}", e);
         }
@@ -1560,7 +1558,7 @@ fn press_key(key: OsCode, out: &mut KbdOut, x: &Option<Sender<ServerMessage>>) -
 fn release_key(key: OsCode, out: &mut KbdOut, x: &Option<Sender<ServerMessage>>) -> Result<()> {
     out.release_key(key)?;
     if let Some(tx) = &x {
-        let err = tx.send(ServerMessage::KeyEvent(tcp_server::KeyEvent::from_output(&key, tcp_server::KeyAction::Release)));
+        let err = tx.send(ServerMessage::from_output(&key, tcp_server::KeyAction::Release));
         if let Err(e) = err {
             log::error!("could not send event notification: {}", e);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,7 +179,10 @@ fn main_impl() -> Result<()> {
     };
 
     let (tx, rx) = std::sync::mpsc::channel();
-    Kanata::start_processing_loop(kanata_arc.clone(), rx, ntx, args.nodelay);
+
+    kanata_arc.lock().ntx = ntx;
+
+    Kanata::start_processing_loop(kanata_arc.clone(), rx, args.nodelay);
 
     if let (Some(server), Some(nrx)) = (server, nrx) {
         Kanata::start_notification_loop(nrx, server.connections);

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -89,7 +89,7 @@ impl ServerMessage {
 impl FromStr for ClientMessage {
     type Err = serde_json::Error;
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         serde_json::from_str(s)
     }
 }


### PR DESCRIPTION
Following up on #496 

This PR is still in it's initial stage, but currently it:
* [Breaking] Adds a newline between server messages for easier parsing
*  Added events for input and output keys
* Added "startup" message with all of the layers

What I haven't been able to figure out:
* How to send the defsrc layer
* How to send layers in general, in a "better" format. 
Currently the text representation of the layers requires the user to parse it themselves, with info they can't have (like variables and such), I want to know if I can access and serialize an already parsed form of the layer, so it's easier to understand on the client program.