### PR TITLE
refactor: use bounded channel

### DIFF
--- a/src/kanata/linux.rs
+++ b/src/kanata/linux.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, bail, Result};
 use log::info;
 use parking_lot::Mutex;
 use std::convert::TryFrom;
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::SyncSender as Sender;
 use std::sync::Arc;
 
 use super::*;
@@ -63,7 +63,7 @@ impl Kanata {
                 }
 
                 // Send key events to the processing loop
-                if let Err(e) = tx.send(key_event) {
+                if let Err(e) = tx.try_send(key_event) {
                     bail!("failed to send on channel: {}", e)
                 }
             }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -3,7 +3,7 @@
 use anyhow::{anyhow, bail, Result};
 use log::{error, info};
 use parking_lot::Mutex;
-use std::sync::mpsc::{Receiver, Sender, TryRecvError};
+use std::sync::mpsc::{Receiver, SyncSender as Sender, TryRecvError};
 
 use kanata_keyberon::key_code::*;
 use kanata_keyberon::layout::*;
@@ -1475,7 +1475,7 @@ impl Kanata {
             self.print_layer(cur_layer);
 
             if let Some(tx) = tx {
-                match tx.send(ServerMessage::LayerChange { new }) {
+                match tx.try_send(ServerMessage::LayerChange { new }) {
                     Ok(_) => {}
                     Err(error) => {
                         log::error!("could not send event notification: {}", error);

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use kanata_interception as ic;
 use parking_lot::Mutex;
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::SyncSender as Sender;
 use std::sync::Arc;
 
 use super::PRESSED_KEYS;
@@ -112,7 +112,7 @@ impl Kanata {
                         }
                         _ => {}
                     }
-                    tx.send(key_event)?;
+                    tx.try_send(key_event)?;
                 }
             }
         }

--- a/src/kanata/windows/llhook.rs
+++ b/src/kanata/windows/llhook.rs
@@ -1,6 +1,6 @@
 use parking_lot::Mutex;
 use std::convert::TryFrom;
-use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender as Sender, TryRecvError};
 use std::sync::Arc;
 use std::time;
 
@@ -20,7 +20,7 @@ impl Kanata {
         };
         native_windows_gui::init()?;
 
-        let (preprocess_tx, preprocess_rx) = channel();
+        let (preprocess_tx, preprocess_rx) = sync_channel(100);
         start_event_preprocessor(preprocess_rx, tx);
 
         // This callback should return `false` if the input event is **not** handled by the
@@ -73,7 +73,7 @@ impl Kanata {
 }
 
 fn try_send_panic(tx: &Sender<KeyEvent>, kev: KeyEvent) {
-    if let Err(e) = tx.send(kev) {
+    if let Err(e) = tx.try_send(kev) {
         panic!("failed to send on channel: {e:?}")
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,13 +172,13 @@ fn main_impl() -> Result<()> {
     let (server, ntx, nrx) = if let Some(port) = args.port {
         let mut server = TcpServer::new(port);
         server.start(kanata_arc.clone());
-        let (ntx, nrx) = std::sync::mpsc::channel();
+        let (ntx, nrx) = std::sync::mpsc::sync_channel(100);
         (Some(server), Some(ntx), Some(nrx))
     } else {
         (None, None, None)
     };
 
-    let (tx, rx) = std::sync::mpsc::channel();
+    let (tx, rx) = std::sync::mpsc::sync_channel(100);
     Kanata::start_processing_loop(kanata_arc.clone(), rx, ntx, args.nodelay);
 
     if let (Some(server), Some(nrx)) = (server, nrx) {


### PR DESCRIPTION
This commit attempts to fix an issue with excessive CPU and memory usage. At the time there are no steps to reproduce, but one suspicion is masses of rogue input events from the kernel. Thus the code is changed to use bounded channels with a reasonably large size (100) that I wouldn't expect to get filled up.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
