### PR TITLE
feat: add movemouse-smooth-diagonals

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -753,6 +753,7 @@ fn parse_defcfg(expr: &[SExpr]) -> Result<HashMap<String, String>> {
         "log-layer-changes",
         "delegate-to-first-layer",
         "linux-continue-if-no-devs-found",
+        "movemouse-smooth-diagonals",
     ];
     let mut cfg = HashMap::default();
     let mut exprs = check_first_expr(expr.iter(), "defcfg")?;

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -144,6 +144,34 @@ pub struct Kanata {
     pub waiting_for_idle: HashSet<FakeKeyOnIdle>,
     /// Number of ticks since kanata was idle.
     pub ticks_since_idle: u16,
+    /// Removes jaggedneess of vertical and horizontal mouse movements when used
+    /// simultaneously at the cost of increased mousemove actions latency.
+    movemouse_smooth_diagonals: bool,
+    /// If movemouse_smooth_diagonals is enabled, the previous mouse actions
+    /// gets stored in this buffer and if the next movemouse action is opposite axis
+    /// than the one stored in the buffer, both events are outputted at the same time.
+    movemouse_buffer: Option<(Axis, CalculatedMouseMove)>,
+}
+
+#[derive(PartialEq, Clone, Copy)]
+pub enum Axis {
+    Vertical,
+    Horizontal,
+}
+
+impl Into<Axis> for MoveDirection {
+    fn into(self) -> Axis {
+        match self {
+            MoveDirection::Up | MoveDirection::Down => Axis::Vertical,
+            MoveDirection::Left | MoveDirection::Right => Axis::Horizontal,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct CalculatedMouseMove {
+    pub direction: MoveDirection,
+    pub distance: u16,
 }
 
 pub struct ScrollState {
@@ -345,10 +373,16 @@ impl Kanata {
             dynamic_macros: Default::default(),
             log_layer_changes,
             caps_word: None,
+            movemouse_smooth_diagonals: cfg
+                .items
+                .get("movemouse-smooth-diagonals")
+                .map(|s| TRUE_VALUES.contains(&s.to_lowercase().as_str()))
+                .unwrap_or_default(),
             #[cfg(target_os = "linux")]
             defcfg_items: cfg.items,
             waiting_for_idle: HashSet::default(),
             ticks_since_idle: 0,
+            movemouse_buffer: None,
         })
     }
 
@@ -383,6 +417,11 @@ impl Kanata {
         self.sequences = cfg.sequences;
         self.overrides = cfg.overrides;
         self.log_layer_changes = log_layer_changes;
+        self.movemouse_smooth_diagonals = cfg
+            .items
+            .get("movemouse-smooth-diagonals")
+            .map(|s| TRUE_VALUES.contains(&s.to_lowercase().as_str()))
+            .unwrap_or_default();
         *MAPPED_KEYS.lock() = cfg.mapped_keys;
         Kanata::set_repeat_rate(&cfg.items)?;
         log::info!("Live reload successful");
@@ -525,7 +564,32 @@ impl Kanata {
                 let scaled_distance =
                     apply_mouse_distance_modifiers(mmsv.distance, &self.move_mouse_speed_modifiers);
                 log::debug!("handle_move_mouse: scaled vdistance: {}", scaled_distance);
-                self.kbd_out.move_mouse(mmsv.direction, scaled_distance)?;
+
+                let current_move = CalculatedMouseMove {
+                    direction: mmsv.direction,
+                    distance: scaled_distance,
+                };
+
+                if self.movemouse_smooth_diagonals {
+                    let axis: Axis = current_move.direction.into();
+                    match &self.movemouse_buffer {
+                        Some((previous_axis, previous_move)) => {
+                            if axis == *previous_axis {
+                                self.kbd_out.move_mouse(*previous_move)?;
+                                self.movemouse_buffer = Some((axis, current_move));
+                            } else {
+                                self.kbd_out
+                                    .move_mouse_many(&[*previous_move, current_move])?;
+                                self.movemouse_buffer = None;
+                            }
+                        }
+                        None => {
+                            self.movemouse_buffer = Some((axis, current_move));
+                        }
+                    }
+                } else {
+                    self.kbd_out.move_mouse(current_move)?;
+                }
             } else {
                 mmsv.ticks_until_move -= 1;
             }
@@ -547,7 +611,32 @@ impl Kanata {
                 let scaled_distance =
                     apply_mouse_distance_modifiers(mmsh.distance, &self.move_mouse_speed_modifiers);
                 log::debug!("handle_move_mouse: scaled hdistance: {}", scaled_distance);
-                self.kbd_out.move_mouse(mmsh.direction, scaled_distance)?;
+
+                let current_move = CalculatedMouseMove {
+                    direction: mmsh.direction,
+                    distance: scaled_distance,
+                };
+
+                if self.movemouse_smooth_diagonals {
+                    let axis: Axis = current_move.direction.into();
+                    match &self.movemouse_buffer {
+                        Some((previous_axis, previous_move)) => {
+                            if axis == *previous_axis {
+                                self.kbd_out.move_mouse(*previous_move)?;
+                                self.movemouse_buffer = Some((axis, current_move));
+                            } else {
+                                self.kbd_out
+                                    .move_mouse_many(&[*previous_move, current_move])?;
+                                self.movemouse_buffer = None;
+                            }
+                        }
+                        None => {
+                            self.movemouse_buffer = Some((axis, current_move));
+                        }
+                    }
+                } else {
+                    self.kbd_out.move_mouse(current_move)?;
+                }
             } else {
                 mmsh.ticks_until_move -= 1;
             }
@@ -1181,7 +1270,8 @@ impl Kanata {
                             }
                             pbtn
                         }
-                        CustomAction::MoveMouse { direction, .. } => {
+                        CustomAction::MoveMouse { direction, .. }
+                        | CustomAction::MoveMouseAccel { direction, .. } => {
                             match direction {
                                 MoveDirection::Up | MoveDirection::Down => {
                                     if let Some(move_mouse_state_vertical) =
@@ -1202,28 +1292,8 @@ impl Kanata {
                                     }
                                 }
                             }
-                            pbtn
-                        }
-                        CustomAction::MoveMouseAccel { direction, .. } => {
-                            match direction {
-                                MoveDirection::Up | MoveDirection::Down => {
-                                    if let Some(move_mouse_state_vertical) =
-                                        &self.move_mouse_state_vertical
-                                    {
-                                        if move_mouse_state_vertical.direction == *direction {
-                                            self.move_mouse_state_vertical = None;
-                                        }
-                                    }
-                                }
-                                MoveDirection::Left | MoveDirection::Right => {
-                                    if let Some(move_mouse_state_horizontal) =
-                                        &self.move_mouse_state_horizontal
-                                    {
-                                        if move_mouse_state_horizontal.direction == *direction {
-                                            self.move_mouse_state_horizontal = None;
-                                        }
-                                    }
-                                }
+                            if self.movemouse_smooth_diagonals {
+                                self.movemouse_buffer = None
                             }
                             pbtn
                         }


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Closes #549

Add `movemouse-smooth-diagonals` cfg option that enables smooth diagonal movements by storing a previous movemouse action in a 1-length buffer. If the next movemouse has different axis than the one in the buffer both actions are outputted at the same time.

A few remarks:
- So far I've only did implementation for Linux (I haven't tried implementing win nor wintercept yet).
- This cfg option is intended to work only with movemouse actions that have the same interval, otherwise the behavior is undefined.
- Using this cfg option adds a delay to movemouse actions equal to the interval of used movemouse actions.

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Manual testing
