### PR TITLE
fix(linux): libinput "disable while typing" while kanata is running

### DIFF
--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -347,7 +347,9 @@ impl KbdOut {
 
         let mut device = uinput::VirtualDeviceBuilder::new()?
             .name("kanata")
-            .input_id(evdev::InputId::new(evdev::BusType::BUS_USB, 1, 1, 1))
+            // libinput's "disable while typing" feature don't work when bus_type
+            // is set to BUS_USB, but appears to work when it's set to BUS_I8042.
+            .input_id(evdev::InputId::new(evdev::BusType::BUS_I8042, 1, 1, 1))
             .with_keys(&keys)?
             .with_relative_axes(&relative_axes)?
             .build()?;


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Closes #548
Closes #659

Change virtual output device's bus_type from BUS_USB to BUS_I8042.

This fixes the dwt issues for me on Hyprland and I haven't noticed any regression caused by this change.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Tested manually in Hyprland with `disable_while_typing=1`