### PR TITLE
Add kext support for macOS version 10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ kanata-keyberon = { path = "keyberon" }
 kanata-parser =   { path = "parser" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-karabiner-driverkit = "0.1.1"
+karabiner-driverkit = "0.1.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = "=0.12.0"

--- a/README.md
+++ b/README.md
@@ -98,12 +98,14 @@ Build and run yourself in Windows.
 
 Build and run yourself in macOS:
 
-First, install the [Karabiner VirtualHiDDevice Driver](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/blob/main/dist/Karabiner-DriverKit-VirtualHIDDevice-3.1.0.pkg).
+For macOS version 11 and newer: Install the [Karabiner VirtualHiDDevice Driver](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/blob/main/dist/Karabiner-DriverKit-VirtualHIDDevice-3.1.0.pkg).
 
 To activate it:
 
 `/Applications/.Karabiner-VirtualHIDDevice-Manager.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Manager activate`
 
+For macOS version 10 and older:
+Install the [Karabiner kernel extension](https://github.com/pqrs-org/Karabiner-VirtualHIDDevice).
 
     git clone https://github.com/jtroo/kanata && cd kanata
     cargo build   # --release optional, not really perf sensitive


### PR DESCRIPTION
Bump driverkit to v0.1.2 and update the readme. 
closes #676 

- Add documentation to docs/config.adoc
  - [ N/A] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [N/A ] Yes or N/A
- Update error messages
  - [N/A ] Yes or N/A
- Added tests, or did manual testing
  - [ N/A] Yes
