### PR TITLE
feat: improve error messages for when user tries to put parentheses in deflayer directly or escaped with `\`

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -807,8 +807,10 @@ fn parse_defsrc(expr: &[SExpr], defcfg: &CfgOptions) -> Result<(MappedKeys, Vec<
 type LayerIndexes = HashMap<String, usize>;
 type Aliases = HashMap<String, &'static KanataAction>;
 
-/// Returns layer names and their indexes into the keyberon layout. This also checks that all
-/// layers have the same number of items as the defsrc. Also ensures that there are no duplicate layer names.
+/// Returns layer names and their indexes into the keyberon layout. This also checks that:
+/// - All layers have the same number of items as the defsrc,
+/// - There are no duplicate layer names
+/// - Parentheses weren't used directly or kmonad-style escapes for parentheses weren't used.
 fn parse_layer_indexes(exprs: &[Spanned<Vec<SExpr>>], expected_len: usize) -> Result<LayerIndexes> {
     let mut layer_indexes = HashMap::default();
     for (i, expr) in exprs.iter().enumerate() {
@@ -823,7 +825,19 @@ fn parse_layer_indexes(exprs: &[Spanned<Vec<SExpr>>], expected_len: usize) -> Re
         if layer_indexes.get(&layer_name).is_some() {
             bail_expr!(layer_expr, "duplicate layer name: {}", layer_name);
         }
-        let num_actions = subexprs.count();
+        // Check if user tried to map parentheses by using them directly - `(` and `)`
+        // or escaped them like in kmonad - `\(` and `\)`.
+        for subexpr in subexprs {
+            if subexpr.list(None).is_some_and(|l| {
+                l.is_empty()
+                    || l.len() == 1
+                        && l.first()
+                            .is_some_and(|s| s.atom(None).is_some_and(|atom| atom == "\\"))
+            }) {
+                bail_expr!(subexpr, "If you meant to map keys to `(` and `)`, you have to use `S-0` and `S-9` instead (for US layout).\nSee https://github.com/jtroo/kanata/issues/163 for context.",)
+            }
+        }
+        let num_actions = expr.t.len() - 1;
         if num_actions != expected_len {
             bail_span!(
                 expr,

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1249,3 +1249,55 @@ fn parse_all_defcfg() {
     )
     .expect("succeeds");
 }
+
+#[test]
+fn using_parentheses_in_deflayer_directly_fails_with_custom_message() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let mut s = ParsedState::default();
+    let source = r#"
+(defsrc a b)
+(deflayer base ( ))
+"#;
+    let err = parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+        DEF_LOCAL_KEYS,
+    )
+    .expect_err("should err");
+    assert!(err
+        .msg
+        .contains("You can't put parentheses in deflayer directly"));
+}
+
+#[test]
+fn using_escaped_parentheses_in_deflayer_fails_with_custom_message() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let mut s = ParsedState::default();
+    let source = r#"
+(defsrc a b)
+(deflayer base \( \))
+"#;
+    let err = parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+        DEF_LOCAL_KEYS,
+    )
+    .expect_err("should err");
+    assert!(err
+        .msg
+        .contains("Escaping shifted characters with `\\` is currently not supported"));
+}


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Improve error messages:
- when parentheses are directly put in `deflayer` (#459)
- when an attempt is made to escape parentheses with `\` in `deflayer` (#163).

Worth noting, that these improved error messages will work only in deflayer, and not in actions.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] Yes
- Added tests and did manual testing
  - [x] Yes
