### PR TITLE
fix: incorrect handling of deflocalkeys default mappings

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -418,6 +418,10 @@ pub fn parse_cfg_raw_string(
         {
             let mapping = result?;
             if def_local_keys_variant == DEF_LOCAL_KEYS {
+                assert!(
+                    local_keys.is_none(),
+                    ">1 mutually exclusive deflocalkeys variants was parsed"
+                );
                 local_keys = Some(mapping);
             }
         }
@@ -433,9 +437,7 @@ pub fn parse_cfg_raw_string(
             )
         }
     }
-    if let Some(mapping) = local_keys {
-        replace_custom_str_oscode_mapping(&mapping);
-    }
+    replace_custom_str_oscode_mapping(&local_keys.unwrap_or_default());
 
     let src_expr = root_exprs
         .iter()

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1004,3 +1004,101 @@ fn parse_fake_keys_errors_on_too_many() {
     }
     assert!(checked_for_err);
 }
+
+#[test]
+fn parse_deflocalkeys_overridden() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let source = r#"
+(deflocalkeys-win
++   300
+[   301
+]   302
+{   303
+}   304
+/   305
+;   306
+`   307
+=   308
+-   309
+'   310
+,   311
+.   312
+\   313
+yen 314
+¥   315
+)
+(deflocalkeys-wintercept
++   300
+[   301
+]   302
+{   303
+}   304
+/   305
+;   306
+`   307
+=   308
+-   309
+'   310
+,   311
+.   312
+\   313
+yen 314
+¥   315
+)
+(deflocalkeys-linux
++   300
+[   301
+]   302
+{   303
+}   304
+/   305
+;   306
+`   307
+=   308
+-   309
+'   310
+,   311
+.   312
+\   313
+yen 314
+¥   315
+)
+(defsrc + [  ]  {  }  /  ;  `  =  -  '  ,  .  \  yen ¥  )
+(deflayer base + [  ]  {  }  /  ;  `  =  -  '  ,  .  \  yen ¥  )
+"#;
+    let mut s = ParsedState::default();
+    parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+    )
+    .expect("succeeds");
+}
+
+#[test]
+fn use_default_overridable_mappings() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let source = r#"
+(defsrc + [  ]  a  b  /  ;  `  =  -  '  ,  .  9  yen ¥  )
+(deflayer base + [  ]  {  }  /  ;  `  =  -  '  ,  .  \  yen ¥  )
+"#;
+    let mut s = ParsedState::default();
+    parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+    )
+    .expect("succeeds");
+}

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1029,6 +1029,7 @@ fn parse_deflocalkeys_overridden() {
 \   313
 yen 314
 ¥   315
+new 316
 )
 (deflocalkeys-wintercept
 +   300
@@ -1047,6 +1048,7 @@ yen 314
 \   313
 yen 314
 ¥   315
+new 316
 )
 (deflocalkeys-linux
 +   300
@@ -1065,9 +1067,10 @@ yen 314
 \   313
 yen 314
 ¥   315
+new 316
 )
-(defsrc + [  ]  {  }  /  ;  `  =  -  '  ,  .  \  yen ¥  )
-(deflayer base + [  ]  {  }  /  ;  `  =  -  '  ,  .  \  yen ¥  )
+(defsrc + [  ]  {  }  /  ;  `  =  -  '  ,  .  \  yen ¥ new)
+(deflayer base + [  ]  {  }  /  ;  `  =  -  '  ,  .  \  yen ¥ new)
 "#;
     let mut s = ParsedState::default();
     parse_cfg_raw_string(

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -45,7 +45,6 @@ pub fn replace_custom_str_oscode_mapping(mapping: &HashMap<String, OsCode>) {
 pub fn clear_custom_str_oscode_mapping() {
     let mut local_mapping = CUSTOM_STRS_TO_OSCODES.lock();
     local_mapping.clear();
-    add_default_str_osc_mappings(&mut local_mapping);
     local_mapping.shrink_to_fit();
 }
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Commit 5dc3296 added code to add the default overridable mappings when clearing the deflocalkeys mappings. This was incorrect because it made it so these default mappings were no longer overridable. In addition to the fix, tests are added to prevent future regressions.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
