### PR TITLE
feat+fix: unshift, key repeat on unmod+unshift

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -466,6 +466,11 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;; dead keys é (as opposed to using AltGr) that outputs É when shifted
   dké (macro (unmod ') e)
 
+  ;; unshift is like unmod but only releases shifts
+  ;; In ISO German QWERTZ, force unshifted symbols even if shift is held
+  de{ (unshift ralt 7)
+  de[ (unshift ralt 8)
+
   ;; unicode accepts a single unicode character. The unicode character will
   ;; not be automatically repeated by holding the key down. The alias name
   ;; is the unicode character itself and is referenced by @🙁 in deflayer.

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1716,17 +1716,28 @@ and what the extra non-terminal+non-capitalized keys should be (3rd parameter).
 === unmod[[unmod]]
 <<table-of-contents,Back to ToC>>
 
-The `unmod` action will release all modifiers temporarily and send a key.
+The `unmod` action will release all modifiers temporarily
+and send one or more keys.
 After the `unmod` key is released, the released modifiers are pressed again.
 The modifiers affected are: `lsft,rsft,lctl,rctl,lmet,rmet,lalt,ralt`.
+
+A variant of `unmod` is `unshift`.
+This action only releases the `lsft,rsft` keys.
+This can be useful for forcing unshifted keys while AltGr is still held.
 
 .Example:
 [source]
 ----
-;; holding shift and tapping a @um1 key will still output 1.
-um1 (unmod 1)
-;; dead keys é (as opposed to using AltGr) that outputs É when shifted
-dké (macro (unmod ') e)
+(defalias
+  ;; holding shift and tapping a @um1 key will still output 1.
+  um1 (unmod 1)
+  ;; dead keys é (as opposed to using AltGr) that outputs É when shifted
+  dké (macro (unmod ') e)
+
+  ;; In ISO German QWERTZ, force unshifted symbols even if shift is held
+  { (unshift ralt 7)
+  [ (unshift ralt 8)
+)
 ----
 
 [[cmd]]

--- a/parser/src/cfg/list_actions.rs
+++ b/parser/src/cfg/list_actions.rs
@@ -58,9 +58,10 @@ pub const DYNAMIC_MACRO_RECORD_STOP_TRUNCATE: &str = "dynamic-macro-record-stop-
 pub const SWITCH: &str = "switch";
 pub const SEQUENCE: &str = "sequence";
 pub const UNMOD: &str = "unmod";
+pub const UNSHIFT: &str = "unshift";
 
 pub fn is_list_action(ac: &str) -> bool {
-    const LIST_ACTIONS: [&str; 56] = [
+    const LIST_ACTIONS: [&str; 57] = [
         LAYER_SWITCH,
         LAYER_TOGGLE,
         LAYER_WHILE_HELD,
@@ -117,6 +118,7 @@ pub fn is_list_action(ac: &str) -> bool {
         SWITCH,
         SEQUENCE,
         UNMOD,
+        UNSHIFT,
     ];
     LIST_ACTIONS.contains(&ac)
 }

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1233,7 +1233,7 @@ fn parse_all_defcfg() {
   linux-x11-repeat-delay-rate 400,50
   windows-altgr add-lctl-release
   windows-interception-mouse-hwid "70, 0, 60, 0"
-)e
+)
 (defsrc a)
 (deflayer base a)
 "#;
@@ -1252,11 +1252,11 @@ fn parse_all_defcfg() {
 
 #[test]
 fn parse_unmod() {
-      let _lk = match CFG_PARSE_LOCK.lock() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-  
+
     let source = r#"
 (defsrc a b c d)
 (deflayer base

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1249,3 +1249,31 @@ fn parse_all_defcfg() {
     )
     .expect("succeeds");
 }
+
+#[test]
+fn parse_unmod() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let source = r#"
+(defsrc a b c d)
+(deflayer base
+  (unmod a)
+  (unmod a b)
+  (unshift a)
+  (unshift a b)
+)
+"#;
+    let mut s = ParsedState::default();
+    parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+        DEF_LOCAL_KEYS,
+    )
+    .expect("succeeds");
+}

--- a/parser/src/custom_action.rs
+++ b/parser/src/custom_action.rs
@@ -66,7 +66,10 @@ pub enum CustomAction {
         y: u16,
     },
     Unmodded {
-        key: KeyCode,
+        keys: Vec<KeyCode>,
+    },
+    Unshifted {
+        keys: Vec<KeyCode>,
     },
 }
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Implement unshift and make unmod+unshift key repeat work. Implements #615.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes
