### PR TITLE
feat!: clear non-oneshot output chord on next action

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -27,12 +27,12 @@ be able to configure kanata.
 
 If you follow along with the examples, you should be fine. Kanata should
 also hopefully have helpful error messages in case something goes wrong.
-If you need help, you are welcome to ask.
+If you need help, please feel welcome to ask in the GitHub discussions.
 |#
 
 ;; One defcfg entry may be added if desired. This is used for configuration
 ;; key-value pairs that change kanata's behaviour at a global level.
-;; All configuration items are optional.
+;; All defcfg options are optional.
 (defcfg
   ;; Your keyboard device will likely differ from this. I believe /dev/input/by-id/
   ;; is preferable; I recall reading that it's less likely to change names on you,
@@ -383,6 +383,10 @@ If you need help, you are welcome to ask.
   ;; For ralt/altgr, you can use either of: `RA-` or `AG-`. They both work the
   ;; same and only one is allowed in a single chord. This chord can be useful for
   ;; international layouts.
+  ;;
+  ;; A special behaviour of output chords is that if another key is pressed,
+  ;; all of the chord keys will be released. For the explanation about why
+  ;; this is the case, see the configuration guide.
   ;;
   ;; This use case for multi is typing an all-caps string.
   alp (multi lsft a b c d e f g h i j k l m n o p q r s t u v w x y z)

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -932,6 +932,8 @@ These modifiers may be combined together if desired.
 [source]
 ----
 (defalias
+  ;; Type exclamation mark (US layout)
+  ex! S-1
   ;; Ctrl+C: send SIGINT to a Linux terminal program
   int C-c
   ;; Win+Tab: open Windows' Task View
@@ -941,6 +943,18 @@ These modifiers may be combined together if desired.
   pst C-S-v
 )
 ----
+
+A special behaviour of output chords is that if another key is pressed,
+all of the chord keys will be released
+before the newly pressed key action activates.
+Output chords are typically used do one-off actions such as:
+
+- type a symbol, e.g. `S-1`
+- type a special/accented character, e.g. `RA-a`
+- do a special action like `C-c` to send `SIGTERM` in the terminal
+
+The modifier pressed with these one-off action
+is usually not desired for subsequent actions.
 
 [[repeat-key]]
 === Repeat key

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -2900,7 +2900,10 @@ fn parse_switch(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataA
         let action = parse_action(action, s)?;
 
         let Some(break_or_fallthrough) = break_or_fallthrough_expr.atom(s.vars()) else {
-            bail_expr!(break_or_fallthrough_expr, "{ERR_STR}\nthis must be one of: break, fallthrough");
+            bail_expr!(
+                break_or_fallthrough_expr,
+                "{ERR_STR}\nthis must be one of: break, fallthrough"
+            );
         };
         let break_or_fallthrough = match break_or_fallthrough {
             "break" => BreakOrFallthrough::Break,

--- a/src/kanata/windows/mod.rs
+++ b/src/kanata/windows/mod.rs
@@ -53,9 +53,14 @@ impl Kanata {
     pub fn check_release_non_physical_shift(&mut self) -> Result<()> {
         fn state_filter(v: &State<'_, &&[&CustomAction]>) -> Option<State<'static, ()>> {
             match v {
-                State::NormalKey { keycode, coord } => Some(State::NormalKey::<()> {
+                State::NormalKey {
+                    keycode,
+                    coord,
+                    flags,
+                } => Some(State::NormalKey::<()> {
                     keycode: *keycode,
                     coord: *coord,
+                    flags: *flags,
                 }),
                 State::FakeKey { keycode } => Some(State::FakeKey::<()> { keycode: *keycode }),
                 _ => None,
@@ -81,7 +86,7 @@ impl Kanata {
         // this should not be a problem. State does not implement Hash so can't use a HashSet. A
         // HashSet might perform worse anyway.
         for prev_state in prev_states.iter() {
-            if let State::NormalKey { keycode, coord } = prev_state {
+            if let State::NormalKey { keycode, coord, .. } = prev_state {
                 if !matches!(keycode, KeyCode::LShift | KeyCode::RShift)
                     || (matches!(keycode, KeyCode::LShift)
                         && coord.1 == u16::from(OsCode::KEY_LEFTSHIFT))
@@ -104,6 +109,7 @@ impl Kanata {
                     State::NormalKey {
                         keycode: cur_kc,
                         coord: cur_coord,
+                        ..
                     } => cur_kc != keycode && *cur_coord != (0, u16::from(OsCode::from(keycode))),
                     _ => true,
                 });

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -60,3 +60,15 @@ fn parse_all_keys() {
     ))
     .unwrap();
 }
+
+#[test]
+fn sizeof_state() {
+    assert_eq!(
+        std::mem::size_of::<
+            kanata_keyberon::layout::State<
+                &'static &'static [&'static kanata_parser::custom_action::CustomAction],
+            >,
+        >(),
+        2 * std::mem::size_of::<usize>()
+    );
+}


### PR DESCRIPTION
This commit changes output chord behavior to be more user-friendly by
clearing output chord keys on the next action. I have also been told
(though have not confirmed) that QMK has similar behaviour. I am not
sure that the change in this commit replicates QMK's behaviour
perfectly, but it seems good enough.

Clearing output chord keys on the next action allows a subsequent typed
key to not have modifiers pressed alongside it. Without this change,
typing a new key without first releasing an output chord can have the
unintended typing result. Users have asked about this few times in
issues/discussions and the current workaround is to use a macro.
However, this can be hard to discover. Some users may just be living
with the annoyance because aren't aware that there is a workaround and
they haven't asked.

Output chords within a `one-shot` are ignored because someone might do
something like `(one-shot C-S-lalt)` to get 3 modifiers within a
one-shot action. These are probably intended to remain held. However,
other output chords are usually used to type symbols or accented
characters, e.g. S-1 or RA-a. If the symbol or accented character is
held down, key repeat works just fine because OS key repeats are not
keyberon actions.


## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
