### PR TITLE
parser: allow changing oscode mapping variant at runtime

### DIFF
--- a/parser/src/keys/linux.rs
+++ b/parser/src/keys/linux.rs
@@ -2,11 +2,11 @@
 
 use super::OsCode;
 impl OsCode {
-    pub const fn as_u16_linux(self) -> u16 {
+    pub(super) const fn as_u16_linux(self) -> u16 {
         self as u16
     }
 
-    pub const fn from_u16_linux(code: u16) -> Option<Self> {
+    pub(super) const fn from_u16_linux(code: u16) -> Option<Self> {
         match code {
             0 => Some(OsCode::KEY_RESERVED),
             1 => Some(OsCode::KEY_ESC),

--- a/parser/src/keys/linux.rs
+++ b/parser/src/keys/linux.rs
@@ -2,11 +2,11 @@
 
 use super::OsCode;
 impl OsCode {
-    pub const fn as_u16(self) -> u16 {
+    pub const fn as_u16_linux(self) -> u16 {
         self as u16
     }
 
-    pub const fn from_u16(code: u16) -> Option<Self> {
+    pub const fn from_u16_linux(code: u16) -> Option<Self> {
         match code {
             0 => Some(OsCode::KEY_RESERVED),
             1 => Some(OsCode::KEY_ESC),

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -11,42 +11,42 @@ mod windows;
 mod mappings;
 pub use mappings::*;
 
-#[cfg(any(target_os = "unknown"))]
+#[cfg(target_os = "unknown")]
 #[derive(Clone, Copy)]
 pub enum Platform {
     Win,
     Linux,
 }
 
-#[cfg(any(target_os = "unknown"))]
+#[cfg(target_os = "unknown")]
 pub static OSCODE_MAPPING_VARIANT: Mutex<Platform> = Mutex::new(Platform::Linux);
 
 impl OsCode {
     pub fn as_u16(self) -> u16 {
-        #[cfg(any(target_os = "unknown"))]
+        #[cfg(target_os = "unknown")]
         return match *OSCODE_MAPPING_VARIANT.lock() {
             Platform::Win => self.as_u16_windows(),
             Platform::Linux => self.as_u16_linux(),
         };
 
-        #[cfg(any(target_os = "linux"))]
+        #[cfg(target_os = "linux")]
         return self.as_u16_linux();
 
-        #[cfg(any(target_os = "windows"))]
+        #[cfg(target_os = "windows")]
         return self.as_u16_windows();
     }
 
     pub fn from_u16(code: u16) -> Option<Self> {
-        #[cfg(any(target_os = "unknown"))]
+        #[cfg(target_os = "unknown")]
         return match *OSCODE_MAPPING_VARIANT.lock() {
             Platform::Win => OsCode::from_u16_windows(code),
             Platform::Linux => OsCode::from_u16_linux(code),
         };
 
-        #[cfg(any(target_os = "linux"))]
+        #[cfg(target_os = "linux")]
         return OsCode::from_u16_linux(code);
 
-        #[cfg(any(target_os = "windows"))]
+        #[cfg(target_os = "windows")]
         return OsCode::from_u16_windows(code);
     }
 }

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -11,36 +11,43 @@ mod windows;
 mod mappings;
 pub use mappings::*;
 
+#[cfg(any(target_os = "unknown"))]
 #[derive(Clone, Copy)]
 pub enum Platform {
     Win,
     Linux,
 }
 
-pub static OSCODE_MAPPING_VARIANT: Mutex<Platform> = Mutex::new({
-    if cfg!(target_os = "linux") {
-        Platform::Linux
-    } else if cfg!(target_os = "windows") {
-        Platform::Win
-    } else {
-        // use whatever value as a fallback
-        Platform::Linux
-    }
-});
+#[cfg(any(target_os = "unknown"))]
+pub static OSCODE_MAPPING_VARIANT: Mutex<Platform> = Mutex::new(Platform::Linux);
 
 impl OsCode {
     pub fn as_u16(self) -> u16 {
-        match *OSCODE_MAPPING_VARIANT.lock() {
+        #[cfg(any(target_os = "unknown"))]
+        return match *OSCODE_MAPPING_VARIANT.lock() {
             Platform::Win => self.as_u16_windows(),
             Platform::Linux => self.as_u16_linux(),
-        }
+        };
+
+        #[cfg(any(target_os = "linux"))]
+        return self.as_u16_linux();
+
+        #[cfg(any(target_os = "windows"))]
+        return self.as_u16_windows();
     }
 
     pub fn from_u16(code: u16) -> Option<Self> {
-        match *OSCODE_MAPPING_VARIANT.lock() {
+        #[cfg(any(target_os = "unknown"))]
+        return match *OSCODE_MAPPING_VARIANT.lock() {
             Platform::Win => OsCode::from_u16_windows(code),
             Platform::Linux => OsCode::from_u16_linux(code),
-        }
+        };
+
+        #[cfg(any(target_os = "linux"))]
+        return OsCode::from_u16_linux(code);
+
+        #[cfg(any(target_os = "windows"))]
+        return OsCode::from_u16_windows(code);
     }
 }
 

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -5,7 +5,9 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap as HashMap;
 
+#[cfg(any(target_os = "linux", target_os = "unknown"))]
 mod linux;
+#[cfg(any(target_os = "windows", target_os = "unknown"))]
 mod windows;
 
 mod mappings;

--- a/parser/src/keys/windows.rs
+++ b/parser/src/keys/windows.rs
@@ -203,7 +203,7 @@ mod keys {
 pub use keys::*;
 
 impl OsCode {
-    pub const fn from_u16_windows(code: u16) -> Option<Self> {
+    pub(super) const fn from_u16_windows(code: u16) -> Option<Self> {
         match code {
             0x30 => Some(OsCode::KEY_0),
             0x31 => Some(OsCode::KEY_1),
@@ -841,7 +841,7 @@ impl OsCode {
         }
     }
 
-    pub const fn as_u16_windows(self) -> u16 {
+    pub(super) const fn as_u16_windows(self) -> u16 {
         match self {
             OsCode::KEY_0 => 0x30,
             OsCode::KEY_1 => 0x31,

--- a/parser/src/keys/windows.rs
+++ b/parser/src/keys/windows.rs
@@ -203,7 +203,7 @@ mod keys {
 pub use keys::*;
 
 impl OsCode {
-    pub const fn from_u16(code: u16) -> Option<Self> {
+    pub const fn from_u16_windows(code: u16) -> Option<Self> {
         match code {
             0x30 => Some(OsCode::KEY_0),
             0x31 => Some(OsCode::KEY_1),
@@ -841,7 +841,7 @@ impl OsCode {
         }
     }
 
-    pub const fn as_u16(self) -> u16 {
+    pub const fn as_u16_windows(self) -> u16 {
         match self {
             OsCode::KEY_0 => 0x30,
             OsCode::KEY_1 => 0x31,

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -159,6 +159,8 @@ pub struct Kanata {
     dynamic_macro_max_presses: u16,
     /// Keys that should be unmodded. If empty, any modifier should be cleared.
     unmodded_keys: Vec<KeyCode>,
+    /// Keep track of last pressed key for [`CustomAction::Repeat`].
+    last_pressed_key: KeyCode,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -240,8 +242,6 @@ impl DynamicMacroRecordState {
         }
     }
 }
-
-static LAST_PRESSED_KEY: AtomicU32 = AtomicU32::new(0);
 
 use once_cell::sync::Lazy;
 
@@ -404,6 +404,7 @@ impl Kanata {
             ticks_since_idle: 0,
             movemouse_buffer: None,
             unmodded_keys: vec![],
+            last_pressed_key: KeyCode::No,
         })
     }
 
@@ -845,7 +846,7 @@ impl Kanata {
             // logic there and is easier to add here since we already have
             // allocations and logic.
             self.prev_keys.push(*k);
-            LAST_PRESSED_KEY.store(OsCode::from(k).into(), SeqCst);
+            self.last_pressed_key = *k;
             match &mut self.sequence_state {
                 None => {
                     log::debug!("key press     {:?}", k);
@@ -1233,12 +1234,13 @@ impl Kanata {
                             }
                         }
                         CustomAction::Repeat => {
-                            let key = OsCode::from(LAST_PRESSED_KEY.load(SeqCst));
-                            log::debug!("repeating a keypress {key:?}");
+                            let keycode = self.last_pressed_key;
+                            let osc: OsCode = keycode.into();
+                            log::debug!("repeating a keypress {osc:?}");
                             let mut do_caps_word = false;
                             if !cur_keys.contains(&KeyCode::LShift) {
                                 if let Some(ref mut cw) = self.caps_word {
-                                    cur_keys.push(key.into());
+                                    cur_keys.push(keycode);
                                     let prev_len = cur_keys.len();
                                     cw.maybe_add_lsft(cur_keys);
                                     if cur_keys.len() > prev_len {
@@ -1248,9 +1250,9 @@ impl Kanata {
                                 }
                             }
                             // Release key in case the most recently pressed key is still pressed.
-                            self.kbd_out.release_key(key)?;
-                            self.kbd_out.press_key(key)?;
-                            self.kbd_out.release_key(key)?;
+                            self.kbd_out.release_key(osc)?;
+                            self.kbd_out.press_key(osc)?;
+                            self.kbd_out.release_key(osc)?;
                             if do_caps_word {
                                 self.kbd_out.release_key(OsCode::KEY_LEFTSHIFT)?;
                             }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -12,7 +12,7 @@ use std::collections::VecDeque;
 use std::io::Write;
 use std::net::TcpStream;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering::SeqCst};
+use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
 use std::sync::Arc;
 use std::time;
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add a global variable `OSCODE_MAPPING_VARIANT` that can be manually set to use other `OsCode` mapping variant. 
This change will allow me to fix https://github.com/rszyma/vscode-kanata/issues/5.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] No need for testing
