### PR TITLE
feat: add mouse wheel events to defsrc

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1209,6 +1209,34 @@ fn parse_action_atom(ac_span: &Spanned<String>, s: &ParsedState) -> Result<&'sta
                 s.a.sref(s.a.sref_slice(CustomAction::MouseTap(Btn::Backward))),
             )))
         }
+        "mwu" | "mousewheelup" => {
+            return Ok(s.a.sref(Action::Custom(s.a.sref(s.a.sref_slice(
+                CustomAction::MWheelNotch {
+                    direction: MWheelDirection::Up,
+                },
+            )))))
+        }
+        "mwd" | "mousewheeldown" => {
+            return Ok(s.a.sref(Action::Custom(s.a.sref(s.a.sref_slice(
+                CustomAction::MWheelNotch {
+                    direction: MWheelDirection::Down,
+                },
+            )))))
+        }
+        "mwl" | "mousewheelleft" => {
+            return Ok(s.a.sref(Action::Custom(s.a.sref(s.a.sref_slice(
+                CustomAction::MWheelNotch {
+                    direction: MWheelDirection::Left,
+                },
+            )))))
+        }
+        "mwr" | "mousewheelright" => {
+            return Ok(s.a.sref(Action::Custom(s.a.sref(s.a.sref_slice(
+                CustomAction::MWheelNotch {
+                    direction: MWheelDirection::Right,
+                },
+            )))))
+        }
         "rpt" | "repeat" | "rpt-key" => {
             return Ok(s.a.sref(Action::Custom(
                 s.a.sref(s.a.sref_slice(CustomAction::Repeat)),

--- a/parser/src/custom_action.rs
+++ b/parser/src/custom_action.rs
@@ -6,6 +6,8 @@
 use anyhow::{anyhow, Result};
 use kanata_keyberon::key_code::KeyCode;
 
+use crate::keys::OsCode;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CustomAction {
     Cmd(Vec<String>),
@@ -102,6 +104,20 @@ pub enum MWheelDirection {
     Down,
     Left,
     Right,
+}
+
+impl TryFrom<OsCode> for MWheelDirection {
+    type Error = ();
+    fn try_from(value: OsCode) -> Result<Self, Self::Error> {
+        use OsCode::*;
+        Ok(match value {
+            MouseWheelUp | MouseWheelUpHiRes => MWheelDirection::Up,
+            MouseWheelDown | MouseWheelDownHiRes => MWheelDirection::Down,
+            MouseWheelLeft | MouseWheelLeftHiRes => MWheelDirection::Left,
+            MouseWheelRight | MouseWheelRightHiRes => MWheelDirection::Right,
+            _ => return Err(()),
+        })
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/parser/src/custom_action.rs
+++ b/parser/src/custom_action.rs
@@ -111,10 +111,10 @@ impl TryFrom<OsCode> for MWheelDirection {
     fn try_from(value: OsCode) -> Result<Self, Self::Error> {
         use OsCode::*;
         Ok(match value {
-            MouseWheelUp | MouseWheelUpHiRes => MWheelDirection::Up,
-            MouseWheelDown | MouseWheelDownHiRes => MWheelDirection::Down,
-            MouseWheelLeft | MouseWheelLeftHiRes => MWheelDirection::Left,
-            MouseWheelRight | MouseWheelRightHiRes => MWheelDirection::Right,
+            MouseWheelUp => MWheelDirection::Up,
+            MouseWheelDown => MWheelDirection::Down,
+            MouseWheelLeft => MWheelDirection::Left,
+            MouseWheelRight => MWheelDirection::Right,
             _ => return Err(()),
         })
     }

--- a/parser/src/custom_action.rs
+++ b/parser/src/custom_action.rs
@@ -29,6 +29,9 @@ pub enum CustomAction {
         interval: u16,
         distance: u16,
     },
+    MWheelNotch {
+        direction: MWheelDirection,
+    },
     MoveMouse {
         direction: MoveDirection,
         interval: u16,

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -242,6 +242,16 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "mfwd" | "mouseforward" => OsCode::BTN_EXTRA,
         "mbck" | "mousebackward" => OsCode::BTN_SIDE,
 
+        // NOTE: these are linux-only right now due to missing implementation for windows
+        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+        "mwu" | "mousewheelup" => OsCode::MouseWheelUp,
+        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+        "mwd" | "mousewheeldown" => OsCode::MouseWheelDown,
+        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+        "mwl" | "mousewheelleft" => OsCode::MouseWheelLeft,
+        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+        "mwr" | "mousewheelright" => OsCode::MouseWheelRight,
+
         "hmpg" | "homepage" => OsCode::KEY_HOMEPAGE,
         "mdia" | "media" => OsCode::KEY_MEDIA,
         "mail" => OsCode::KEY_MAIL,
@@ -1018,6 +1028,16 @@ pub enum OsCode {
     BTN_TRIGGER_HAPPY39 = 742,
     BTN_TRIGGER_HAPPY40 = 743,
     BTN_MAX = 744,
+
+    // Mouse wheel events are not a part of EV_KEY, so they technically
+    // shouldn't be there, but they're still there, because this way
+    // it's easier to implement allowing to add them to defsrc without
+    // making tons of changes all over the codebase.
+    MouseWheelUp = 745,
+    MouseWheelDown = 746,
+    MouseWheelLeft = 747,
+    MouseWheelRight = 748,
+
     KEY_MAX = 767,
 }
 

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -1038,11 +1038,6 @@ pub enum OsCode {
     MouseWheelLeft = 747,
     MouseWheelRight = 748,
 
-    MouseWheelUpHiRes = 749,
-    MouseWheelDownHiRes = 750,
-    MouseWheelLeftHiRes = 751,
-    MouseWheelRightHiRes = 752,
-
     KEY_MAX = 767,
 }
 

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -242,14 +242,14 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "mfwd" | "mouseforward" => OsCode::BTN_EXTRA,
         "mbck" | "mousebackward" => OsCode::BTN_SIDE,
 
-        // NOTE: these are linux-only right now due to missing implementation for windows
-        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+        // NOTE: these are linux and interception-only due to missing implementation for LLHOOK
+        #[cfg(any(target_os = "linux", target_os = "unknown", feature = "interception_driver"))]
         "mwu" | "mousewheelup" => OsCode::MouseWheelUp,
-        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+        #[cfg(any(target_os = "linux", target_os = "unknown", feature = "interception_driver"))]
         "mwd" | "mousewheeldown" => OsCode::MouseWheelDown,
-        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+        #[cfg(any(target_os = "linux", target_os = "unknown", feature = "interception_driver"))]
         "mwl" | "mousewheelleft" => OsCode::MouseWheelLeft,
-        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+        #[cfg(any(target_os = "linux", target_os = "unknown", feature = "interception_driver"))]
         "mwr" | "mousewheelright" => OsCode::MouseWheelRight,
 
         "hmpg" | "homepage" => OsCode::KEY_HOMEPAGE,

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -1038,6 +1038,11 @@ pub enum OsCode {
     MouseWheelLeft = 747,
     MouseWheelRight = 748,
 
+    MouseWheelUpHiRes = 749,
+    MouseWheelDownHiRes = 750,
+    MouseWheelLeftHiRes = 751,
+    MouseWheelRightHiRes = 752,
+
     KEY_MAX = 767,
 }
 

--- a/src/kanata/linux.rs
+++ b/src/kanata/linux.rs
@@ -147,7 +147,9 @@ fn handle_scroll(
                     // So to fix this case, we need to use `scroll` which will also send hi-res scrolls
                     // along normal scrolls.
                     //
-                    // However, if this is a normal scroll event, it may be sent alongside a
+                    // However, if this is a normal scroll event, it may be sent alongside a hi-res
+                    // scroll event. In this scenario, the hi-res event should be used to call
+                    // scroll, and not the normal event. Otherwise, too much scrolling will happen.
                     let mut kanata = kanata.lock();
                     if !all_events.iter().any(|ev| {
                         matches!(

--- a/src/kanata/linux.rs
+++ b/src/kanata/linux.rs
@@ -10,7 +10,7 @@ use super::*;
 impl Kanata {
     /// Enter an infinite loop that listens for OS key events and sends them to the processing
     /// thread.
-    pub fn event_loop(kanata: Arc<Mutex<Self>>, tx: Sender<SupportedInputEvent>) -> Result<()> {
+    pub fn event_loop(kanata: Arc<Mutex<Self>>, tx: Sender<KeyEvent>) -> Result<()> {
         info!("entering the event loop");
 
         let k = kanata.lock();
@@ -134,7 +134,10 @@ impl Kanata {
                 };
 
                 // Send key events to the processing loop
-                if let Err(e) = tx.try_send(supported_in_event) {
+                if let Err(e) = tx.try_send(supported_in_event.try_into().expect(
+                    "only hi-res scroll can fail this conversion,
+                    but this should be unreachable for it",
+                )) {
                     bail!("failed to send on channel: {}", e)
                 }
             }

--- a/src/kanata/linux.rs
+++ b/src/kanata/linux.rs
@@ -31,8 +31,7 @@ impl Kanata {
         Kanata::set_repeat_rate(&k.defcfg_items)?;
         drop(k);
 
-        let scroll_wheel_mapped = false
-            || MAPPED_KEYS.lock().contains(&OsCode::MouseWheelUp)
+        let scroll_wheel_mapped = MAPPED_KEYS.lock().contains(&OsCode::MouseWheelUp)
             || MAPPED_KEYS.lock().contains(&OsCode::MouseWheelDown)
             || MAPPED_KEYS.lock().contains(&OsCode::MouseWheelLeft)
             || MAPPED_KEYS.lock().contains(&OsCode::MouseWheelRight);

--- a/src/kanata/linux.rs
+++ b/src/kanata/linux.rs
@@ -31,11 +31,6 @@ impl Kanata {
         Kanata::set_repeat_rate(&k.defcfg_items)?;
         drop(k);
 
-        let scroll_wheel_mapped = MAPPED_KEYS.lock().contains(&OsCode::MouseWheelUp)
-            || MAPPED_KEYS.lock().contains(&OsCode::MouseWheelDown)
-            || MAPPED_KEYS.lock().contains(&OsCode::MouseWheelLeft)
-            || MAPPED_KEYS.lock().contains(&OsCode::MouseWheelRight);
-
         loop {
             let events = kbd_in.read().map_err(|e| anyhow!("failed read: {}", e))?;
             log::trace!("{events:?}");
@@ -81,7 +76,7 @@ impl Kanata {
                         let osc: OsCode = sev
                             .try_into()
                             .expect("standard scroll should have OsCode mapping");
-                        if scroll_wheel_mapped {
+                        if kanata.lock().scroll_wheel_mapped {
                             if MAPPED_KEYS.lock().contains(&osc) {
                                 // Send this event to processing loop.
                             } else {
@@ -119,7 +114,7 @@ impl Kanata {
                         ..
                     }) => {
                         // Don't passthrough hi-res mouse wheel events when scroll wheel is remapped,
-                        if scroll_wheel_mapped {
+                        if kanata.lock().scroll_wheel_mapped {
                             continue;
                         }
                         // Passthrough if none of the scroll wheel events are mapped

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1004,6 +1004,10 @@ impl Kanata {
                                 })
                             }
                         },
+                        CustomAction::MWheelNotch { direction } => {
+                            self.kbd_out
+                                .scroll(*direction, HI_RES_SCROLL_UNITS_IN_LO_RES)?;
+                        }
                         CustomAction::MoveMouse {
                             direction,
                             interval,

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -154,7 +154,6 @@ pub struct Kanata {
     /// gets stored in this buffer and if the next movemouse action is opposite axis
     /// than the one stored in the buffer, both events are outputted at the same time.
     movemouse_buffer: Option<(Axis, CalculatedMouseMove)>,
-    scroll_wheel_mapped: bool,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -334,11 +333,6 @@ impl Kanata {
             .map(|s| !FALSE_VALUES.contains(&s.to_lowercase().as_str()))
             .unwrap_or(true);
 
-        let scroll_wheel_mapped = cfg.mapped_keys.contains(&OsCode::MouseWheelUp)
-            || cfg.mapped_keys.contains(&OsCode::MouseWheelDown)
-            || cfg.mapped_keys.contains(&OsCode::MouseWheelLeft)
-            || cfg.mapped_keys.contains(&OsCode::MouseWheelRight);
-
         *MAPPED_KEYS.lock() = cfg.mapped_keys;
 
         Ok(Self {
@@ -398,7 +392,6 @@ impl Kanata {
             waiting_for_idle: HashSet::default(),
             ticks_since_idle: 0,
             movemouse_buffer: None,
-            scroll_wheel_mapped,
         })
     }
 
@@ -443,10 +436,6 @@ impl Kanata {
             .get("movemouse-inherit-accel-state")
             .map(|s| TRUE_VALUES.contains(&s.to_lowercase().as_str()))
             .unwrap_or_default();
-        self.scroll_wheel_mapped = cfg.mapped_keys.contains(&OsCode::MouseWheelUp)
-            || cfg.mapped_keys.contains(&OsCode::MouseWheelDown)
-            || cfg.mapped_keys.contains(&OsCode::MouseWheelLeft)
-            || cfg.mapped_keys.contains(&OsCode::MouseWheelRight);
         *MAPPED_KEYS.lock() = cfg.mapped_keys;
         Kanata::set_repeat_rate(&cfg.items)?;
         log::info!("Live reload successful");

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -447,12 +447,10 @@ impl Kanata {
         log::debug!("process recv ev {event:?}");
         self.ticks_since_idle = 0;
 
-        let kbrn_ev;
-
-        match event {
+        let kbrn_ev = match event {
             SupportedInputEvent::KeyEvent(kev) => {
                 let evc: u16 = kev.code.into();
-                kbrn_ev = match kev.value {
+                match kev.value {
                     KeyValue::Press => {
                         if let Some(state) = &mut self.dynamic_macro_record_state {
                             state.macro_items.push(DynamicMacroItem::Press(kev.code));
@@ -469,7 +467,7 @@ impl Kanata {
                         let ret = self.handle_repeat(kev);
                         return ret;
                     }
-                };
+                }
             }
             SupportedInputEvent::ScrollEvent(sev) => {
                 let osc: OsCode = match (*sev).try_into() {
@@ -481,7 +479,7 @@ impl Kanata {
                 self.layout.bm().event(Event::Release(0, evc));
                 return Ok(());
             }
-        }
+        };
 
         self.layout.bm().event(kbrn_ev);
         Ok(())

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -154,6 +154,7 @@ pub struct Kanata {
     /// gets stored in this buffer and if the next movemouse action is opposite axis
     /// than the one stored in the buffer, both events are outputted at the same time.
     movemouse_buffer: Option<(Axis, CalculatedMouseMove)>,
+    scroll_wheel_mapped: bool,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -333,6 +334,11 @@ impl Kanata {
             .map(|s| !FALSE_VALUES.contains(&s.to_lowercase().as_str()))
             .unwrap_or(true);
 
+        let scroll_wheel_mapped = cfg.mapped_keys.contains(&OsCode::MouseWheelUp)
+            || cfg.mapped_keys.contains(&OsCode::MouseWheelDown)
+            || cfg.mapped_keys.contains(&OsCode::MouseWheelLeft)
+            || cfg.mapped_keys.contains(&OsCode::MouseWheelRight);
+
         *MAPPED_KEYS.lock() = cfg.mapped_keys;
 
         Ok(Self {
@@ -392,6 +398,7 @@ impl Kanata {
             waiting_for_idle: HashSet::default(),
             ticks_since_idle: 0,
             movemouse_buffer: None,
+            scroll_wheel_mapped,
         })
     }
 
@@ -436,6 +443,10 @@ impl Kanata {
             .get("movemouse-inherit-accel-state")
             .map(|s| TRUE_VALUES.contains(&s.to_lowercase().as_str()))
             .unwrap_or_default();
+        self.scroll_wheel_mapped = cfg.mapped_keys.contains(&OsCode::MouseWheelUp)
+            || cfg.mapped_keys.contains(&OsCode::MouseWheelDown)
+            || cfg.mapped_keys.contains(&OsCode::MouseWheelLeft)
+            || cfg.mapped_keys.contains(&OsCode::MouseWheelRight);
         *MAPPED_KEYS.lock() = cfg.mapped_keys;
         Kanata::set_repeat_rate(&cfg.items)?;
         log::info!("Live reload successful");

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -38,12 +38,7 @@ impl Kanata {
         if mouse_to_intercept_hwid.is_some() {
             intrcptn.set_filter(
                 ic::is_mouse,
-                ic::Filter::MouseFilter(
-                    ic::MouseState::all()
-                        & (!ic::MouseState::WHEEL)
-                        & (!ic::MouseState::HWHEEL)
-                        & (!ic::MouseState::MOVE),
-                ),
+                ic::Filter::MouseFilter(ic::MouseState::all() & (!ic::MouseState::MOVE)),
             );
         }
         let mut is_dev_interceptable: HashMap<ic::Device, bool> = HashMap::default();
@@ -199,7 +194,7 @@ fn mouse_state_to_event(
         } else {
             OsCode::MouseWheelDown
         };
-        if !MAPPED_KEYS.lock().contains(&osc) {
+        if MAPPED_KEYS.lock().contains(&osc) {
             Some(KeyEvent {
                 code: osc,
                 value: KeyValue::Tap,
@@ -213,7 +208,7 @@ fn mouse_state_to_event(
         } else {
             OsCode::MouseWheelLeft
         };
-        if !MAPPED_KEYS.lock().contains(&osc) {
+        if MAPPED_KEYS.lock().contains(&osc) {
             Some(KeyEvent {
                 code: osc,
                 value: KeyValue::Tap,

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -292,9 +292,9 @@ impl TryFrom<InputEvent> for SupportedInputEvent {
                     ),
                     (RelativeAxisType::REL_HWHEEL, dist) => (
                         if dist > 0 {
-                            MWheelDirection::Left
-                        } else {
                             MWheelDirection::Right
+                        } else {
+                            MWheelDirection::Left
                         },
                         ScrollEventKind::Standard,
                     ),
@@ -308,9 +308,9 @@ impl TryFrom<InputEvent> for SupportedInputEvent {
                     ),
                     (RelativeAxisType::REL_HWHEEL_HI_RES, dist) => (
                         if dist > 0 {
-                            MWheelDirection::Left
-                        } else {
                             MWheelDirection::Right
+                        } else {
+                            MWheelDirection::Left
                         },
                         ScrollEventKind::HiRes,
                     ),

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -284,33 +284,33 @@ impl TryFrom<InputEvent> for SupportedInputEvent {
                 let (direction, kind) = match (axis_type, item.value()) {
                     (RelativeAxisType::REL_WHEEL, dist) => (
                         if dist > 0 {
-                            MoveDirection::Up
+                            MWheelDirection::Up
                         } else {
-                            MoveDirection::Down
+                            MWheelDirection::Down
                         },
                         ScrollEventKind::Standard,
                     ),
                     (RelativeAxisType::REL_HWHEEL, dist) => (
                         if dist > 0 {
-                            MoveDirection::Left
+                            MWheelDirection::Left
                         } else {
-                            MoveDirection::Right
+                            MWheelDirection::Right
                         },
                         ScrollEventKind::Standard,
                     ),
                     (RelativeAxisType::REL_WHEEL_HI_RES, dist) => (
                         if dist > 0 {
-                            MoveDirection::Up
+                            MWheelDirection::Up
                         } else {
-                            MoveDirection::Down
+                            MWheelDirection::Down
                         },
                         ScrollEventKind::HiRes,
                     ),
                     (RelativeAxisType::REL_HWHEEL_HI_RES, dist) => (
                         if dist > 0 {
-                            MoveDirection::Left
+                            MWheelDirection::Left
                         } else {
-                            MoveDirection::Right
+                            MWheelDirection::Right
                         },
                         ScrollEventKind::HiRes,
                     ),

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -271,32 +271,18 @@ impl TryFrom<InputEvent> for KeyEvent {
             evdev::InputEventKind::RelAxis(axis_type) => {
                 let dist = item.value();
                 let code: OsCode = match axis_type {
-                    RelativeAxisType::REL_WHEEL => {
+                    RelativeAxisType::REL_WHEEL | RelativeAxisType::REL_WHEEL_HI_RES => {
                         if dist > 0 {
                             MouseWheelUp
                         } else {
                             MouseWheelDown
                         }
                     }
-                    RelativeAxisType::REL_HWHEEL => {
+                    RelativeAxisType::REL_HWHEEL | RelativeAxisType::REL_HWHEEL_HI_RES => {
                         if dist > 0 {
                             MouseWheelRight
                         } else {
                             MouseWheelLeft
-                        }
-                    }
-                    RelativeAxisType::REL_WHEEL_HI_RES => {
-                        if dist > 0 {
-                            MouseWheelUpHiRes
-                        } else {
-                            MouseWheelDownHiRes
-                        }
-                    }
-                    RelativeAxisType::REL_HWHEEL_HI_RES => {
-                        if dist > 0 {
-                            MouseWheelRightHiRes
-                        } else {
-                            MouseWheelLeftHiRes
                         }
                     }
                     _ => return Err(()),

--- a/src/oskbd/mod.rs
+++ b/src/oskbd/mod.rs
@@ -17,6 +17,7 @@ pub enum KeyValue {
     Release = 0,
     Press = 1,
     Repeat = 2,
+    Tap,
 }
 
 impl From<i32> for KeyValue {
@@ -94,4 +95,17 @@ impl TryFrom<ScrollEvent> for OsCode {
 pub enum SupportedInputEvent {
     KeyEvent(KeyEvent),
     ScrollEvent(ScrollEvent),
+}
+
+impl TryFrom<SupportedInputEvent> for KeyEvent {
+    type Error = ();
+    fn try_from(value: SupportedInputEvent) -> Result<Self, Self::Error> {
+        Ok(match value {
+            SupportedInputEvent::KeyEvent(kev) => kev,
+            SupportedInputEvent::ScrollEvent(sev) => KeyEvent {
+                code: sev.try_into()?,
+                value: KeyValue::Tap,
+            },
+        })
+    }
 }

--- a/src/oskbd/mod.rs
+++ b/src/oskbd/mod.rs
@@ -45,7 +45,7 @@ impl From<KeyValue> for bool {
     }
 }
 
-use kanata_parser::{custom_action::MoveDirection, keys::OsCode};
+use kanata_parser::{custom_action::MWheelDirection, keys::OsCode};
 
 #[derive(Debug, Clone, Copy)]
 pub struct KeyEvent {
@@ -69,7 +69,7 @@ pub enum ScrollEventKind {
 #[derive(Debug, Clone, Copy)]
 pub struct ScrollEvent {
     pub kind: ScrollEventKind,
-    pub direction: MoveDirection,
+    pub direction: MWheelDirection,
     /// Unit: scroll notches if ScrollEventKind::Standard or
     /// scroll notches * 120 if ScrollEventKind::HiRes
     pub distance: u32,
@@ -80,10 +80,10 @@ impl TryFrom<ScrollEvent> for OsCode {
     fn try_from(value: ScrollEvent) -> Result<Self, Self::Error> {
         match value.kind {
             ScrollEventKind::Standard => Ok(match value.direction {
-                MoveDirection::Up => OsCode::MouseWheelUp,
-                MoveDirection::Down => OsCode::MouseWheelDown,
-                MoveDirection::Left => OsCode::MouseWheelLeft,
-                MoveDirection::Right => OsCode::MouseWheelRight,
+                MWheelDirection::Up => OsCode::MouseWheelUp,
+                MWheelDirection::Down => OsCode::MouseWheelDown,
+                MWheelDirection::Left => OsCode::MouseWheelLeft,
+                MWheelDirection::Right => OsCode::MouseWheelRight,
             }),
             ScrollEventKind::HiRes => Err(()),
         }

--- a/src/oskbd/mod.rs
+++ b/src/oskbd/mod.rs
@@ -91,21 +91,17 @@ impl TryFrom<ScrollEvent> for OsCode {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum SupportedInputEvent {
-    KeyEvent(KeyEvent),
-    ScrollEvent(ScrollEvent),
-}
-
-impl TryFrom<SupportedInputEvent> for KeyEvent {
+impl TryFrom<OsCode> for ScrollEventKind {
     type Error = ();
-    fn try_from(value: SupportedInputEvent) -> Result<Self, Self::Error> {
+    fn try_from(value: OsCode) -> Result<Self, Self::Error> {
+        use OsCode::*;
         Ok(match value {
-            SupportedInputEvent::KeyEvent(kev) => kev,
-            SupportedInputEvent::ScrollEvent(sev) => KeyEvent {
-                code: sev.try_into()?,
-                value: KeyValue::Tap,
-            },
+            MouseWheelUp | MouseWheelDown | MouseWheelLeft | MouseWheelRight => {
+                ScrollEventKind::Standard
+            }
+            MouseWheelUpHiRes | MouseWheelDownHiRes | MouseWheelLeftHiRes
+            | MouseWheelRightHiRes => ScrollEventKind::HiRes,
+            _ => return Err(()),
         })
     }
 }

--- a/src/oskbd/mod.rs
+++ b/src/oskbd/mod.rs
@@ -79,14 +79,12 @@ impl TryFrom<ScrollEvent> for OsCode {
     type Error = ();
     fn try_from(value: ScrollEvent) -> Result<Self, Self::Error> {
         match value.kind {
-            ScrollEventKind::Standard => {
-                Ok(match value.direction {
-                    MoveDirection::Up => OsCode::MouseWheelUp,
-                    MoveDirection::Down => OsCode::MouseWheelDown,
-                    MoveDirection::Left => OsCode::MouseWheelLeft,
-                    MoveDirection::Right => OsCode::MouseWheelRight,
-                })
-            }
+            ScrollEventKind::Standard => Ok(match value.direction {
+                MoveDirection::Up => OsCode::MouseWheelUp,
+                MoveDirection::Down => OsCode::MouseWheelDown,
+                MoveDirection::Left => OsCode::MouseWheelLeft,
+                MoveDirection::Right => OsCode::MouseWheelRight,
+            }),
             ScrollEventKind::HiRes => Err(()),
         }
     }

--- a/src/oskbd/mod.rs
+++ b/src/oskbd/mod.rs
@@ -67,30 +67,6 @@ pub enum ScrollEventKind {
     HiRes,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct ScrollEvent {
-    pub kind: ScrollEventKind,
-    pub direction: MWheelDirection,
-    /// Unit: scroll notches if ScrollEventKind::Standard or
-    /// scroll notches * 120 if ScrollEventKind::HiRes
-    pub distance: u32,
-}
-
-impl TryFrom<ScrollEvent> for OsCode {
-    type Error = ();
-    fn try_from(value: ScrollEvent) -> Result<Self, Self::Error> {
-        match value.kind {
-            ScrollEventKind::Standard => Ok(match value.direction {
-                MWheelDirection::Up => OsCode::MouseWheelUp,
-                MWheelDirection::Down => OsCode::MouseWheelDown,
-                MWheelDirection::Left => OsCode::MouseWheelLeft,
-                MWheelDirection::Right => OsCode::MouseWheelRight,
-            }),
-            ScrollEventKind::HiRes => Err(()),
-        }
-    }
-}
-
 impl TryFrom<OsCode> for ScrollEventKind {
     type Error = ();
     fn try_from(value: OsCode) -> Result<Self, Self::Error> {

--- a/src/oskbd/mod.rs
+++ b/src/oskbd/mod.rs
@@ -46,7 +46,7 @@ impl From<KeyValue> for bool {
     }
 }
 
-use kanata_parser::{custom_action::MWheelDirection, keys::OsCode};
+use kanata_parser::keys::OsCode;
 
 #[derive(Debug, Clone, Copy)]
 pub struct KeyEvent {
@@ -58,26 +58,5 @@ pub struct KeyEvent {
 impl KeyEvent {
     pub fn new(code: OsCode, value: KeyValue) -> Self {
         Self { code, value }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum ScrollEventKind {
-    Standard,
-    HiRes,
-}
-
-impl TryFrom<OsCode> for ScrollEventKind {
-    type Error = ();
-    fn try_from(value: OsCode) -> Result<Self, Self::Error> {
-        use OsCode::*;
-        Ok(match value {
-            MouseWheelUp | MouseWheelDown | MouseWheelLeft | MouseWheelRight => {
-                ScrollEventKind::Standard
-            }
-            MouseWheelUpHiRes | MouseWheelDownHiRes | MouseWheelLeftHiRes
-            | MouseWheelRightHiRes => ScrollEventKind::HiRes,
-            _ => return Err(()),
-        })
     }
 }

--- a/src/oskbd/mod.rs
+++ b/src/oskbd/mod.rs
@@ -80,14 +80,14 @@ impl TryFrom<ScrollEvent> for OsCode {
     fn try_from(value: ScrollEvent) -> Result<Self, Self::Error> {
         match value.kind {
             ScrollEventKind::Standard => {
-                return Ok(match value.direction {
+                Ok(match value.direction {
                     MoveDirection::Up => OsCode::MouseWheelUp,
                     MoveDirection::Down => OsCode::MouseWheelDown,
                     MoveDirection::Left => OsCode::MouseWheelLeft,
                     MoveDirection::Right => OsCode::MouseWheelRight,
                 })
             }
-            ScrollEventKind::HiRes => return Err(()),
+            ScrollEventKind::HiRes => Err(()),
         }
     }
 }

--- a/src/oskbd/mod.rs
+++ b/src/oskbd/mod.rs
@@ -45,7 +45,7 @@ impl From<KeyValue> for bool {
     }
 }
 
-use kanata_parser::keys::OsCode;
+use kanata_parser::{custom_action::MoveDirection, keys::OsCode};
 
 #[derive(Debug, Clone, Copy)]
 pub struct KeyEvent {
@@ -58,4 +58,42 @@ impl KeyEvent {
     pub fn new(code: OsCode, value: KeyValue) -> Self {
         Self { code, value }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ScrollEventKind {
+    Standard,
+    HiRes,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ScrollEvent {
+    pub kind: ScrollEventKind,
+    pub direction: MoveDirection,
+    /// Unit: scroll notches if ScrollEventKind::Standard or
+    /// scroll notches * 120 if ScrollEventKind::HiRes
+    pub distance: u32,
+}
+
+impl TryFrom<ScrollEvent> for OsCode {
+    type Error = ();
+    fn try_from(value: ScrollEvent) -> Result<Self, Self::Error> {
+        match value.kind {
+            ScrollEventKind::Standard => {
+                return Ok(match value.direction {
+                    MoveDirection::Up => OsCode::MouseWheelUp,
+                    MoveDirection::Down => OsCode::MouseWheelDown,
+                    MoveDirection::Left => OsCode::MouseWheelLeft,
+                    MoveDirection::Right => OsCode::MouseWheelRight,
+                })
+            }
+            ScrollEventKind::HiRes => return Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SupportedInputEvent {
+    KeyEvent(KeyEvent),
+    ScrollEvent(ScrollEvent),
 }

--- a/src/oskbd/windows/interception.rs
+++ b/src/oskbd/windows/interception.rs
@@ -24,6 +24,7 @@ impl InputEvent {
                     match val {
                         KeyValue::Press | KeyValue::Repeat => KeyState::DOWN,
                         KeyValue::Release => KeyState::UP,
+                        KeyValue::Tap => panic!("invalid value attempted to be sent"),
                     },
                     true,
                 );

--- a/src/oskbd/windows/mod.rs
+++ b/src/oskbd/windows/mod.rs
@@ -20,6 +20,8 @@ pub use self::interception::*;
 #[cfg(feature = "interception_driver")]
 pub use interception_convert::*;
 
+pub const HI_RES_SCROLL_UNITS_IN_LO_RES: u16 = 120;
+
 fn send_uc(c: char, up: bool) {
     log::debug!("sending unicode {c}");
     let mut inputs: [INPUT; 2] = unsafe { mem::zeroed() };
@@ -54,6 +56,7 @@ fn write_code(code: u16, value: KeyValue) -> Result<(), std::io::Error> {
         match value {
             KeyValue::Press | KeyValue::Repeat => false,
             KeyValue::Release => true,
+            KeyValue::Tap => panic!("invalid value attempted to be sent"),
         },
     );
     Ok(())


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Closes https://github.com/jtroo/kanata/issues/553

- For now, implemented only for Linux 
- Allows adding scroll events to `defsrc`
- (Currently) adding any of the new scroll labels to `deflayer` or anywhere else don't error and just outputs nothing. 
- Tested manually, appears functonal.

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
