### PR TITLE
feat!: add configurable limit to dynamic macro

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -169,6 +169,10 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;;
   ;; movemouse-smooth-diagonals yes
 
+  ;; This configuration allows you to customize the length limit on dynamic macros.
+  ;; The default limit is 128 keys.
+  ;;
+  ;; dynamic-macro-max-presses 1000
 )
 
 ;; deflocalkeys-* enables you to define and use key names that match your locale

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -431,6 +431,20 @@ synchronize the mouse movements.
 )
 ----
 
+=== dynamic-macro-max-presses [[dynamic-macro-max-presses]]
+<<table-of-contents,Back to ToC>>
+
+This configuration allows you to customize the length limit on dynamic macros.
+The default length limit is 128 keys.
+
+.Example:
+[source]
+----
+(defcfg
+  dynamic-macro-max-presses 1000
+)
+----
+
 [[linux-only-linux-dev]]
 === Linux only: linux-dev
 <<table-of-contents,Back to ToC>>
@@ -676,6 +690,7 @@ a non-applicable operating system.
   delegate-to-first-layer yes
   movemouse-inherit-accel-state yes
   movemouse-smooth-diagonals yes
+  dynamic-macro-max-presses 1000
   linux-dev /dev/input/dev1:/dev/input/dev2
   linux-dev-names-include "Name 1:Name 2"
   linux-dev-names-exclude "Name 3:Name 4"

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -739,6 +739,7 @@ fn parse_defcfg(expr: &[SExpr]) -> Result<HashMap<String, String>> {
     let non_bool_cfg_keys = &[
         "sequence-timeout",
         "sequence-input-mode",
+        "dynamic-macro-max-presses",
         "linux-dev",
         "linux-dev-names-include",
         "linux-dev-names-exclude",


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
 Add a configurable limit to dynamic macro recording length. The default is 128 keys. This commit closes #595.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
