### PR TITLE
feat: add movemouse-inherit-accel-state cfg option

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -153,6 +153,15 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;; which is the layer active upon startup, that is in the same position.
   ;;
   ;; delegate-to-first-layer yes
+
+  ;; This config entry alters the behavior of movemouse-accel actions.
+  ;; By default, this setting is disabled - vertical and horizontal
+  ;; acceleration are independent. Enabling this setting will emulate QMK mouse
+  ;; move acceleration behavior, i.e. the acceleration state of new mouse
+  ;; movement actions are inherited if others are already being pressed.
+  ;;
+  ;; movemouse-inherit-accel-state yes
+
 )
 
 ;; deflocalkeys-* enables you to define and use key names that match your locale

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -392,6 +392,26 @@ For more context, see https://github.com/jtroo/kanata/issues/435.
 )
 ----
 
+
+[[movemouse-inherit-accel-state]]
+=== movemouse-inherit-accel-state
+<<table-of-contents,Back to ToC>>
+
+By default `movemouse-accel` actions will track the acceleration
+state for vertical and horizontal axes separately.
+
+When this setting is enabled, `movemouse-accel` will behave exactly like mouse movements in https://qmk.fm[QMK],
+i.e. the acceleration state of new mouse
+movement actions will be inherited if others are already being pressed.
+
+.Example:
+[source]
+----
+(defcfg
+  movemouse-inherit-accel-state yes
+)
+----
+
 [[linux-only-linux-dev]]
 === Linux only: linux-dev
 <<table-of-contents,Back to ToC>>
@@ -1153,6 +1173,8 @@ interval (unit: ms) between movement actions. The second number is the time it
 takes (unit: ms) to linearly ramp up from the minimum distance to the maximum
 distance. The third and fourth numbers are the minimum and maximum distances
 (unit: pixels) of each movement.
+
+There is a toggable defcfg option related to `movemouse-accel` - <<movemouse-inherit-accel-state>>. You might want to enable it, especially if you're coming from QMK.
 
 [[set-mouse]]
 ==== Set absolute mouse position

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -750,6 +750,7 @@ fn parse_defcfg(expr: &[SExpr]) -> Result<HashMap<String, String>> {
         "log-layer-changes",
         "delegate-to-first-layer",
         "linux-continue-if-no-devs-found",
+        "movemouse-inherit-accel-state",
     ];
     let mut cfg = HashMap::default();
     let mut exprs = check_first_expr(expr.iter(), "defcfg")?;

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -144,6 +144,9 @@ pub struct Kanata {
     pub waiting_for_idle: HashSet<FakeKeyOnIdle>,
     /// Number of ticks since kanata was idle.
     pub ticks_since_idle: u16,
+    /// If a mousemove action is active and another mousemove action is activated,
+    /// reuse the acceleration state.
+    movemouse_inherit_accel_state: bool,
 }
 
 pub struct ScrollState {
@@ -161,6 +164,7 @@ pub struct MoveMouseState {
     pub move_mouse_accel_state: Option<MoveMouseAccelState>,
 }
 
+#[derive(Clone, Copy)]
 pub struct MoveMouseAccelState {
     pub accel_ticks_from_min: u16,
     pub accel_ticks_until_max: u16,
@@ -345,6 +349,11 @@ impl Kanata {
             dynamic_macros: Default::default(),
             log_layer_changes,
             caps_word: None,
+            movemouse_inherit_accel_state: cfg
+                .items
+                .get("movemouse-inherit-accel-state")
+                .map(|s| TRUE_VALUES.contains(&s.to_lowercase().as_str()))
+                .unwrap_or_default(),
             #[cfg(target_os = "linux")]
             defcfg_items: cfg.items,
             waiting_for_idle: HashSet::default(),
@@ -918,10 +927,44 @@ impl Kanata {
                             min_distance,
                             max_distance,
                         } => {
-                            let f_max_distance: f64 = *max_distance as f64;
-                            let f_min_distance: f64 = *min_distance as f64;
-                            let f_accel_time: f64 = *accel_time as f64;
-                            let increment = (f_max_distance - f_min_distance) / f_accel_time;
+                            let move_mouse_accel_state = match (
+                                self.movemouse_inherit_accel_state,
+                                &self.move_mouse_state_horizontal,
+                                &self.move_mouse_state_vertical,
+                            ) {
+                                (
+                                    true,
+                                    Some(MoveMouseState {
+                                        move_mouse_accel_state: Some(s),
+                                        ..
+                                    }),
+                                    _,
+                                )
+                                | (
+                                    true,
+                                    _,
+                                    Some(MoveMouseState {
+                                        move_mouse_accel_state: Some(s),
+                                        ..
+                                    }),
+                                ) => *s,
+                                _ => {
+                                    let f_max_distance: f64 = *max_distance as f64;
+                                    let f_min_distance: f64 = *min_distance as f64;
+                                    let f_accel_time: f64 = *accel_time as f64;
+                                    let increment =
+                                        (f_max_distance - f_min_distance) / f_accel_time;
+
+                                    MoveMouseAccelState {
+                                        accel_ticks_from_min: 0,
+                                        accel_ticks_until_max: *accel_time,
+                                        accel_increment: increment,
+                                        min_distance: *min_distance,
+                                        max_distance: *max_distance,
+                                    }
+                                }
+                            };
+
                             match direction {
                                 MoveDirection::Up | MoveDirection::Down => {
                                     self.move_mouse_state_vertical = Some(MoveMouseState {
@@ -929,13 +972,7 @@ impl Kanata {
                                         distance: *min_distance,
                                         ticks_until_move: 0,
                                         interval: *interval,
-                                        move_mouse_accel_state: Some(MoveMouseAccelState {
-                                            accel_ticks_from_min: 0,
-                                            accel_ticks_until_max: *accel_time,
-                                            accel_increment: increment,
-                                            min_distance: *min_distance,
-                                            max_distance: *max_distance,
-                                        }),
+                                        move_mouse_accel_state: Some(move_mouse_accel_state),
                                     })
                                 }
                                 MoveDirection::Left | MoveDirection::Right => {
@@ -944,13 +981,7 @@ impl Kanata {
                                         distance: *min_distance,
                                         ticks_until_move: 0,
                                         interval: *interval,
-                                        move_mouse_accel_state: Some(MoveMouseAccelState {
-                                            accel_ticks_from_min: 0,
-                                            accel_ticks_until_max: *accel_time,
-                                            accel_increment: increment,
-                                            min_distance: *min_distance,
-                                            max_distance: *max_distance,
-                                        }),
+                                        move_mouse_accel_state: Some(move_mouse_accel_state),
                                     })
                                 }
                             }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -392,6 +392,11 @@ impl Kanata {
         self.sequences = cfg.sequences;
         self.overrides = cfg.overrides;
         self.log_layer_changes = log_layer_changes;
+        self.movemouse_inherit_accel_state = cfg
+            .items
+            .get("movemouse-inherit-accel-state")
+            .map(|s| TRUE_VALUES.contains(&s.to_lowercase().as_str()))
+            .unwrap_or_default();
         *MAPPED_KEYS.lock() = cfg.mapped_keys;
         Kanata::set_repeat_rate(&cfg.items)?;
         log::info!("Live reload successful");


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Implement an cfg option to inherit `movemouse` accel state 
https://github.com/jtroo/kanata/discussions/504#discussioncomment-6578201 1st point
https://github.com/jtroo/kanata/issues/549#issuecomment-1696533063 partially


## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes 
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes 
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes, manual

