### PR TITLE
feat: more verbose logging for cmd

### DIFF
--- a/src/kanata/cmd.rs
+++ b/src/kanata/cmd.rs
@@ -15,25 +15,25 @@ pub(super) fn run_cmd_in_thread(cmd_and_args: Vec<String>) -> std::thread::JoinH
         for arg in args {
             cmd.arg(arg);
         }
+        let cmd_str = format!(
+            "Program: {:?}, Arguments: {}",
+            cmd.get_program(),
+            cmd.get_args()
+                .map(|arg| format!("{:?}", arg))
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        log::info!("Running cmd: {}", cmd_str);
         match cmd.output() {
             Ok(output) => {
                 log::info!(
-                    "Successfully ran cmd {}\nstdout:\n{}\nstderr:\n{}",
-                    {
-                        let mut printable_cmd = Vec::new();
-                        printable_cmd.push(format!("{:?}", cmd.get_program()));
-
-                        let printable_cmd = cmd.get_args().fold(printable_cmd, |mut cmd, arg| {
-                            cmd.push(format!("{arg:?}"));
-                            cmd
-                        });
-                        printable_cmd.join(" ")
-                    },
+                    "Successfully ran cmd: {}\nstdout:\n{}\nstderr:\n{}",
+                    cmd_str,
                     String::from_utf8_lossy(&output.stdout),
                     String::from_utf8_lossy(&output.stderr)
                 );
             }
-            Err(e) => log::error!("Failed to execute cmd: {}", e),
+            Err(e) => log::error!("Failed to execute program {:?}: {}", cmd.get_program(), e),
         };
     })
 }

--- a/src/kanata/cmd.rs
+++ b/src/kanata/cmd.rs
@@ -19,7 +19,7 @@ pub(super) fn run_cmd_in_thread(cmd_and_args: Vec<String>) -> std::thread::JoinH
             "Program: {:?}, Arguments: {}",
             cmd.get_program(),
             cmd.get_args()
-                .map(|arg| format!("{:?}", arg))
+                .map(|arg| arg.to_string_lossy())
                 .collect::<Vec<_>>()
                 .join(" ")
         );

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -693,7 +693,7 @@ impl Symlink {
     fn clean_when_killed(symlink: Self) {
         thread::spawn(|| {
             let mut signals = Signals::new([SIGINT, SIGTERM]).expect("signals register");
-            for signal in &mut signals {
+            if let Some(signal) = (&mut signals).into_iter().next() {
                 match signal {
                     SIGINT | SIGTERM => {
                         drop(symlink);


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
I feel like current logging for cmd action is not enough. This PR fixes it.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Manual testing
