### PR TITLE
feat: add `check` argument

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -216,7 +216,7 @@ pub struct Cfg {
 /// Parse a new configuration from a file.
 pub fn new_from_file(p: &Path) -> MResult<Cfg> {
     let (items, mapped_keys, layer_info, key_outputs, layout, sequences, overrides) = parse_cfg(p)?;
-    log::info!("config parsed");
+    log::info!("config file is valid");
     Ok(Cfg {
         items,
         mapped_keys,

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1460,6 +1460,12 @@ impl Kanata {
             let mut ms_elapsed = 0;
 
             info!("Starting kanata proper");
+
+            info!(
+                "You may forcefully exit kanata by pressing lctl+spc+esc at any time. \
+                        These keys refer to defsrc input, meaning BEFORE kanata remaps keys."
+            );
+
             let err = loop {
                 let can_block = {
                     let mut k = kanata.lock();

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,8 @@ kanata.kbd in the current working directory and
     #[arg(short, long, verbatim_doc_comment)]
     symlink_path: Option<String>,
 
-    #[cfg_attr(target_os = "macos", doc = "List the keyboards available for grabbing")]
+    /// List the keyboards available for grabbing and exit.
+    #[cfg(target_os = "macos")]
     #[arg(short, long)]
     list: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 use clap::Parser;
+use kanata_parser::cfg;
 use log::info;
 use simplelog::*;
 
@@ -119,6 +120,10 @@ kanata.kbd in the current working directory and
     #[cfg(target_os = "linux")]
     #[arg(short, long, verbatim_doc_comment)]
     wait_device_ms: Option<u64>,
+
+    /// Validate configuration file and exit
+    #[arg(long, verbatim_doc_comment)]
+    check: bool,
 }
 
 /// Parse CLI arguments and initialize logging.
@@ -171,6 +176,19 @@ fn cli_init() -> Result<ValidatedArgs> {
     } else {
         bail!("No config files provided\nFor more info, pass the `-h` or `--help` flags.");
     }
+
+    if args.check {
+        log::info!("validating config only and exiting");
+        let status = match cfg::new_from_file(&cfg_paths[0]) {
+            Ok(_) => 0,
+            Err(e) => {
+                log::error!("{e:?}");
+                1
+            }
+        };
+        std::process::exit(status);
+    }
+
 
     #[cfg(target_os = "linux")]
     if let Some(wait) = args.wait_device_ms {

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,10 +161,6 @@ fn cli_init() -> Result<ValidatedArgs> {
     log::info!("using LLHOOK+SendInput for keyboard IO");
     #[cfg(all(feature = "interception_driver", target_os = "windows"))]
     log::info!("using the Interception driver for keyboard IO");
-    log::info!(
-        "You may forcefully exit kanata by pressing lctl+spc+esc at any time. \
-                These keys refer to defsrc input, meaning BEFORE kanata remaps keys."
-    );
 
     if let Some(config_file) = cfg_paths.first() {
         if !config_file.exists() {
@@ -188,7 +184,6 @@ fn cli_init() -> Result<ValidatedArgs> {
         };
         std::process::exit(status);
     }
-
 
     #[cfg(target_os = "linux")]
     if let Some(wait) = args.wait_device_ms {


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Closes #689

Add `--check` argument. Name not final, but I think it's good enough. No short arg, because `c` is already occupied by cfg file arg, but maybe some other letter could be used.

Additionally fixed bug with `list` argument showing up despite of binary not being compiled for macOS.

Also I've included some other subjective changes regarding logs (see 3rd and 4th commits). I can revert if you don't like them

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes, manual testing
