### PR TITLE
Fix a typo in config.adoc

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -76,7 +76,7 @@ amount of whitespace (spaces, tabs, newlines) are not relevant. You may use
 spaces, tabs, or newlines however you like to visually format `defsrc` to your
 liking.
 
-The the primary source of all key names are the
+The primary source of all key names are the
 `str_to_oscode` and `default_mappings` functions in
 https://github.com/jtroo/kanata/blob/main/parser/src/keys/mod.rs[the source].
 Please feel welcome to file an issue


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  -  N/A
- Added tests, or did manual testing
  - N/A
