### PR TITLE
Enable `fn` alias on Linux in `str_to_oscode`

### DIFF
--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -267,7 +267,7 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "f22" => OsCode::KEY_F22,
         "f23" => OsCode::KEY_F23,
         "f24" => OsCode::KEY_F24,
-        #[cfg(any(target_os = "macos", target_os = "unknown"))]
+        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "unknown"))]
         "fn" => OsCode::KEY_FN,
         #[cfg(target_os = "windows")]
         "kana" | "katakana" | "katakanahiragana" => OsCode::KEY_HANGEUL,


### PR DESCRIPTION
Was there a reason it wasn't enabled? What about windows?

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
