### PR TITLE
feat!: conditionally compile tcp server code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,11 +454,12 @@ dependencies = [
 
 [[package]]
 name = "karabiner-driverkit"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc92890fc2bb14a485e777968e7c18355386a30467cc0bf24f7744c9e44dde5"
+checksum = "37c0f0d450e1a3e33739108102ec7e23e56b870b09b367ffb54a82a95682f999"
 dependencies = [
  "cc",
+ "os_info",
 ]
 
 [[package]]
@@ -669,6 +670,17 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_info"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+dependencies = [
+ "log",
+ "serde",
+ "winapi",
+]
 
 [[package]]
 name = "owo-colors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,10 @@ native-windows-gui = { version = "1.0.12", default_features = false }
 kanata-interception = { version = "0.2.0", optional = true }
 
 [features]
-cmd = ["kanata-parser/cmd"]
+default = ["tcp_server"]
 perf_logging = []
+tcp_server = []
+cmd = ["kanata-parser/cmd"]
 interception_driver = ["kanata-interception", "kanata-parser/interception_driver"]
 
 [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,9 +81,9 @@ kanata.kbd in the current working directory and
     #[arg(short, long, verbatim_doc_comment)]
     cfg: Option<Vec<PathBuf>>,
 
-    #[cfg(feature = "tcp_server")]
     /// Port to run the optional TCP server on. If blank, no TCP port will be
     /// listened on.
+    #[cfg(feature = "tcp_server")]
     #[arg(short, long, verbatim_doc_comment)]
     port: Option<i32>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ type CfgPath = PathBuf;
 
 pub struct ValidatedArgs {
     paths: Vec<CfgPath>,
+    #[cfg(feature = "tcp_server")]
     port: Option<i32>,
     #[cfg(target_os = "linux")]
     symlink_path: Option<String>,
@@ -80,6 +81,7 @@ kanata.kbd in the current working directory and
     #[arg(short, long, verbatim_doc_comment)]
     cfg: Option<Vec<PathBuf>>,
 
+    #[cfg(feature = "tcp_server")]
     /// Port to run the optional TCP server on. If blank, no TCP port will be
     /// listened on.
     #[arg(short, long, verbatim_doc_comment)]
@@ -178,6 +180,7 @@ fn cli_init() -> Result<ValidatedArgs> {
 
     Ok(ValidatedArgs {
         paths: cfg_paths,
+        #[cfg(feature = "tcp_server")]
         port: args.port,
         #[cfg(target_os = "linux")]
         symlink_path: args.symlink_path,
@@ -200,7 +203,16 @@ fn main_impl() -> Result<()> {
     // events, which it sends to the "processing loop". The processing loop handles keyboard events
     // while also maintaining `tick()` calls to keyberon.
 
-    let (server, ntx, nrx) = if let Some(port) = args.port {
+    let (server, ntx, nrx) = if let Some(port) = {
+        #[cfg(feature = "tcp_server")]
+        {
+            args.port
+        }
+        #[cfg(not(feature = "tcp_server"))]
+        {
+            None
+        }
+    } {
         let mut server = TcpServer::new(port);
         server.start(kanata_arc.clone());
         let (ntx, nrx) = std::sync::mpsc::sync_channel(100);
@@ -213,6 +225,7 @@ fn main_impl() -> Result<()> {
     Kanata::start_processing_loop(kanata_arc.clone(), rx, ntx, args.nodelay);
 
     if let (Some(server), Some(nrx)) = (server, nrx) {
+        #[allow(clippy::unit_arg)]
         Kanata::start_notification_loop(nrx, server.connections);
     }
 


### PR DESCRIPTION
The motivation for this commit is to enable savings on binary size if desired.

This commit turns the TCP server code into an optional feature. The feature is enabled by default for backwards compatibility. Turning off default features saves 81920 bytes from the stripped binary when compiling with release profile when testing on my system.

## Describe your changes. Use imperative present tense.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
