### PR TITLE
feat: better handling of Windows LLHOOK stuck keys

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -2274,9 +2274,12 @@ fn parse_fake_key_op_coord_action(
     Ok((Coord { x, y }, action))
 }
 
+pub const NORMAL_KEY_ROW: u8 = 0;
+pub const FAKE_KEY_ROW: u8 = 1;
+
 fn get_fake_key_coords<T: Into<usize>>(y: T) -> (u8, u16) {
     let y: usize = y.into();
-    (1, y as u16)
+    (FAKE_KEY_ROW, y as u16)
 }
 
 fn parse_fake_key_delay(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {


### PR DESCRIPTION
There are two changes in this commit.

1) Always live reload after ~1s.

After 1 second if live reload is still not done, there might be a key in a stuck state. One known instance where this happens is Win+L to lock the screen when on Windows and using the LLHOOK mechanism. The release of Win and L keys will not be caught by the kanata process when on the lock screen. However, the OS knows that these keys have released - only the kanata state is wrong. And since kanata has a key in a stuck state, without this 1s fallback, live reload would never activate. Having this fallback allows live reload to happen which resets the kanata states.

2) Clear states after ~65.5s of no external input but still not idle.

This code only runs in the LLHOOK Windows version. The reason for this existing is the same as in 1). The main motivator is the Win+L example. The thought is that after locking their screen, the user will probably go away for a while. The software can detect the abnormality of zero user inputs for an extended period of time while still not being idle and assume that keys got stuck.