### PR TITLE
parser: allow specifying which deflocalkeys variant to use

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -318,7 +318,8 @@ fn parse_cfg_raw(
         .get_file_content(&cfg_file_name)
         .map_err(|e| miette::miette!(e))?;
 
-    parse_cfg_raw_string(&text, s, p, &mut file_content_provider).map_err(|e| e.into())
+    parse_cfg_raw_string(&text, s, p, &mut file_content_provider, DEF_LOCAL_KEYS)
+        .map_err(|e| e.into())
 }
 
 fn expand_includes(
@@ -368,6 +369,7 @@ pub fn parse_cfg_raw_string(
     s: &mut ParsedState,
     cfg_path: &Path,
     file_content_provider: &mut FileContentProvider,
+    def_local_keys_variant_to_apply: &str,
 ) -> Result<(
     HashMap<String, String>,
     MappedKeys,
@@ -420,7 +422,7 @@ pub fn parse_cfg_raw_string(
             .map(|custom_keys| parse_deflocalkeys(def_local_keys_variant, custom_keys))
         {
             let mapping = result?;
-            if def_local_keys_variant == DEF_LOCAL_KEYS {
+            if def_local_keys_variant == def_local_keys_variant_to_apply {
                 assert!(
                     local_keys.is_none(),
                     ">1 mutually exclusive deflocalkeys variants was parsed"

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -45,6 +45,7 @@ fn span_works_with_unicode_characters() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .expect_err("should be an error because @😊 is not defined")
     .span
@@ -82,6 +83,7 @@ fn test_multiline_error_span() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .expect_err("should error on unknown top level block")
     .span
@@ -111,6 +113,7 @@ fn test_span_of_an_unterminated_block_comment_error() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .expect_err("should be an unterminated comment error")
     .span
@@ -201,6 +204,7 @@ fn parse_action_vars() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .unwrap();
 }
@@ -225,6 +229,7 @@ fn parse_delegate_to_default_layer_yes() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .unwrap();
     assert_eq!(
@@ -253,6 +258,7 @@ fn parse_delegate_to_default_layer_yes_but_base_transparent() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .unwrap();
     assert_eq!(
@@ -281,6 +287,7 @@ fn parse_delegate_to_default_layer_no() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .unwrap();
     assert_eq!(
@@ -685,6 +692,7 @@ fn parse_bad_submacro() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .map_err(|_e| {
         // uncomment to see what this looks like when running test
@@ -715,6 +723,7 @@ fn parse_bad_submacro_2() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .map_err(|_e| {
         // uncomment to see what this looks like when running test
@@ -750,6 +759,7 @@ fn parse_switch() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .unwrap();
     assert_eq!(
@@ -822,6 +832,7 @@ fn parse_switch_exceed_depth() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .map_err(|_e| {
         // uncomment to see what this looks like when running test
@@ -853,6 +864,7 @@ fn parse_on_idle_fakekey() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .map_err(|_e| {
         // uncomment to see what this looks like when running test
@@ -895,6 +907,7 @@ fn parse_on_idle_fakekey_errors() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .map_err(|_e| {
         // comment out to see what this looks like when running test
@@ -918,6 +931,7 @@ fn parse_on_idle_fakekey_errors() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .map_err(|_e| {
         // uncomment to see what this looks like when running test
@@ -941,6 +955,7 @@ fn parse_on_idle_fakekey_errors() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .map_err(|_e| {
         // uncomment to see what this looks like when running test
@@ -964,6 +979,7 @@ fn parse_on_idle_fakekey_errors() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .map_err(|_e| {
         // uncomment to see what this looks like when running test
@@ -1082,6 +1098,7 @@ new 316
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .expect("succeeds");
 }
@@ -1104,6 +1121,7 @@ fn use_default_overridable_mappings() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .expect("succeeds");
 }
@@ -1129,6 +1147,7 @@ fn list_action_not_in_list_error_message_is_good() {
         &mut FileContentProvider {
             get_file_content_fn: &mut |_| unimplemented!(),
         },
+        DEF_LOCAL_KEYS,
     )
     .map_err(|e| {
         assert_eq!(


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Allows passing which deflocalkeys variant to use as argument to parse function.

Merging this PR would allow https://github.com/rszyma/vscode-kanata/pull/4 to move forward.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] N/A
