### PR TITLE
refactor: validate defcfg values in parser

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -707,7 +707,7 @@ a non-applicable operating system.
   linux-dev /dev/input/dev1:/dev/input/dev2
   linux-dev-names-include "Name 1:Name 2"
   linux-dev-names-exclude "Name 3:Name 4"
-  linux-continue-if-no-dev-found yes
+  linux-continue-if-no-devs-found yes
   linux-unicode-u-code v
   linux-unicode-termination space
   linux-x11-repeat-delay-rate 400,50

--- a/keyberon/src/action/switch.rs
+++ b/keyberon/src/action/switch.rs
@@ -278,13 +278,12 @@ fn bool_evaluation_test_0() {
         OpCode::new_key(KeyCode::F),
     ];
     let keycodes = [KeyCode::A, KeyCode::B, KeyCode::D, KeyCode::F];
-    assert_eq!(
+    assert!(
         evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        true
+        )
     );
 }
 
@@ -309,13 +308,12 @@ fn bool_evaluation_test_1() {
         KeyCode::E,
         KeyCode::F,
     ];
-    assert_eq!(
+    assert!(
         evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        true
+        )
     );
 }
 
@@ -333,13 +331,12 @@ fn bool_evaluation_test_2() {
         OpCode(KeyCode::F as u16),
     ];
     let keycodes = [KeyCode::A, KeyCode::B, KeyCode::E, KeyCode::F];
-    assert_eq!(
-        evaluate_boolean(
+    assert!(
+        !evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        false
+        )
     );
 }
 
@@ -357,13 +354,12 @@ fn bool_evaluation_test_3() {
         OpCode(KeyCode::F as u16),
     ];
     let keycodes = [KeyCode::B, KeyCode::C, KeyCode::D, KeyCode::E, KeyCode::F];
-    assert_eq!(
-        evaluate_boolean(
+    assert!(
+        !evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        false
+        )
     );
 }
 
@@ -371,13 +367,12 @@ fn bool_evaluation_test_3() {
 fn bool_evaluation_test_4() {
     let opcodes = [];
     let keycodes = [];
-    assert_eq!(
+    assert!(
         evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        true
+        )
     );
 }
 
@@ -392,13 +387,12 @@ fn bool_evaluation_test_5() {
         KeyCode::E,
         KeyCode::F,
     ];
-    assert_eq!(
+    assert!(
         evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        true
+        )
     );
 }
 
@@ -413,13 +407,12 @@ fn bool_evaluation_test_6() {
         KeyCode::E,
         KeyCode::F,
     ];
-    assert_eq!(
+    assert!(
         evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        true
+        )
     );
 }
 
@@ -427,13 +420,12 @@ fn bool_evaluation_test_6() {
 fn bool_evaluation_test_7() {
     let opcodes = [OpCode(KeyCode::A as u16), OpCode(KeyCode::B as u16)];
     let keycodes = [KeyCode::C, KeyCode::D, KeyCode::E, KeyCode::F];
-    assert_eq!(
-        evaluate_boolean(
+    assert!(
+        !evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        false
+        )
     );
 }
 
@@ -446,13 +438,12 @@ fn bool_evaluation_test_9() {
         OpCode(KeyCode::C as u16),
     ];
     let keycodes = [KeyCode::C, KeyCode::D, KeyCode::E, KeyCode::F];
-    assert_eq!(
+    assert!(
         evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        true
+        )
     );
 }
 
@@ -465,13 +456,12 @@ fn bool_evaluation_test_10() {
         OpCode(KeyCode::C as u16),
     ];
     let keycodes = [KeyCode::C, KeyCode::D, KeyCode::E, KeyCode::F];
-    assert_eq!(
-        evaluate_boolean(
+    assert!(
+        !evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        false
+        )
     );
 }
 
@@ -483,13 +473,12 @@ fn bool_evaluation_test_11() {
         OpCode(KeyCode::B as u16),
     ];
     let keycodes = [KeyCode::C, KeyCode::D, KeyCode::E, KeyCode::F];
-    assert_eq!(
-        evaluate_boolean(
+    assert!(
+        !evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        false
+        )
     );
 }
 
@@ -503,13 +492,12 @@ fn bool_evaluation_test_12() {
         OpCode(KeyCode::C as u16),
     ];
     let keycodes = [KeyCode::C, KeyCode::D, KeyCode::E, KeyCode::F];
-    assert_eq!(
+    assert!(
         evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        true
+        )
     );
 }
 
@@ -526,13 +514,12 @@ fn bool_evaluation_test_max_depth_does_not_panic() {
         OpCode(0x1008),
     ];
     let keycodes = [];
-    assert_eq!(
+    assert!(
         evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        true
+        )
     );
 }
 
@@ -551,13 +538,12 @@ fn bool_evaluation_test_more_than_max_depth_panics() {
         OpCode(0x1009),
     ];
     let keycodes = [];
-    assert_eq!(
+    assert!(
         evaluate_boolean(
             opcodes.as_slice(),
             keycodes.iter().copied(),
             [].iter().copied()
-        ),
-        true
+        )
     );
 }
 
@@ -632,37 +618,33 @@ fn switch_historical_1() {
         KeyCode::G,
         KeyCode::H,
     ];
-    assert_eq!(
+    assert!(
         evaluate_boolean(
             opcode_true.as_slice(),
             [].iter().copied(),
             hist_keycodes.iter().copied(),
-        ),
-        true
+        )
     );
-    assert_eq!(
+    assert!(
         evaluate_boolean(
             opcode_true2.as_slice(),
             [].iter().copied(),
             hist_keycodes.iter().copied(),
-        ),
-        true
+        )
     );
-    assert_eq!(
-        evaluate_boolean(
+    assert!(
+        !evaluate_boolean(
             opcode_false.as_slice(),
             [].iter().copied(),
             hist_keycodes.iter().copied(),
-        ),
-        false
+        )
     );
-    assert_eq!(
-        evaluate_boolean(
+    assert!(
+        !evaluate_boolean(
             opcode_false2.as_slice(),
             [].iter().copied(),
             hist_keycodes.iter().copied(),
-        ),
-        false
+        )
     );
 }
 

--- a/keyberon/src/action/switch.rs
+++ b/keyberon/src/action/switch.rs
@@ -278,13 +278,11 @@ fn bool_evaluation_test_0() {
         OpCode::new_key(KeyCode::F),
     ];
     let keycodes = [KeyCode::A, KeyCode::B, KeyCode::D, KeyCode::F];
-    assert!(
-        evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
@@ -308,13 +306,11 @@ fn bool_evaluation_test_1() {
         KeyCode::E,
         KeyCode::F,
     ];
-    assert!(
-        evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
@@ -331,13 +327,11 @@ fn bool_evaluation_test_2() {
         OpCode(KeyCode::F as u16),
     ];
     let keycodes = [KeyCode::A, KeyCode::B, KeyCode::E, KeyCode::F];
-    assert!(
-        !evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(!evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
@@ -354,26 +348,22 @@ fn bool_evaluation_test_3() {
         OpCode(KeyCode::F as u16),
     ];
     let keycodes = [KeyCode::B, KeyCode::C, KeyCode::D, KeyCode::E, KeyCode::F];
-    assert!(
-        !evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(!evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
 fn bool_evaluation_test_4() {
     let opcodes = [];
     let keycodes = [];
-    assert!(
-        evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
@@ -387,13 +377,11 @@ fn bool_evaluation_test_5() {
         KeyCode::E,
         KeyCode::F,
     ];
-    assert!(
-        evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
@@ -407,26 +395,22 @@ fn bool_evaluation_test_6() {
         KeyCode::E,
         KeyCode::F,
     ];
-    assert!(
-        evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
 fn bool_evaluation_test_7() {
     let opcodes = [OpCode(KeyCode::A as u16), OpCode(KeyCode::B as u16)];
     let keycodes = [KeyCode::C, KeyCode::D, KeyCode::E, KeyCode::F];
-    assert!(
-        !evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(!evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
@@ -438,13 +422,11 @@ fn bool_evaluation_test_9() {
         OpCode(KeyCode::C as u16),
     ];
     let keycodes = [KeyCode::C, KeyCode::D, KeyCode::E, KeyCode::F];
-    assert!(
-        evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
@@ -456,13 +438,11 @@ fn bool_evaluation_test_10() {
         OpCode(KeyCode::C as u16),
     ];
     let keycodes = [KeyCode::C, KeyCode::D, KeyCode::E, KeyCode::F];
-    assert!(
-        !evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(!evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
@@ -473,13 +453,11 @@ fn bool_evaluation_test_11() {
         OpCode(KeyCode::B as u16),
     ];
     let keycodes = [KeyCode::C, KeyCode::D, KeyCode::E, KeyCode::F];
-    assert!(
-        !evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(!evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
@@ -492,13 +470,11 @@ fn bool_evaluation_test_12() {
         OpCode(KeyCode::C as u16),
     ];
     let keycodes = [KeyCode::C, KeyCode::D, KeyCode::E, KeyCode::F];
-    assert!(
-        evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
@@ -514,13 +490,11 @@ fn bool_evaluation_test_max_depth_does_not_panic() {
         OpCode(0x1008),
     ];
     let keycodes = [];
-    assert!(
-        evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
@@ -538,13 +512,11 @@ fn bool_evaluation_test_more_than_max_depth_panics() {
         OpCode(0x1009),
     ];
     let keycodes = [];
-    assert!(
-        evaluate_boolean(
-            opcodes.as_slice(),
-            keycodes.iter().copied(),
-            [].iter().copied()
-        )
-    );
+    assert!(evaluate_boolean(
+        opcodes.as_slice(),
+        keycodes.iter().copied(),
+        [].iter().copied()
+    ));
 }
 
 #[test]
@@ -618,34 +590,26 @@ fn switch_historical_1() {
         KeyCode::G,
         KeyCode::H,
     ];
-    assert!(
-        evaluate_boolean(
-            opcode_true.as_slice(),
-            [].iter().copied(),
-            hist_keycodes.iter().copied(),
-        )
-    );
-    assert!(
-        evaluate_boolean(
-            opcode_true2.as_slice(),
-            [].iter().copied(),
-            hist_keycodes.iter().copied(),
-        )
-    );
-    assert!(
-        !evaluate_boolean(
-            opcode_false.as_slice(),
-            [].iter().copied(),
-            hist_keycodes.iter().copied(),
-        )
-    );
-    assert!(
-        !evaluate_boolean(
-            opcode_false2.as_slice(),
-            [].iter().copied(),
-            hist_keycodes.iter().copied(),
-        )
-    );
+    assert!(evaluate_boolean(
+        opcode_true.as_slice(),
+        [].iter().copied(),
+        hist_keycodes.iter().copied(),
+    ));
+    assert!(evaluate_boolean(
+        opcode_true2.as_slice(),
+        [].iter().copied(),
+        hist_keycodes.iter().copied(),
+    ));
+    assert!(!evaluate_boolean(
+        opcode_false.as_slice(),
+        [].iter().copied(),
+        hist_keycodes.iter().copied(),
+    ));
+    assert!(!evaluate_boolean(
+        opcode_false2.as_slice(),
+        [].iter().copied(),
+        hist_keycodes.iter().copied(),
+    ));
 }
 
 #[test]

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -71,7 +71,7 @@ impl Default for CfgOptions {
             #[cfg(any(target_os = "linux", target_os = "unknown"))]
             linux_x11_repeat_delay_rate: None,
             #[cfg(any(target_os = "windows", target_os = "unknown"))]
-            windows_altgr: AltGrBehaviour::DoNothing,
+            windows_altgr: AltGrBehaviour::default(),
             #[cfg(any(
                 all(feature = "interception_driver", target_os = "windows"),
                 target_os = "unknown"
@@ -333,3 +333,8 @@ pub enum AltGrBehaviour {
     AddLctlRelease,
 }
 
+impl Default for AltGrBehaviour {
+    fn default() -> Self {
+        Self::DoNothing
+    }
+}

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -1,0 +1,322 @@
+use super::error::*;
+use super::sexpr::SExpr;
+use super::HashSet;
+use crate::cfg::check_first_expr;
+use crate::cfg::parse_colon_separated_text;
+use crate::cfg::KeyRepeatSettings;
+use crate::custom_action::*;
+use crate::keys::*;
+use crate::{anyhow_expr, anyhow_span, bail, bail_expr};
+
+#[derive(Debug)]
+pub struct CfgOptions {
+    pub process_unmapped_keys: bool,
+    pub enable_cmd: bool,
+    pub sequence_timeout: u16,
+    pub sequence_input_mode: SequenceInputMode,
+    pub sequence_backtrack_modcancel: bool,
+    pub log_layer_changes: bool,
+    pub delegate_to_first_layer: bool,
+    pub movemouse_inherit_accel_state: bool,
+    pub movemouse_smooth_diagonals: bool,
+    pub dynamic_macro_max_presses: u16,
+    #[cfg(any(target_os = "linux", target_os = "unknown"))]
+    pub linux_dev: Vec<String>,
+    #[cfg(any(target_os = "linux", target_os = "unknown"))]
+    pub linux_dev_names_include: Option<Vec<String>>,
+    #[cfg(any(target_os = "linux", target_os = "unknown"))]
+    pub linux_dev_names_exclude: Option<Vec<String>>,
+    #[cfg(any(target_os = "linux", target_os = "unknown"))]
+    pub linux_continue_if_no_devs_found: bool,
+    #[cfg(any(target_os = "linux", target_os = "unknown"))]
+    pub linux_unicode_u_code: OsCode,
+    #[cfg(any(target_os = "linux", target_os = "unknown"))]
+    pub linux_unicode_termination: UnicodeTermination,
+    #[cfg(any(target_os = "linux", target_os = "unknown"))]
+    pub linux_x11_repeat_delay_rate: Option<KeyRepeatSettings>,
+    #[cfg(any(target_os = "windows", target_os = "unknown"))]
+    pub windows_altgr: AltGrBehaviour,
+    #[cfg(any(
+        all(feature = "interception_driver", target_os = "windows"),
+        target_os = "unknown"
+    ))]
+    pub windows_interception_mouse_hwid: Option<[u8; HWID_ARR_SZ]>,
+}
+
+impl Default for CfgOptions {
+    fn default() -> Self {
+        Self {
+            process_unmapped_keys: false,
+            enable_cmd: false,
+            sequence_timeout: 1000,
+            sequence_input_mode: SequenceInputMode::HiddenSuppressed,
+            sequence_backtrack_modcancel: true,
+            log_layer_changes: true,
+            delegate_to_first_layer: false,
+            movemouse_inherit_accel_state: false,
+            movemouse_smooth_diagonals: false,
+            dynamic_macro_max_presses: 128,
+            #[cfg(any(target_os = "linux", target_os = "unknown"))]
+            linux_dev: vec![],
+            #[cfg(any(target_os = "linux", target_os = "unknown"))]
+            linux_dev_names_include: None,
+            #[cfg(any(target_os = "linux", target_os = "unknown"))]
+            linux_dev_names_exclude: None,
+            #[cfg(any(target_os = "linux", target_os = "unknown"))]
+            linux_continue_if_no_devs_found: false,
+            #[cfg(any(target_os = "linux", target_os = "unknown"))]
+            // historically was the only option, so make KEY_U the default
+            linux_unicode_u_code: OsCode::KEY_U,
+            #[cfg(any(target_os = "linux", target_os = "unknown"))]
+            // historically was the only option, so make Enter the default
+            linux_unicode_termination: UnicodeTermination::Enter,
+            #[cfg(any(target_os = "linux", target_os = "unknown"))]
+            linux_x11_repeat_delay_rate: None,
+            #[cfg(any(target_os = "windows", target_os = "unknown"))]
+            windows_altgr: AltGrBehaviour::DoNothing,
+            #[cfg(any(
+                all(feature = "interception_driver", target_os = "windows"),
+                target_os = "unknown"
+            ))]
+            windows_interception_mouse_hwid: None,
+        }
+    }
+}
+
+/// Parse configuration entries from an expression starting with defcfg.
+pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
+    let mut seen_keys = HashSet::default();
+    let mut cfg = CfgOptions::default();
+    let mut exprs = check_first_expr(expr.iter(), "defcfg")?;
+    // Read k-v pairs from the configuration
+    loop {
+        let key = match exprs.next() {
+            Some(k) => k,
+            None => return Ok(cfg),
+        };
+        let val = match exprs.next() {
+            Some(v) => v,
+            None => bail_expr!(key, "Found a defcfg option missing a value"),
+        };
+        match (&key, &val) {
+            (SExpr::Atom(k), SExpr::Atom(v)) => {
+                if !seen_keys.insert(&k.t) {
+                    bail_expr!(key, "Duplicate defcfg option {}", k.t);
+                }
+                match k.t.as_str() {
+                    k @ "sequence-timeout" => {
+                        cfg.sequence_timeout = parse_cfg_val_u16(val, k, true)?;
+                    }
+                    "sequence-input-mode" => {
+                        cfg.sequence_input_mode =
+                            SequenceInputMode::try_from_str(&v.t.trim_matches('"'))
+                                .map_err(|e| anyhow_expr!(val, "{}", e.to_string()))?;
+                    }
+                    k @ "dynamic-macro-max-presses" => {
+                        cfg.dynamic_macro_max_presses = parse_cfg_val_u16(val, k, false)?;
+                    }
+                    "linux-dev" => {
+                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+                        {
+                            let paths = v.t.trim_matches('"');
+                            cfg.linux_dev = parse_colon_separated_text(paths);
+                        }
+                    }
+                    "linux-dev-names-include" => {
+                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+                        {
+                            let paths = v.t.trim_matches('"');
+                            cfg.linux_dev_names_include = Some(parse_colon_separated_text(paths));
+                        }
+                    }
+                    "linux-dev-names-exclude" => {
+                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+                        {
+                            let paths = v.t.trim_matches('"');
+                            cfg.linux_dev_names_exclude = Some(parse_colon_separated_text(paths));
+                        }
+                    }
+                    _k @ "linux-unicode-u-code" => {
+                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+                        {
+                            cfg.linux_unicode_u_code = str_to_oscode(v.t.trim_matches('"'))
+                                .ok_or_else(|| {
+                                    anyhow_expr!(val, "unknown code for {_k}: {}", v.t)
+                                })?;
+                        }
+                    }
+                    _k @ "linux-unicode-termination" => {
+                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+                        {
+                            cfg.linux_unicode_termination = match v.t.trim_matches('"') {
+                                "enter" => UnicodeTermination::Enter,
+                                "space" => UnicodeTermination::Space,
+                                "enter-space" => UnicodeTermination::EnterSpace,
+                                "space-enter" => UnicodeTermination::SpaceEnter,
+                                _ => bail_expr!(
+                                    val,
+                                    "{_k} got {}. It accepts: enter|space|enter-space|space-enter",
+                                    v.t
+                                ),
+                            }
+                        }
+                    }
+                    _k @ "linux-x11-repeat-delay-rate" => {
+                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+                        {
+                            let delay_rate = v.t.trim_matches('"').split(',').collect::<Vec<_>>();
+                            let errmsg = anyhow_span!(v, "Invalid value for {_k}.\nExpected two numbers 0-65535 separated by a comma, e.g. 200,25");
+                            if delay_rate.len() != 2 {
+                                bail!("{:?}", errmsg)
+                            }
+                            cfg.linux_x11_repeat_delay_rate = Some(KeyRepeatSettings {
+                                delay: match str::parse::<u16>(delay_rate[0]) {
+                                    Ok(delay) => delay,
+                                    Err(_) => bail!("{:?}", errmsg),
+                                },
+                                rate: match str::parse::<u16>(delay_rate[0]) {
+                                    Ok(rate) => rate,
+                                    Err(_) => bail!("{:?}", errmsg),
+                                },
+                            });
+                        }
+                    }
+                    _k @ "windows-altgr" => {
+                        #[cfg(any(target_os = "windows", target_os = "unknown"))]
+                        {
+                            const CANCEL: &str = "cancel-lctl-press";
+                            const ADD: &str = "add-lctl-release";
+                            cfg.windows_altgr = match v.t.trim_matches('"') {
+                                CANCEL => AltGrBehaviour::CancelLctlPress,
+                                ADD => AltGrBehaviour::AddLctlRelease,
+                                _ => bail_expr!(
+                                    val,
+                                    "Invalid value for {_k}: {}. Valid values are {},{}",
+                                    v.t,
+                                    CANCEL,
+                                    ADD
+                                ),
+                            }
+                        }
+                    }
+                    _k @ "windows-interception-mouse-hwid" => {
+                        #[cfg(any(
+                            all(feature = "interception_driver", target_os = "windows"),
+                            target_os = "unknown"
+                        ))]
+                        {
+                            let hwid = v.t.trim_matches('"');
+                            log::trace!("win hwid: {hwid}");
+                            let hwid_vec = hwid
+                                .split_whitespace()
+                                .try_fold(vec![], |mut hwid_bytes, hwid_byte| {
+                                    hwid_byte.trim_matches(',').parse::<u8>().map(|b| {
+                                        hwid_bytes.push(b);
+                                        hwid_bytes
+                                    })
+                                }).map_err(|_| anyhow_expr!(val, "{_k} format is invalid. It should consist of integers separated by commas"))?;
+                            let hwid_slice = hwid_vec.iter().copied().enumerate()
+                                .try_fold([0u8; HWID_ARR_SZ], |mut hwid, idx_byte| {
+                                    let (i, b) = idx_byte;
+                                    if i > HWID_ARR_SZ {
+                                        bail_expr!(val, "{_k} is too long; it should be up to {HWID_ARR_SZ} 8-bit unsigned integers")
+                                    }
+                                    hwid[i] = b;
+                                    Ok(hwid)
+                            });
+                            cfg.windows_interception_mouse_hwid = Some(hwid_slice?);
+                        }
+                    }
+
+                    "process-unmapped-keys" => {
+                        cfg.process_unmapped_keys = parse_defcfg_val_bool(val, &k.t)?
+                    }
+                    "danger-enable-cmd" => cfg.enable_cmd = parse_defcfg_val_bool(val, &k.t)?,
+                    "sequence-backtrack-modcancel" => {
+                        cfg.sequence_backtrack_modcancel = parse_defcfg_val_bool(val, &k.t)?
+                    }
+                    "log-layer-changes" => {
+                        cfg.log_layer_changes = parse_defcfg_val_bool(val, &k.t)?
+                    }
+                    "delegate-to-first-layer" => {
+                        cfg.delegate_to_first_layer = parse_defcfg_val_bool(val, &k.t)?;
+                        if cfg.delegate_to_first_layer {
+                            log::info!("delegating transparent keys on other layers to first defined layer");
+                        }
+                    }
+                    "linux-continue-if-no-devs-found" => {
+                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+                        {
+                            cfg.linux_continue_if_no_devs_found = parse_defcfg_val_bool(val, &k.t)?
+                        }
+                    }
+                    "movemouse-smooth-diagonals" => {
+                        cfg.movemouse_smooth_diagonals = parse_defcfg_val_bool(val, &k.t)?
+                    }
+                    "movemouse-inherit-accel-state" => {
+                        cfg.movemouse_inherit_accel_state = parse_defcfg_val_bool(val, &k.t)?
+                    }
+                    _ => bail_expr!(key, "Unknown defcfg option {}", &k.t),
+                };
+            }
+            (SExpr::List(_), _) => {
+                bail_expr!(key, "Lists are not allowed in defcfg");
+            }
+            (_, SExpr::List(_)) => {
+                bail_expr!(val, "Lists are not allowed in defcfg");
+            }
+        }
+    }
+}
+
+pub const FALSE_VALUES: [&str; 3] = ["no", "false", "0"];
+pub const TRUE_VALUES: [&str; 3] = ["yes", "true", "1"];
+pub const BOOLEAN_VALUES: [&str; 6] = ["yes", "true", "1", "no", "false", "0"];
+
+fn parse_defcfg_val_bool(expr: &SExpr, label: &str) -> Result<bool> {
+    match &expr {
+        SExpr::Atom(v) => {
+            let val = v.t.trim_matches('"').to_ascii_lowercase();
+            if TRUE_VALUES.contains(&val.as_str()) {
+                Ok(true)
+            } else if FALSE_VALUES.contains(&val.as_str()) {
+                Ok(false)
+            } else {
+                bail_expr!(
+                    expr,
+                    "The value for {label} must be one of: {}",
+                    BOOLEAN_VALUES.join(", ")
+                );
+            }
+        }
+        SExpr::List(_) => {
+            bail_expr!(
+                expr,
+                "The value for {label} cannot be a list, it must be one of: {}",
+                BOOLEAN_VALUES.join(", "),
+            )
+        }
+    }
+}
+
+fn parse_cfg_val_u16(expr: &SExpr, label: &str, exclude_zero: bool) -> Result<u16> {
+    let start = if exclude_zero { 1 } else { 0 };
+    match &expr {
+        SExpr::Atom(v) => Ok(str::parse::<u16>(&v.t.trim_matches('"'))
+            .ok()
+            .and_then(|u| {
+                if exclude_zero && u == 0 {
+                    None
+                } else {
+                    Some(u)
+                }
+            })
+            .ok_or_else(|| anyhow_expr!(expr, "{label} must be {start}-65535"))?),
+        SExpr::List(_) => {
+            bail_expr!(
+                expr,
+                "The value for {label} cannot be a list, it must be a number {start}-65535",
+            )
+        }
+    }
+}

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -206,9 +206,9 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                             let hwid = v.t.trim_matches('"');
                             log::trace!("win hwid: {hwid}");
                             let hwid_vec = hwid
-                                .split_whitespace()
+                                .split(',')
                                 .try_fold(vec![], |mut hwid_bytes, hwid_byte| {
-                                    hwid_byte.trim_matches(',').parse::<u8>().map(|b| {
+                                    hwid_byte.trim_matches(' ').parse::<u8>().map(|b| {
                                         hwid_bytes.push(b);
                                         hwid_bytes
                                     })

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -3,9 +3,7 @@ use super::sexpr::SExpr;
 use super::HashSet;
 use crate::cfg::check_first_expr;
 use crate::cfg::parse_colon_separated_text;
-use crate::cfg::KeyRepeatSettings;
 use crate::custom_action::*;
-use crate::keys::*;
 use crate::{anyhow_expr, anyhow_span, bail, bail_expr};
 
 #[derive(Debug)]
@@ -320,3 +318,18 @@ fn parse_cfg_val_u16(expr: &SExpr, label: &str, exclude_zero: bool) -> Result<u1
         }
     }
 }
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct KeyRepeatSettings {
+    pub delay: u16,
+    pub rate: u16,
+}
+
+#[cfg(any(target_os = "windows", target_os = "unknown"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AltGrBehaviour {
+    DoNothing,
+    CancelLctlPress,
+    AddLctlRelease,
+}
+

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -1,9 +1,9 @@
 use super::error::*;
 use super::sexpr::SExpr;
 use super::HashSet;
-use crate::cfg::{check_first_expr, HWID_ARR_SZ};
+use crate::cfg::check_first_expr;
 use crate::custom_action::*;
-use crate::keys::{str_to_oscode, OsCode};
+#[allow(unused)]
 use crate::{anyhow_expr, anyhow_span, bail, bail_expr};
 
 #[derive(Debug)]
@@ -27,7 +27,7 @@ pub struct CfgOptions {
     #[cfg(any(target_os = "linux", target_os = "unknown"))]
     pub linux_continue_if_no_devs_found: bool,
     #[cfg(any(target_os = "linux", target_os = "unknown"))]
-    pub linux_unicode_u_code: OsCode,
+    pub linux_unicode_u_code: crate::keys::OsCode,
     #[cfg(any(target_os = "linux", target_os = "unknown"))]
     pub linux_unicode_termination: UnicodeTermination,
     #[cfg(any(target_os = "linux", target_os = "unknown"))]
@@ -64,7 +64,7 @@ impl Default for CfgOptions {
             linux_continue_if_no_devs_found: false,
             #[cfg(any(target_os = "linux", target_os = "unknown"))]
             // historically was the only option, so make KEY_U the default
-            linux_unicode_u_code: OsCode::KEY_U,
+            linux_unicode_u_code: crate::keys::OsCode::KEY_U,
             #[cfg(any(target_os = "linux", target_os = "unknown"))]
             // historically was the only option, so make Enter the default
             linux_unicode_termination: UnicodeTermination::Enter,
@@ -137,10 +137,10 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                     _k @ "linux-unicode-u-code" => {
                         #[cfg(any(target_os = "linux", target_os = "unknown"))]
                         {
-                            cfg.linux_unicode_u_code = str_to_oscode(v.t.trim_matches('"'))
-                                .ok_or_else(|| {
-                                    anyhow_expr!(val, "unknown code for {_k}: {}", v.t)
-                                })?;
+                            cfg.linux_unicode_u_code = crate::keys::str_to_oscode(
+                                v.t.trim_matches('"'),
+                            )
+                            .ok_or_else(|| anyhow_expr!(val, "unknown code for {_k}: {}", v.t))?;
                         }
                     }
                     _k @ "linux-unicode-termination" => {
@@ -368,3 +368,9 @@ impl Default for AltGrBehaviour {
         Self::DoNothing
     }
 }
+
+#[cfg(any(
+    all(feature = "interception_driver", target_os = "windows"),
+    target_os = "unknown"
+))]
+pub const HWID_ARR_SZ: usize = 128;

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -159,22 +159,22 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                             }
                         }
                     }
-                    _k @ "linux-x11-repeat-delay-rate" => {
+                    "linux-x11-repeat-delay-rate" => {
                         #[cfg(any(target_os = "linux", target_os = "unknown"))]
                         {
                             let delay_rate = v.t.trim_matches('"').split(',').collect::<Vec<_>>();
-                            let errmsg = anyhow_span!(v, "Invalid value for {_k}.\nExpected two numbers 0-65535 separated by a comma, e.g. 200,25");
+                            const ERRMSG: &str = "Invalid value for linux-x11-repeat-delay-rate.\nExpected two numbers 0-65535 separated by a comma, e.g. 200,25";
                             if delay_rate.len() != 2 {
-                                bail!("{:?}", errmsg)
+                                bail_expr!(val, "{}", ERRMSG)
                             }
                             cfg.linux_x11_repeat_delay_rate = Some(KeyRepeatSettings {
                                 delay: match str::parse::<u16>(delay_rate[0]) {
                                     Ok(delay) => delay,
-                                    Err(_) => bail!("{:?}", errmsg),
+                                    Err(_) => bail_expr!(val, "{}", ERRMSG),
                                 },
-                                rate: match str::parse::<u16>(delay_rate[0]) {
+                                rate: match str::parse::<u16>(delay_rate[1]) {
                                     Ok(rate) => rate,
-                                    Err(_) => bail!("{:?}", errmsg),
+                                    Err(_) => bail_expr!(val, "{}", ERRMSG),
                                 },
                             });
                         }

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -3072,25 +3072,6 @@ fn create_key_outputs(layers: &KanataLayers, overrides: &Overrides) -> KeyOutput
     outs
 }
 
-pub fn parse_colon_separated_text(paths: &str) -> Vec<String> {
-    let mut all_paths = vec![];
-    let mut full_dev_path = String::new();
-    let mut dev_path_iter = paths.split(':').peekable();
-    while let Some(dev_path) = dev_path_iter.next() {
-        if dev_path.ends_with('\\') && dev_path_iter.peek().is_some() {
-            full_dev_path.push_str(dev_path.trim_end_matches('\\'));
-            full_dev_path.push(':');
-            continue;
-        } else {
-            full_dev_path.push_str(dev_path);
-        }
-        all_paths.push(full_dev_path.clone());
-        full_dev_path.clear();
-    }
-    all_paths.shrink_to_fit();
-    all_paths
-}
-
 fn add_key_output_from_action_to_key_pos(
     osc_slot: OsCode,
     action: &KanataAction,

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -51,6 +51,9 @@ use custom_tap_hold::*;
 mod list_actions;
 use list_actions::*;
 
+mod defcfg;
+use defcfg::*;
+
 use crate::custom_action::*;
 use crate::keys::*;
 use crate::layers::*;
@@ -81,15 +84,17 @@ mod tests;
 #[cfg(test)]
 pub use sexpr::parse;
 
+#[macro_export]
 macro_rules! bail {
     ($err:expr $(,)?) => {
-        return Err(ParseError::from(anyhow!($err)))
+        return Err(ParseError::from(anyhow::anyhow!($err)))
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return Err(ParseError::from(anyhow!($fmt, $($arg)*)))
+        return Err(ParseError::from(anyhow::anyhow!($fmt, $($arg)*)))
     };
 }
 
+#[macro_export]
 macro_rules! bail_expr {
     ($expr:expr, $fmt:expr $(,)?) => {
         return Err(ParseError::from_expr($expr, format!($fmt)))
@@ -99,6 +104,7 @@ macro_rules! bail_expr {
     };
 }
 
+#[macro_export]
 macro_rules! bail_span {
     ($expr:expr, $fmt:expr $(,)?) => {
         return Err(ParseError::from_spanned($expr, format!($fmt)))
@@ -108,6 +114,7 @@ macro_rules! bail_span {
     };
 }
 
+#[macro_export]
 macro_rules! anyhow_expr {
     ($expr:expr, $fmt:expr $(,)?) => {
         ParseError::from_expr($expr, format!($fmt))
@@ -117,6 +124,7 @@ macro_rules! anyhow_expr {
     };
 }
 
+#[macro_export]
 macro_rules! anyhow_span {
     ($expr:expr, $fmt:expr $(,)?) => {
         ParseError::from_spanned($expr, format!($fmt))
@@ -197,81 +205,6 @@ pub struct Cfg {
     pub sequences: KeySeqsToFKeys,
     /// Overrides defined in `defoverrides`.
     pub overrides: Overrides,
-}
-
-#[derive(Debug)]
-pub struct CfgOptions {
-    pub process_unmapped_keys: bool,
-    pub enable_cmd: bool,
-    pub sequence_timeout: u16,
-    pub sequence_input_mode: SequenceInputMode,
-    pub sequence_backtrack_modcancel: bool,
-    pub log_layer_changes: bool,
-    pub delegate_to_first_layer: bool,
-    pub movemouse_inherit_accel_state: bool,
-    pub movemouse_smooth_diagonals: bool,
-    pub dynamic_macro_max_presses: u16,
-    #[cfg(any(target_os = "linux", target_os = "unknown"))]
-    pub linux_dev: Vec<String>,
-    #[cfg(any(target_os = "linux", target_os = "unknown"))]
-    pub linux_dev_names_include: Option<Vec<String>>,
-    #[cfg(any(target_os = "linux", target_os = "unknown"))]
-    pub linux_dev_names_exclude: Option<Vec<String>>,
-    #[cfg(any(target_os = "linux", target_os = "unknown"))]
-    pub linux_continue_if_no_devs_found: bool,
-    #[cfg(any(target_os = "linux", target_os = "unknown"))]
-    pub linux_unicode_u_code: OsCode,
-    #[cfg(any(target_os = "linux", target_os = "unknown"))]
-    pub linux_unicode_termination: UnicodeTermination,
-    #[cfg(any(target_os = "linux", target_os = "unknown"))]
-    pub linux_x11_repeat_delay_rate: Option<KeyRepeatSettings>,
-    #[cfg(any(target_os = "windows", target_os = "unknown"))]
-    pub windows_altgr: AltGrBehaviour,
-    #[cfg(any(
-        all(feature = "interception_driver", target_os = "windows"),
-        target_os = "unknown"
-    ))]
-    pub windows_interception_mouse_hwid: Option<[u8; HWID_ARR_SZ]>,
-}
-
-impl Default for CfgOptions {
-    fn default() -> Self {
-        Self {
-            process_unmapped_keys: false,
-            enable_cmd: false,
-            sequence_timeout: 1000,
-            sequence_input_mode: SequenceInputMode::HiddenSuppressed,
-            sequence_backtrack_modcancel: true,
-            log_layer_changes: true,
-            delegate_to_first_layer: false,
-            movemouse_inherit_accel_state: false,
-            movemouse_smooth_diagonals: false,
-            dynamic_macro_max_presses: 128,
-            #[cfg(any(target_os = "linux", target_os = "unknown"))]
-            linux_dev: vec![],
-            #[cfg(any(target_os = "linux", target_os = "unknown"))]
-            linux_dev_names_include: None,
-            #[cfg(any(target_os = "linux", target_os = "unknown"))]
-            linux_dev_names_exclude: None,
-            #[cfg(any(target_os = "linux", target_os = "unknown"))]
-            linux_continue_if_no_devs_found: false,
-            #[cfg(any(target_os = "linux", target_os = "unknown"))]
-            // historically was the only option, so make KEY_U the default
-            linux_unicode_u_code: OsCode::KEY_U,
-            #[cfg(any(target_os = "linux", target_os = "unknown"))]
-            // historically was the only option, so make Enter the default
-            linux_unicode_termination: UnicodeTermination::Enter,
-            #[cfg(any(target_os = "linux", target_os = "unknown"))]
-            linux_x11_repeat_delay_rate: None,
-            #[cfg(any(target_os = "windows", target_os = "unknown"))]
-            windows_altgr: AltGrBehaviour::DoNothing,
-            #[cfg(any(
-                all(feature = "interception_driver", target_os = "windows"),
-                target_os = "unknown"
-            ))]
-            windows_interception_mouse_hwid: None,
-        }
-    }
 }
 
 /// Parse a new configuration from a file.
@@ -785,244 +718,6 @@ fn check_first_expr<'a>(
         bail!("Passed non-{expected_first} expression to {expected_first}: {first_atom}");
     }
     Ok(exprs)
-}
-
-/// Parse configuration entries from an expression starting with defcfg.
-fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
-    let mut seen_keys = HashSet::default();
-    let mut cfg = CfgOptions::default();
-    let mut exprs = check_first_expr(expr.iter(), "defcfg")?;
-    // Read k-v pairs from the configuration
-    loop {
-        let key = match exprs.next() {
-            Some(k) => k,
-            None => return Ok(cfg),
-        };
-        let val = match exprs.next() {
-            Some(v) => v,
-            None => bail_expr!(key, "Found a defcfg option missing a value"),
-        };
-        match (&key, &val) {
-            (SExpr::Atom(k), SExpr::Atom(v)) => {
-                if !seen_keys.insert(&k.t) {
-                    bail_expr!(key, "Duplicate defcfg option {}", k.t);
-                }
-                match k.t.as_str() {
-                    k @ "sequence-timeout" => {
-                        cfg.sequence_timeout = parse_cfg_val_u16(val, k, true)?;
-                    }
-                    "sequence-input-mode" => {
-                        cfg.sequence_input_mode =
-                            SequenceInputMode::try_from_str(&v.t.trim_matches('"'))
-                                .map_err(|e| anyhow_expr!(val, "{}", e.to_string()))?;
-                    }
-                    k @ "dynamic-macro-max-presses" => {
-                        cfg.dynamic_macro_max_presses = parse_cfg_val_u16(val, k, false)?;
-                    }
-                    "linux-dev" => {
-                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
-                        {
-                            let paths = v.t.trim_matches('"');
-                            cfg.linux_dev = parse_colon_separated_text(paths);
-                        }
-                    }
-                    "linux-dev-names-include" => {
-                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
-                        {
-                            let paths = v.t.trim_matches('"');
-                            cfg.linux_dev_names_include = Some(parse_colon_separated_text(paths));
-                        }
-                    }
-                    "linux-dev-names-exclude" => {
-                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
-                        {
-                            let paths = v.t.trim_matches('"');
-                            cfg.linux_dev_names_exclude = Some(parse_colon_separated_text(paths));
-                        }
-                    }
-                    _k @ "linux-unicode-u-code" => {
-                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
-                        {
-                            cfg.linux_unicode_u_code = str_to_oscode(v.t.trim_matches('"'))
-                                .ok_or_else(|| {
-                                    anyhow_expr!(val, "unknown code for {_k}: {}", v.t)
-                                })?;
-                        }
-                    }
-                    _k @ "linux-unicode-termination" => {
-                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
-                        {
-                            cfg.linux_unicode_termination = match v.t.trim_matches('"') {
-                                "enter" => UnicodeTermination::Enter,
-                                "space" => UnicodeTermination::Space,
-                                "enter-space" => UnicodeTermination::EnterSpace,
-                                "space-enter" => UnicodeTermination::SpaceEnter,
-                                _ => bail_expr!(
-                                    val,
-                                    "{_k} got {}. It accepts: enter|space|enter-space|space-enter",
-                                    v.t
-                                ),
-                            }
-                        }
-                    }
-                    _k @ "linux-x11-repeat-delay-rate" => {
-                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
-                        {
-                            let delay_rate = v.t.trim_matches('"').split(',').collect::<Vec<_>>();
-                            let errmsg = anyhow_span!(v, "Invalid value for {_k}.\nExpected two numbers 0-65535 separated by a comma, e.g. 200,25");
-                            if delay_rate.len() != 2 {
-                                bail!("{:?}", errmsg)
-                            }
-                            cfg.linux_x11_repeat_delay_rate = Some(KeyRepeatSettings {
-                                delay: match str::parse::<u16>(delay_rate[0]) {
-                                    Ok(delay) => delay,
-                                    Err(_) => bail!("{:?}", errmsg),
-                                },
-                                rate: match str::parse::<u16>(delay_rate[0]) {
-                                    Ok(rate) => rate,
-                                    Err(_) => bail!("{:?}", errmsg),
-                                },
-                            });
-                        }
-                    }
-                    _k @ "windows-altgr" => {
-                        #[cfg(any(target_os = "windows", target_os = "unknown"))]
-                        {
-                            const CANCEL: &str = "cancel-lctl-press";
-                            const ADD: &str = "add-lctl-release";
-                            cfg.windows_altgr = match v.t.trim_matches('"') {
-                                CANCEL => AltGrBehaviour::CancelLctlPress,
-                                ADD => AltGrBehaviour::AddLctlRelease,
-                                _ => bail_expr!(
-                                    val,
-                                    "Invalid value for {_k}: {}. Valid values are {},{}",
-                                    v.t,
-                                    CANCEL,
-                                    ADD
-                                ),
-                            }
-                        }
-                    }
-                    _k @ "windows-interception-mouse-hwid" => {
-                        #[cfg(any(
-                            all(feature = "interception_driver", target_os = "windows"),
-                            target_os = "unknown"
-                        ))]
-                        {
-                            let hwid = v.t.trim_matches('"');
-                            log::trace!("win hwid: {hwid}");
-                            let hwid_vec = hwid
-                                .split_whitespace()
-                                .try_fold(vec![], |mut hwid_bytes, hwid_byte| {
-                                    hwid_byte.trim_matches(',').parse::<u8>().map(|b| {
-                                        hwid_bytes.push(b);
-                                        hwid_bytes
-                                    })
-                                }).map_err(|_| anyhow_expr!(val, "{_k} format is invalid. It should consist of integers separated by commas"))?;
-                            let hwid_slice = hwid_vec.iter().copied().enumerate()
-                                .try_fold([0u8; HWID_ARR_SZ], |mut hwid, idx_byte| {
-                                    let (i, b) = idx_byte;
-                                    if i > HWID_ARR_SZ {
-                                        bail_expr!(val, "{_k} is too long; it should be up to {HWID_ARR_SZ} 8-bit unsigned integers")
-                                    }
-                                    hwid[i] = b;
-                                    Ok(hwid)
-                            });
-                            cfg.windows_interception_mouse_hwid = Some(hwid_slice?);
-                        }
-                    }
-
-                    "process-unmapped-keys" => {
-                        cfg.process_unmapped_keys = parse_defcfg_val_bool(val, &k.t)?
-                    }
-                    "danger-enable-cmd" => cfg.enable_cmd = parse_defcfg_val_bool(val, &k.t)?,
-                    "sequence-backtrack-modcancel" => {
-                        cfg.sequence_backtrack_modcancel = parse_defcfg_val_bool(val, &k.t)?
-                    }
-                    "log-layer-changes" => {
-                        cfg.log_layer_changes = parse_defcfg_val_bool(val, &k.t)?
-                    }
-                    "delegate-to-first-layer" => {
-                        cfg.delegate_to_first_layer = parse_defcfg_val_bool(val, &k.t)?;
-                        if cfg.delegate_to_first_layer {
-                            log::info!("delegating transparent keys on other layers to first defined layer");
-                        }
-                    }
-                    "linux-continue-if-no-devs-found" => {
-                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
-                        {
-                            cfg.linux_continue_if_no_devs_found = parse_defcfg_val_bool(val, &k.t)?
-                        }
-                    }
-                    "movemouse-smooth-diagonals" => {
-                        cfg.movemouse_smooth_diagonals = parse_defcfg_val_bool(val, &k.t)?
-                    }
-                    "movemouse-inherit-accel-state" => {
-                        cfg.movemouse_inherit_accel_state = parse_defcfg_val_bool(val, &k.t)?
-                    }
-                    _ => bail_expr!(key, "Unknown defcfg option {}", &k.t),
-                };
-            }
-            (SExpr::List(_), _) => {
-                bail_expr!(key, "Lists are not allowed in defcfg");
-            }
-            (_, SExpr::List(_)) => {
-                bail_expr!(val, "Lists are not allowed in defcfg");
-            }
-        }
-    }
-}
-
-pub const FALSE_VALUES: [&str; 3] = ["no", "false", "0"];
-pub const TRUE_VALUES: [&str; 3] = ["yes", "true", "1"];
-pub const BOOLEAN_VALUES: [&str; 6] = ["yes", "true", "1", "no", "false", "0"];
-
-fn parse_defcfg_val_bool(expr: &SExpr, label: &str) -> Result<bool> {
-    match &expr {
-        SExpr::Atom(v) => {
-            let val = v.t.trim_matches('"').to_ascii_lowercase();
-            if TRUE_VALUES.contains(&val.as_str()) {
-                Ok(true)
-            } else if FALSE_VALUES.contains(&val.as_str()) {
-                Ok(false)
-            } else {
-                bail_expr!(
-                    expr,
-                    "The value for {label} must be one of: {}",
-                    BOOLEAN_VALUES.join(", ")
-                );
-            }
-        }
-        SExpr::List(_) => {
-            bail_expr!(
-                expr,
-                "The value for {label} cannot be a list, it must be one of: {}",
-                BOOLEAN_VALUES.join(", "),
-            )
-        }
-    }
-}
-
-fn parse_cfg_val_u16(expr: &SExpr, label: &str, exclude_zero: bool) -> Result<u16> {
-    let start = if exclude_zero { 1 } else { 0 };
-    match &expr {
-        SExpr::Atom(v) => Ok(str::parse::<u16>(&v.t.trim_matches('"'))
-            .ok()
-            .and_then(|u| {
-                if exclude_zero && u == 0 {
-                    None
-                } else {
-                    Some(u)
-                }
-            })
-            .ok_or_else(|| anyhow_expr!(expr, "{label} must be {start}-65535"))?),
-        SExpr::List(_) => {
-            bail_expr!(
-                expr,
-                "The value for {label} cannot be a list, it must be a number {start}-65535",
-            )
-        }
-    }
 }
 
 /// Parse custom keys from an expression starting with deflocalkeys.

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -3165,9 +3165,3 @@ fn add_kc_output(
 fn create_layout(layers: Box<KanataLayers>, a: Arc<Allocations>) -> KanataLayout {
     KanataLayout::new(Layout::new(a.bref(layers)), a)
 }
-
-#[cfg(any(
-    all(feature = "interception_driver", target_os = "windows"),
-    target_os = "unknown"
-))]
-pub const HWID_ARR_SZ: usize = 128;

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -425,7 +425,7 @@ pub fn parse_cfg_raw_string(
             if def_local_keys_variant == def_local_keys_variant_to_apply {
                 assert!(
                     local_keys.is_none(),
-                    ">1 mutually exclusive deflocalkeys variants was parsed"
+                    ">1 mutually exclusive deflocalkeys variants were parsed"
                 );
                 local_keys = Some(mapping);
             }
@@ -812,7 +812,7 @@ fn parse_deflocalkeys(
     def_local_keys_variant: &str,
     expr: &[SExpr],
 ) -> Result<HashMap<String, OsCode>> {
-    let mut cfg = HashMap::default();
+    let mut localkeys = HashMap::default();
     let mut exprs = check_first_expr(expr.iter(), def_local_keys_variant)?;
     // Read k-v pairs from the configuration
     while let Some(key_expr) = exprs.next() {
@@ -824,7 +824,7 @@ fn parse_deflocalkeys(
                 key_expr,
                 "Cannot use {key} in {def_local_keys_variant} because it is a default key name"
             );
-        } else if cfg.contains_key(key) {
+        } else if localkeys.contains_key(key) {
             bail_expr!(
                 key_expr,
                 "Duplicate {key} found in {def_local_keys_variant}"
@@ -847,9 +847,9 @@ fn parse_deflocalkeys(
             None => bail_expr!(key_expr, "Key without a number in {def_local_keys_variant}"),
         };
         log::debug!("custom mapping: {key} {}", osc.as_u16());
-        cfg.insert(key.to_owned(), osc);
+        localkeys.insert(key.to_owned(), osc);
     }
-    Ok(cfg)
+    Ok(localkeys)
 }
 
 /// Parse mapped keys from an expression starting with defsrc. Returns the key mapping as well as

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -52,7 +52,7 @@ mod list_actions;
 use list_actions::*;
 
 mod defcfg;
-use defcfg::*;
+pub use defcfg::*;
 
 use crate::custom_action::*;
 use crate::keys::*;
@@ -3183,20 +3183,6 @@ fn add_kc_output(
 /// Create a layout from `layers::LAYERS`.
 fn create_layout(layers: Box<KanataLayers>, a: Arc<Allocations>) -> KanataLayout {
     KanataLayout::new(Layout::new(a.bref(layers)), a)
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct KeyRepeatSettings {
-    pub delay: u16,
-    pub rate: u16,
-}
-
-#[cfg(any(target_os = "windows", target_os = "unknown"))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AltGrBehaviour {
-    DoNothing,
-    CancelLctlPress,
-    AddLctlRelease,
 }
 
 #[cfg(any(

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -840,20 +840,16 @@ fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                             cfg.linux_dev_names_exclude = Some(parse_colon_separated_text(paths));
                         }
                     }
-                    "linux-unicode-u-code" => {
+                    _k @ "linux-unicode-u-code" => {
                         #[cfg(any(target_os = "linux", target_os = "unknown"))]
                         {
                             cfg.linux_unicode_u_code = str_to_oscode(v.t.trim_matches('"'))
                                 .ok_or_else(|| {
-                                    anyhow_expr!(
-                                        val,
-                                        "unknown code for linux-unicode-u-code {}",
-                                        v.t
-                                    )
+                                    anyhow_expr!(val, "unknown code for {_k}: {}", v.t)
                                 })?;
                         }
                     }
-                    "linux-unicode-termination" => {
+                    _k @ "linux-unicode-termination" => {
                         #[cfg(any(target_os = "linux", target_os = "unknown"))]
                         {
                             cfg.linux_unicode_termination = match v.t.trim_matches('"') {
@@ -861,15 +857,19 @@ fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                                 "space" => UnicodeTermination::Space,
                                 "enter-space" => UnicodeTermination::EnterSpace,
                                 "space-enter" => UnicodeTermination::SpaceEnter,
-                                _ => bail_expr!(val, "linux-unicode-termination got {}. It accepts: enter|space|enter-space|space-enter", v.t),
+                                _ => bail_expr!(
+                                    val,
+                                    "{_k} got {}. It accepts: enter|space|enter-space|space-enter",
+                                    v.t
+                                ),
                             }
                         }
                     }
-                    "linux-x11-repeat-delay-rate" => {
+                    _k @ "linux-x11-repeat-delay-rate" => {
                         #[cfg(any(target_os = "linux", target_os = "unknown"))]
                         {
                             let delay_rate = v.t.split(',').collect::<Vec<_>>();
-                            let errmsg = anyhow_span!(v, "Invalid value for linux-x11-repeat-delay-rate.\nExpected two numbers 0-65535 separated by a comma, e.g. 200,25");
+                            let errmsg = anyhow_span!(v, "Invalid value for {_k}.\nExpected two numbers 0-65535 separated by a comma, e.g. 200,25");
                             if delay_rate.len() != 2 {
                                 bail!("{:?}", errmsg)
                             }
@@ -885,7 +885,7 @@ fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                             });
                         }
                     }
-                    "windows-altgr" => {
+                    _k @ "windows-altgr" => {
                         #[cfg(any(target_os = "windows", target_os = "unknown"))]
                         {
                             const CANCEL: &str = "cancel-lctl-press";
@@ -895,7 +895,7 @@ fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                                 ADD => AltGrBehaviour::AddLctlRelease,
                                 _ => bail_expr!(
                                     val,
-                                    "Invalid value for windows-altgr: {}. Valid values are {},{}",
+                                    "Invalid value for {_k}: {}. Valid values are {},{}",
                                     v.t,
                                     CANCEL,
                                     ADD
@@ -903,7 +903,7 @@ fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                             }
                         }
                     }
-                    "windows-interception-mouse-hwid" => {
+                    _k @ "windows-interception-mouse-hwid" => {
                         #[cfg(any(
                             all(feature = "interception_driver", target_os = "windows"),
                             target_os = "unknown"
@@ -918,12 +918,12 @@ fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                                         hwid_bytes.push(b);
                                         hwid_bytes
                                     })
-                                }).map_err(|_| anyhow_expr!(val, "windows-interception-mouse-hwid format is invalid. It should consist of integers separated by commas"))?;
+                                }).map_err(|_| anyhow_expr!(val, "{_k} format is invalid. It should consist of integers separated by commas"))?;
                             let hwid_slice = hwid_vec.iter().copied().enumerate()
                                     .fold([0u8; HWID_ARR_SZ], |mut hwid, idx_byte| {
                                         let (i, b) = idx_byte;
                                         if i > HWID_ARR_SZ {
-                                            panic!("windows-interception-mouse-hwid is too long; it should be up to {HWID_ARR_SZ} 8-bit unsigned integers");
+                                            bail_expr!(val, "{_k} is too long; it should be up to {HWID_ARR_SZ} 8-bit unsigned integers")
                                         }
                                         hwid[i] = b;
                                         hwid

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -392,23 +392,6 @@ pub fn parse_cfg_raw_string(
 
     error_on_unknown_top_level_atoms(&spanned_root_exprs)?;
 
-    let cfg = root_exprs
-        .iter()
-        .find(gen_first_atom_filter("defcfg"))
-        .map(|cfg| parse_defcfg(cfg))
-        .transpose()?
-        .unwrap_or_default();
-    if let Some(spanned) = spanned_root_exprs
-        .iter()
-        .filter(gen_first_atom_filter_spanned("defcfg"))
-        .nth(1)
-    {
-        bail_span!(
-            spanned,
-            "Only one defcfg is allowed, found more. Delete the extras."
-        )
-    }
-
     let mut local_keys: Option<HashMap<String, OsCode>> = None;
     clear_custom_str_oscode_mapping();
     for def_local_keys_variant in [
@@ -443,6 +426,23 @@ pub fn parse_cfg_raw_string(
         }
     }
     replace_custom_str_oscode_mapping(&local_keys.unwrap_or_default());
+
+    let cfg = root_exprs
+        .iter()
+        .find(gen_first_atom_filter("defcfg"))
+        .map(|cfg| parse_defcfg(cfg))
+        .transpose()?
+        .unwrap_or_default();
+    if let Some(spanned) = spanned_root_exprs
+        .iter()
+        .filter(gen_first_atom_filter_spanned("defcfg"))
+        .nth(1)
+    {
+        bail_span!(
+            spanned,
+            "Only one defcfg is allowed, found more. Delete the extras."
+        )
+    }
 
     let src_expr = root_exprs
         .iter()

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -825,21 +825,21 @@ fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                         #[cfg(any(target_os = "linux", target_os = "unknown"))]
                         {
                             let paths = v.t.trim_matches('"');
-                            cfg.linux_dev = parse_colon_separated_text(&paths);
+                            cfg.linux_dev = parse_colon_separated_text(paths);
                         }
                     }
                     "linux-dev-names-include" => {
                         #[cfg(any(target_os = "linux", target_os = "unknown"))]
                         {
                             let paths = v.t.trim_matches('"');
-                            cfg.linux_dev_names_include = Some(parse_colon_separated_text(&paths));
+                            cfg.linux_dev_names_include = Some(parse_colon_separated_text(paths));
                         }
                     }
                     "linux-dev-names-exclude" => {
                         #[cfg(any(target_os = "linux", target_os = "unknown"))]
                         {
                             let paths = v.t.trim_matches('"');
-                            cfg.linux_dev_names_exclude = Some(parse_colon_separated_text(&paths));
+                            cfg.linux_dev_names_exclude = Some(parse_colon_separated_text(paths));
                         }
                     }
                     "linux-unicode-u-code" => {
@@ -2534,14 +2534,13 @@ fn parse_fake_key_op_coord_action(
     };
     let action = ac_params[1]
         .atom(s.vars())
-        .map(|a| match a {
+        .and_then(|a| match a {
             "tap" => Some(FakeKeyAction::Tap),
             "press" => Some(FakeKeyAction::Press),
             "release" => Some(FakeKeyAction::Release),
             "toggle" => Some(FakeKeyAction::Toggle),
             _ => None,
         })
-        .flatten()
         .ok_or_else(|| {
             anyhow_expr!(
                 &ac_params[1],
@@ -3111,7 +3110,7 @@ fn parse_sequence_start(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static
     let input_mode = if ac_params.len() > 1 {
         if let Some(Ok(input_mode)) = ac_params[1]
             .atom(s.vars())
-            .map(|config_str| SequenceInputMode::try_from_str(config_str))
+            .map(SequenceInputMode::try_from_str)
         {
             input_mode
         } else {
@@ -3280,13 +3279,12 @@ fn parse_on_idle_fakekey(ac_params: &[SExpr], s: &ParsedState) -> Result<&'stati
     };
     let action = ac_params[1]
         .atom(s.vars())
-        .map(|a| match a {
+        .and_then(|a| match a {
             "tap" => Some(FakeKeyAction::Tap),
             "press" => Some(FakeKeyAction::Press),
             "release" => Some(FakeKeyAction::Release),
             _ => None,
         })
-        .flatten()
         .ok_or_else(|| {
             anyhow_expr!(
                 &ac_params[1],

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1205,3 +1205,47 @@ fn parse_device_paths() {
     assert_eq!(parse_colon_separated_text("h\\:w"), ["h:w"]);
     assert_eq!(parse_colon_separated_text("h\\:w\\"), ["h:w\\"]);
 }
+
+#[test]
+fn parse_all_defcfg() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let source = r#"
+(defcfg
+  process-unmapped-keys yes
+  danger-enable-cmd yes
+  sequence-timeout 2000
+  sequence-input-mode visible-backspaced
+  sequence-backtrack-modcancel no
+  log-layer-changes no
+  delegate-to-first-layer yes
+  movemouse-inherit-accel-state yes
+  movemouse-smooth-diagonals yes
+  dynamic-macro-max-presses 1000
+  linux-dev /dev/input/dev1:/dev/input/dev2
+  linux-dev-names-include "Name 1:Name 2"
+  linux-dev-names-exclude "Name 3:Name 4"
+  linux-continue-if-no-devs-found yes
+  linux-unicode-u-code v
+  linux-unicode-termination space
+  linux-x11-repeat-delay-rate 400,50
+  windows-altgr add-lctl-release
+  windows-interception-mouse-hwid "70, 0, 60, 0"
+)
+(defsrc a)
+(deflayer base a)
+"#;
+    let mut s = ParsedState::default();
+    parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+        DEF_LOCAL_KEYS,
+    )
+    .expect("succeeds");
+}

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1198,3 +1198,10 @@ fn list_action_not_in_list_error_message_is_good() {
     })
     .unwrap_err();
 }
+
+#[test]
+fn parse_device_paths() {
+    assert_eq!(parse_colon_separated_text("h:w"), ["h", "w"]);
+    assert_eq!(parse_colon_separated_text("h\\:w"), ["h:w"]);
+    assert_eq!(parse_colon_separated_text("h\\:w\\"), ["h:w\\"]);
+}

--- a/parser/src/keys/linux.rs
+++ b/parser/src/keys/linux.rs
@@ -771,3 +771,11 @@ impl From<Btn> for OsCode {
         }
     }
 }
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum UnicodeTermination {
+    Enter,
+    Space,
+    SpaceEnter,
+    EnterSpace,
+}

--- a/parser/src/keys/linux.rs
+++ b/parser/src/keys/linux.rs
@@ -771,11 +771,3 @@ impl From<Btn> for OsCode {
         }
     }
 }
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum UnicodeTermination {
-    Enter,
-    Space,
-    SpaceEnter,
-    EnterSpace,
-}

--- a/src/kanata/linux.rs
+++ b/src/kanata/linux.rs
@@ -29,7 +29,7 @@ impl Kanata {
 
         // In some environments, this needs to be done after the input device grab otherwise it
         // does not work on kanata startup.
-        Kanata::set_repeat_rate(&k.defcfg_items)?;
+        Kanata::set_repeat_rate(k.x11_repeat_rate)?;
         drop(k);
 
         loop {
@@ -83,28 +83,20 @@ impl Kanata {
         Ok(())
     }
 
-    pub fn set_repeat_rate(cfg_items: &HashMap<String, String>) -> Result<()> {
-        if let Some(x11_rpt_str) = cfg_items.get("linux-x11-repeat-delay-rate") {
-            let delay_rate = x11_rpt_str.split(',').collect::<Vec<_>>();
-            let errmsg = format!("Invalid value for linux-x11-repeat-delay-rate: \"{x11_rpt_str}\".\nExpected two numbers 0-65535 separated by a comma, e.g. 200,25");
-            if delay_rate.len() != 2 {
-                log::error!("{errmsg}");
-            }
-            str::parse::<u16>(delay_rate[0]).map_err(|e| {
-                log::error!("{errmsg}");
-                e
-            })?;
-            str::parse::<u16>(delay_rate[1]).map_err(|e| {
-                log::error!("{errmsg}");
-                e
-            })?;
+    pub fn set_repeat_rate(s: Option<KeyRepeatSettings>) -> Result<()> {
+        if let Some(s) = s {
             log::info!(
                 "Using xset to set X11 repeat delay to {} and repeat rate to {}",
-                delay_rate[0],
-                delay_rate[1]
+                s.delay,
+                s.rate,
             );
             let cmd_output = std::process::Command::new("xset")
-                .args(["r", "rate", delay_rate[0], delay_rate[1]])
+                .args([
+                    "r",
+                    "rate",
+                    s.delay.to_string().as_str(),
+                    s.rate.to_string().as_str(),
+                ])
                 .output()
                 .map_err(|e| {
                     log::error!("failed to run xset: {e:?}");

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1,6 +1,6 @@
 //! Implements the glue between OS input/output and keyberon state management.
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use log::{error, info};
 use parking_lot::Mutex;
 use std::sync::mpsc::{Receiver, SyncSender as Sender, TryRecvError};

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -9,8 +9,6 @@ use crate::kanata::*;
 use crate::oskbd::KeyValue;
 use kanata_parser::keys::OsCode;
 
-const HWID_ARR_SZ: usize = 128;
-
 impl Kanata {
     pub fn event_loop(kanata: Arc<Mutex<Self>>, tx: Sender<KeyEvent>) -> Result<()> {
         let intrcptn = ic::Interception::new().ok_or_else(|| anyhow!("interception driver should init: have you completed the interception driver installation?"))?;
@@ -21,20 +19,7 @@ impl Kanata {
             information: 0,
         }; 32];
 
-        let mouse_to_intercept_hwid: Option<[u8; HWID_ARR_SZ]> = kanata
-            .lock()
-            .intercept_mouse_hwid.as_ref()
-            .map(|hwid| {
-                hwid.iter().copied().enumerate()
-                    .fold([0u8; HWID_ARR_SZ], |mut hwid, idx_byte| {
-                        let (i, b) = idx_byte;
-                        if i > HWID_ARR_SZ {
-                            panic!("windows-interception-mouse-hwid is too long; it should be up to {HWID_ARR_SZ} 8-bit unsigned integers");
-                        }
-                        hwid[i] = b;
-                        hwid
-                    })
-            });
+        let mouse_to_intercept_hwid: Option<[u8; HWID_ARR_SZ]> = kanata.lock().intercept_mouse_hwid;
         if mouse_to_intercept_hwid.is_some() {
             intrcptn.set_filter(
                 ic::is_mouse,

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use kanata_interception as ic;
 use parking_lot::Mutex;
 use std::sync::mpsc::SyncSender as Sender;

--- a/src/kanata/windows/mod.rs
+++ b/src/kanata/windows/mod.rs
@@ -1,9 +1,8 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 
 use parking_lot::Mutex;
 
 use crate::kanata::*;
-use kanata_parser::cfg;
 
 #[cfg(not(feature = "interception_driver"))]
 mod llhook;
@@ -15,37 +14,13 @@ mod interception;
 #[cfg(feature = "interception_driver")]
 pub use self::interception::*;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AltGrBehaviour {
-    DoNothing,
-    CancelLctlPress,
-    AddLctlRelease,
-}
-
 static PRESSED_KEYS: Lazy<Mutex<HashSet<OsCode>>> = Lazy::new(|| Mutex::new(HashSet::default()));
 
 pub static ALTGR_BEHAVIOUR: Lazy<Mutex<AltGrBehaviour>> =
-    Lazy::new(|| Mutex::new(AltGrBehaviour::DoNothing));
+    Lazy::new(|| Mutex::new(CfgOptions::default().windows_altgr));
 
-pub fn set_win_altgr_behaviour(cfg: &cfg::Cfg) -> Result<()> {
-    *ALTGR_BEHAVIOUR.lock() = {
-        const CANCEL: &str = "cancel-lctl-press";
-        const ADD: &str = "add-lctl-release";
-        match cfg.items.get("windows-altgr") {
-            None => AltGrBehaviour::DoNothing,
-            Some(cfg_val) => match cfg_val.as_str() {
-                CANCEL => AltGrBehaviour::CancelLctlPress,
-                ADD => AltGrBehaviour::AddLctlRelease,
-                _ => bail!(
-                    "Invalid value for windows-altgr: {}. Valid values are {},{}",
-                    cfg_val,
-                    CANCEL,
-                    ADD
-                ),
-            },
-        }
-    };
-    Ok(())
+pub fn set_win_altgr_behaviour(b: AltGrBehaviour) {
+    *ALTGR_BEHAVIOUR.lock() = b;
 }
 
 impl Kanata {
@@ -128,11 +103,6 @@ impl Kanata {
 
     #[cfg(feature = "interception_driver")]
     pub fn check_release_non_physical_shift(&mut self) -> Result<()> {
-        Ok(())
-    }
-
-    pub fn set_repeat_rate(_cfg_items: &HashMap<String, String>) -> Result<()> {
-        // TODO: no-op right now
         Ok(())
     }
 }

--- a/src/kanata/windows/mod.rs
+++ b/src/kanata/windows/mod.rs
@@ -17,7 +17,7 @@ pub use self::interception::*;
 static PRESSED_KEYS: Lazy<Mutex<HashSet<OsCode>>> = Lazy::new(|| Mutex::new(HashSet::default()));
 
 pub static ALTGR_BEHAVIOUR: Lazy<Mutex<AltGrBehaviour>> =
-    Lazy::new(|| Mutex::new(CfgOptions::default().windows_altgr));
+    Lazy::new(|| Mutex::new(AltGrBehaviour::default()));
 
 pub fn set_win_altgr_behaviour(b: AltGrBehaviour) {
     *ALTGR_BEHAVIOUR.lock() = b;

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -303,14 +303,6 @@ impl From<KeyEvent> for InputEvent {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum UnicodeTermination {
-    Enter,
-    Space,
-    SpaceEnter,
-    EnterSpace,
-}
-
 use std::cell::Cell;
 
 pub struct KbdOut {
@@ -708,25 +700,6 @@ impl Symlink {
     }
 }
 
-pub fn parse_colon_separated_text(paths: &str) -> Vec<String> {
-    let mut all_paths = vec![];
-    let mut full_dev_path = String::new();
-    let mut dev_path_iter = paths.split(':').peekable();
-    while let Some(dev_path) = dev_path_iter.next() {
-        if dev_path.ends_with('\\') && dev_path_iter.peek().is_some() {
-            full_dev_path.push_str(dev_path.trim_end_matches('\\'));
-            full_dev_path.push(':');
-            continue;
-        } else {
-            full_dev_path.push_str(dev_path);
-        }
-        all_paths.push(full_dev_path.clone());
-        full_dev_path.clear();
-    }
-    all_paths.shrink_to_fit();
-    all_paths
-}
-
 // Note for allow: the ioctl_read_buf triggers this clippy lint.
 // Note: CI does not yet support this lint, so also allowing unknown lints.
 #[allow(unknown_lints)]
@@ -758,6 +731,7 @@ fn wait_for_all_keys_unpressed(dev: &Device) -> Result<(), io::Error> {
 
 #[test]
 fn test_parse_dev_paths() {
+    use kanata_parser::cfg::parse_colon_separated_text;
     assert_eq!(parse_colon_separated_text("h:w"), ["h", "w"]);
     assert_eq!(parse_colon_separated_text("h\\:w"), ["h:w"]);
     assert_eq!(parse_colon_separated_text("h\\:w\\"), ["h:w\\"]);

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -19,8 +19,8 @@ use std::thread;
 
 use super::*;
 use crate::{kanata::CalculatedMouseMove, oskbd::KeyEvent};
-use kanata_parser::custom_action::*;
 use kanata_parser::keys::*;
+use kanata_parser::{cfg::UnicodeTermination, custom_action::*};
 
 pub struct KbdIn {
     devices: HashMap<Token, (Device, String)>,
@@ -727,14 +727,6 @@ fn wait_for_all_keys_unpressed(dev: &Device) -> Result<(), io::Error> {
         std::thread::sleep(std::time::Duration::from_micros(100));
     }
     Ok(())
-}
-
-#[test]
-fn test_parse_dev_paths() {
-    use kanata_parser::cfg::parse_colon_separated_text;
-    assert_eq!(parse_colon_separated_text("h:w"), ["h", "w"]);
-    assert_eq!(parse_colon_separated_text("h\\:w"), ["h:w"]);
-    assert_eq!(parse_colon_separated_text("h\\:w\\"), ["h:w\\"]);
 }
 
 impl Drop for Symlink {


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

1. Move validation of cfg values to `parse_defcfg` instead of validating them all over the codebase. Reason: before kanata didn't show location when parsing of a cfg value failed, now it does.
2. Replace `HashMap<String, String>` with `CfgOptions`, which holds only validated cfg values. Reason: Allows to easily parse lists as values, since now the actual value parsing is no longer delayed after parser function exited. This was done with #121 in mind.
3. Move cfg options defaults to a `CfgOptions::default`. Reason: it's good to have similar code in one place.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] Yes 
- Added tests, or did manual testing
  - [x] manual testing 