### PR TITLE
feat!(dynamic-macro): record and simulate delays by default

### DIFF
--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -123,11 +123,19 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                         cfg.dynamic_macro_max_presses = parse_cfg_val_u16(val, label, false)?;
                     }
                     "dynamic-macro-replay-delay-behaviour" => {
-                        cfg.dynamic_macro_replay_delay_behaviour = match label {
-                            "constant" => ReplayDelayBehaviour::Constant,
-                            "recorded" => ReplayDelayBehaviour::Recorded,
-                            _ => bail_expr!(val, "this option must be one of: constant | recorded"),
-                        }
+                        cfg.dynamic_macro_replay_delay_behaviour = val
+                            .atom(None)
+                            .map(|v| match v {
+                                "constant" => Ok(ReplayDelayBehaviour::Constant),
+                                "recorded" => Ok(ReplayDelayBehaviour::Recorded),
+                                _ => bail_expr!(
+                                    val,
+                                    "this option must be one of: constant | recorded"
+                                ),
+                            })
+                            .ok_or_else(|| {
+                                anyhow_expr!(val, "this option must be one of: constant | recorded")
+                            })??;
                     }
                     "linux-dev" => {
                         #[cfg(any(target_os = "linux", target_os = "unknown"))]

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -58,7 +58,7 @@ impl Default for CfgOptions {
             movemouse_inherit_accel_state: false,
             movemouse_smooth_diagonals: false,
             dynamic_macro_max_presses: 128,
-            dynamic_macro_replay_delay_behaviour: ReplayDelayBehaviour::Constant,
+            dynamic_macro_replay_delay_behaviour: ReplayDelayBehaviour::Recorded,
             concurrent_tap_hold: false,
             #[cfg(any(target_os = "linux", target_os = "unknown"))]
             linux_dev: vec![],
@@ -459,8 +459,9 @@ pub const HWID_ARR_SZ: usize = 128;
 pub enum ReplayDelayBehaviour {
     /// Always use a fixed number of ticks between presses and releases.
     /// This is the original kanata behaviour.
+    /// This means that held action activations like in tap-hold do not behave as intended.
     Constant,
     /// Use the recorded number of ticks between presses and releases.
-    /// This is new behaviour.
+    /// This is newer behaviour.
     Recorded,
 }

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -18,6 +18,7 @@ pub struct CfgOptions {
     pub movemouse_inherit_accel_state: bool,
     pub movemouse_smooth_diagonals: bool,
     pub dynamic_macro_max_presses: u16,
+    pub dynamic_macro_replay_delay_behaviour: ReplayDelayBehaviour,
     pub concurrent_tap_hold: bool,
     #[cfg(any(target_os = "linux", target_os = "unknown"))]
     pub linux_dev: Vec<String>,
@@ -57,6 +58,7 @@ impl Default for CfgOptions {
             movemouse_inherit_accel_state: false,
             movemouse_smooth_diagonals: false,
             dynamic_macro_max_presses: 128,
+            dynamic_macro_replay_delay_behaviour: ReplayDelayBehaviour::Constant,
             concurrent_tap_hold: false,
             #[cfg(any(target_os = "linux", target_os = "unknown"))]
             linux_dev: vec![],
@@ -119,6 +121,13 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                     }
                     "dynamic-macro-max-presses" => {
                         cfg.dynamic_macro_max_presses = parse_cfg_val_u16(val, label, false)?;
+                    }
+                    "dynamic-macro-replay-delay-behaviour" => {
+                        cfg.dynamic_macro_replay_delay_behaviour = match label {
+                            "constant" => ReplayDelayBehaviour::Constant,
+                            "recorded" => ReplayDelayBehaviour::Recorded,
+                            _ => bail_expr!(val, "this option must be one of: constant | recorded"),
+                        }
                     }
                     "linux-dev" => {
                         #[cfg(any(target_os = "linux", target_os = "unknown"))]
@@ -445,3 +454,13 @@ impl Default for AltGrBehaviour {
     target_os = "unknown"
 ))]
 pub const HWID_ARR_SZ: usize = 128;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReplayDelayBehaviour {
+    /// Always use a fixed number of ticks between presses and releases.
+    /// This is the original kanata behaviour.
+    Constant,
+    /// Use the recorded number of ticks between presses and releases.
+    /// This is new behaviour.
+    Recorded,
+}

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -15,7 +15,6 @@ mod windows;
 pub use macos::PageCode;
 
 mod mappings;
-pub use mappings::*;
 
 #[cfg(target_os = "unknown")]
 #[derive(Clone, Copy)]

--- a/src/kanata/dynamic_macro.rs
+++ b/src/kanata/dynamic_macro.rs
@@ -173,10 +173,9 @@ pub fn begin_record_macro(
                         pending_event.0,
                         state.current_delay,
                     ))),
-                    WaitingEventType::Release => state.macro_items.push(DynamicMacroItem::Release((
-                        pending_event.0,
-                        state.current_delay,
-                    ))),
+                    WaitingEventType::Release => state.macro_items.push(DynamicMacroItem::Release(
+                        (pending_event.0, state.current_delay),
+                    )),
                 };
             }
             // remove the last item, since it's almost certainly a "macro

--- a/src/kanata/dynamic_macro.rs
+++ b/src/kanata/dynamic_macro.rs
@@ -67,7 +67,7 @@ impl DynamicMacroRecordState {
                     pending_event.0,
                     self.current_delay,
                 ))),
-                WaitingEventType::Release => self.macro_items.push(DynamicMacroItem::Press((
+                WaitingEventType::Release => self.macro_items.push(DynamicMacroItem::Release((
                     pending_event.0,
                     self.current_delay,
                 ))),

--- a/src/kanata/dynamic_macro.rs
+++ b/src/kanata/dynamic_macro.rs
@@ -173,7 +173,7 @@ pub fn begin_record_macro(
                         pending_event.0,
                         state.current_delay,
                     ))),
-                    WaitingEventType::Release => state.macro_items.push(DynamicMacroItem::Press((
+                    WaitingEventType::Release => state.macro_items.push(DynamicMacroItem::Release((
                         pending_event.0,
                         state.current_delay,
                     ))),
@@ -251,7 +251,7 @@ pub fn stop_macro(
                     pending_event.0,
                     state.current_delay,
                 ))),
-                WaitingEventType::Release => state.macro_items.push(DynamicMacroItem::Press((
+                WaitingEventType::Release => state.macro_items.push(DynamicMacroItem::Release((
                     pending_event.0,
                     state.current_delay,
                 ))),

--- a/src/kanata/dynamic_macro.rs
+++ b/src/kanata/dynamic_macro.rs
@@ -31,13 +31,16 @@ impl DynamicMacroRecordState {
         let mut pressed_oscs = HashSet::default();
         for item in self.macro_items.iter() {
             match item {
-                DynamicMacroItem::Press(osc) => pressed_oscs.insert(*osc),
-                DynamicMacroItem::Release(osc) => pressed_oscs.remove(osc),
-                DynamicMacroItem::EndMacro(_) => false,
-                DynamicMacroItem::Delay(_) => false,
+                DynamicMacroItem::Press(osc) => {
+                    pressed_oscs.insert(*osc);
+                }
+                DynamicMacroItem::Release(osc) => {
+                    pressed_oscs.remove(osc);
+                }
+                DynamicMacroItem::EndMacro(_) | DynamicMacroItem::Delay(_) => {}
             };
         }
-        // Hopefully release order doesn't matter here since a HashSet is being used
+        // Hopefully release order doesn't matter here. A HashSet is being used, meaning release order is arbitrary.
         for osc in pressed_oscs.into_iter() {
             self.macro_items.push(DynamicMacroItem::Release(osc));
         }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -429,7 +429,9 @@ impl Kanata {
                 if tick_replay_state(
                     &mut self.dynamic_macro_replay_state,
                     self.dynamic_macro_replay_behaviour,
-                ).is_some() {
+                )
+                .is_some()
+                {
                     log::error!("overshot to next event at iteration #{i}, the code is broken!");
                     break;
                 }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -416,8 +416,8 @@ impl Kanata {
                 self.dynamic_macro_replay_behaviour,
             ) {
                 log::debug!("sending event at tick {}", self.tick_count);
-                self.layout.bm().event(event.0);
-                extra_ticks = extra_ticks.saturating_add(event.1);
+                self.layout.bm().event(event.key_event());
+                extra_ticks = extra_ticks.saturating_add(event.delay());
                 log::debug!("dyn macro ms elapsed: {ms_elapsed}");
                 log::debug!("dyn macro extra ticks: {extra_ticks}");
             }
@@ -426,10 +426,10 @@ impl Kanata {
         if ms_elapsed > 0 {
             for i in 0..(extra_ticks.saturating_sub(ms_elapsed as u16)) {
                 self.tick_states()?;
-                if let Some(_) = tick_replay_state(
+                if tick_replay_state(
                     &mut self.dynamic_macro_replay_state,
                     self.dynamic_macro_replay_behaviour,
-                ) {
+                ).is_some() {
                     log::error!("overshot to next event at iteration #{i}, the code is broken!");
                     break;
                 }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -416,7 +416,7 @@ impl Kanata {
                 Some(ReplayEvent::KeyEvent(event)) => {
                     self.layout.bm().event(event);
                 }
-                Some(ReplayEvent::Delay(ticks)) => {
+                Some(ReplayEvent::ExtraTicks(ticks)) => {
                     extra_ticks = extra_ticks.saturating_add(ticks);
                 }
                 None => {}
@@ -432,7 +432,7 @@ impl Kanata {
                 Some(ReplayEvent::KeyEvent(event)) => {
                     self.layout.bm().event(event);
                 }
-                Some(ReplayEvent::Delay(_)) => {
+                Some(ReplayEvent::ExtraTicks(_)) => {
                     unreachable!("there should not be replay delays when doing extra ticks")
                 }
                 None => {}
@@ -1162,7 +1162,7 @@ impl Kanata {
                         }
                         CustomAction::DynamicMacroRecord(macro_id) => {
                             if let Some((macro_id, prev_recorded_macro)) =
-                                record_macro(*macro_id, &mut self.dynamic_macro_record_state)
+                                begin_record_macro(*macro_id, &mut self.dynamic_macro_record_state)
                             {
                                 self.dynamic_macros.insert(macro_id, prev_recorded_macro);
                             }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -163,7 +163,6 @@ pub struct Kanata {
     unshifted_keys: Vec<KeyCode>,
     /// Keep track of last pressed key for [`CustomAction::Repeat`].
     last_pressed_key: KeyCode,
-    tick_count: u64,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -323,7 +322,6 @@ impl Kanata {
             unmodded_keys: vec![],
             unshifted_keys: vec![],
             last_pressed_key: KeyCode::No,
-            tick_count: 0,
         })
     }
 
@@ -415,11 +413,9 @@ impl Kanata {
                 &mut self.dynamic_macro_replay_state,
                 self.dynamic_macro_replay_behaviour,
             ) {
-                log::debug!("sending event at tick {}", self.tick_count);
                 self.layout.bm().event(event.key_event());
                 extra_ticks = extra_ticks.saturating_add(event.delay());
-                log::debug!("dyn macro ms elapsed: {ms_elapsed}");
-                log::debug!("dyn macro extra ticks: {extra_ticks}");
+                log::debug!("dyn macro extra ticks: {extra_ticks}, ms_elapsed: {ms_elapsed}");
             }
         }
 
@@ -490,7 +486,6 @@ impl Kanata {
         tick_record_state(&mut self.dynamic_macro_record_state);
         self.prev_keys.clear();
         self.prev_keys.append(&mut self.cur_keys);
-        self.tick_count += 1;
         Ok(())
     }
 

--- a/src/kanata/windows/mod.rs
+++ b/src/kanata/windows/mod.rs
@@ -6,13 +6,9 @@ use crate::kanata::*;
 
 #[cfg(not(feature = "interception_driver"))]
 mod llhook;
-#[cfg(not(feature = "interception_driver"))]
-pub use llhook::*;
 
 #[cfg(feature = "interception_driver")]
 mod interception;
-#[cfg(feature = "interception_driver")]
-pub use self::interception::*;
 
 static PRESSED_KEYS: Lazy<Mutex<HashSet<OsCode>>> = Lazy::new(|| Mutex::new(HashSet::default()));
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Implements #658.

This is a breaking change in behaviour of dynamic macros. I'm not sure that the anyone would really want the old behaviour though. It seems odd that someone might be dependent on it.

Kanata defaults to the new behaviour but can be reverted if desired. I may choose to remove the `defcfg` option though, and **only** have the new behaviour. For now the option is left undocumented, so that I can argue that it is not a breaking change if I choose to remove the option in the future, since the option was never documented ;)

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes
