### PR TITLE
feat!: add concat keyword for defvar

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -291,6 +291,14 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   hold-timeout  200
   tt $tap-timeout
   ht $hold-timeout
+
+  ;; A list value in defvar that begins with concat behaves in a special manner
+  ;; where strings will be joined together.
+  ;;
+  ;; Below results in 100200
+  a "hello"
+  b "world"
+  ct (concat $a " " $b)
 )
 
 (defalias

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -229,19 +229,18 @@ mentioned before, please ask for help in an issue or discussion if needed, and
 help with https://github.com/jtroo/kanata/blob/main/docs/locales.adoc[this document] is very welcome so that future
 users can have an easier time 🙂.
 
-[[optional-defcfg-entries]]
-== Optional defcfg entries
-
-[[defcfg]]
-=== defcfg
+[[introduction-defcfg]]
+== Introduction to defcfg
 <<table-of-contents,Back to ToC>>
 
 Your configuration file may include a single `defcfg` entry.
+The `defcfg` can be empty or omitted.
+There are options that change kanata's behaviour,
+but this introduction will introduce
+only the most prevalent entry: `process-unmapped-keys`.
+All other options can be found later in the <<optional-defcfg-options>> section.
 
-It can be empty but there are options that can change kanata's behaviour that
-will be described in this section.
-
-.Example:
+.Example of an empty defcfg:
 [source]
 ----
 (defcfg)
@@ -251,535 +250,27 @@ will be described in this section.
 === process-unmapped-keys
 <<table-of-contents,Back to ToC>>
 
-Enabling this configuration makes kanata process keys that are not in defsrc.
-This is useful if you are only mapping a few keys in defsrc instead of most of
-the keys on your keyboard.
+The `process-unmapped-keys` option in `defcfg` is probably the most
+generally impactful option.
+Enabling this configuration makes kanata process keys
+that are not defined in `defsrc'.
+This might be useful
+if you are only mapping a few keys in defsrc
+instead of most of the keys on your keyboard.
 
 Without this, some actions like `+rpt+`, `+tap-hold-release+`, `+one-shot+`,
 will not work correctly for subsequent key presses that are not in defsrc.
 
-This is disabled by default. The reason this is not enabled by default is
-because some keys may not work correctly if they are intercepted. For example,
-see the <<windows-only-windows-altgr>> option below.
+This option is disabled by default.
+The reason this is not enabled by default is
+because some keys may not work correctly if they are intercepted.
+For example, see <<windows-only-windows-altgr>>.
 
 .Example:
 [source]
 ----
 (defcfg
   process-unmapped-keys yes
-)
-----
-
-[[danger-enable-cmd]]
-=== danger-enable-cmd
-<<table-of-contents,Back to ToC>>
-
-This option can be used to enable the `cmd` action in your configuration. The
-`+cmd+` action allows kanata to execute programs with arguments passed to them.
-
-This requires using a kanata program that is compiled with the `cmd` action
-enabled. The reason for this is so that if you choose to, there is no way for
-kanata to execute arbitrary programs even if you download some random
-configuration from the internet.
-
-This configuration is disabled by default and can be enabled by giving it the
-value `yes`.
-
-.Example:
-[source]
-----
-(defcfg
-  danger-enable-cmd yes
-)
-----
-
-[[sequence-timeout]]
-=== sequence-timeout
-<<table-of-contents,Back to ToC>>
-
-This option customizes the key sequence timeout (unit: ms). Its default value
-is 1000. The purpose of this item is explained in <<sequences>>.
-
-.Example:
-[source]
-----
-(defcfg
-  sequence-timeout 2000
-)
-----
-
-[[sequence-input-mode]]
-=== sequence-input-mode
-<<table-of-contents,Back to ToC>>
-
-This option customizes the key sequence input mode. Its default value when not
-configured is `hidden-suppressed`.
-
-The options are:
-
-- `visible-backspaced`: types sequence characters as they are inputted. The
-  typed characters will be erased with backspaces for a valid sequence termination.
-- `hidden-suppressed`: hides sequence characters as they are typed. Does not
-  output the hidden characters for an invalid sequence termination.
-- `hidden-delay-type`: hides sequence characters as they are typed. Outputs the
-  hidden characters for an invalid sequence termination either after a
-  timeout or after a non-sequence key is typed.
-
-For `visible-backspaced` and `hidden-delay-type`, a sequence leader input will
-be ignored if a sequence is already active. For historical reasons, and in case
-it is desired behaviour, a sequence leader input using `hidden-suppressed` will
-reset the key sequence.
-
-See <<sequences>> for more about sequences.
-
-.Example:
-[source]
-----
-(defcfg
-  sequence-input-mode visible-backspaced
-)
-----
-
-
-[[sequence-backtrack-modcancel]]
-=== sequence-backtrack-modcancel
-<<table-of-contents,Back to ToC>>
-
-This option customizes the behaviour of key sequences
-when modifiers are used.
-The default is `yes` and can be overridden to `no` if desired.
-
-Setting it to `yes` allows both `fk1` and `fk2` to be activated
-in the following configuration, but with `no`,
-`fk1` will be impossible to activate
-
-----
-(defseq
-  fk1 (lsft a b)
-  fk2 (S-(c d))
-)
-----
-
-See <<sequences>> for more about sequences and
-https://github.com/jtroo/kanata/blob/main/docs/sequence-adding-chords-ideas.md[this document]
-for more context about this specific configuration.
-
-.Example:
-[source]
-----
-(defcfg
-  sequence-backtrack-modcancel no
-)
-----
-
-[[log-layer-changes]]
-=== log-layer-changes
-<<table-of-contents,Back to ToC>>
-
-By default, kanata will log layer changes. However, logging has some processing
-overhead. If you do not care for the logging, you can choose to disable it.
-
-.Example:
-[source]
-----
-(defcfg
-  log-layer-changes no
-)
-----
-
-[[delegate-to-first-layer]]
-=== delegate-to-first-layer
-<<table-of-contents,Back to ToC>>
-
-
-By default, transparent keys on layers
-will delegate to the corresponding defsrc key
-when found on a layer activated by `layer-switch`.
-
-This config entry changes the behaviour
-to delegate to the action in the same position on the first layer defined
-in the configuration, which is the active layer on startup.
-
-For more context, see https://github.com/jtroo/kanata/issues/435.
-
-.Example:
-[source]
-----
-(defcfg
-  delegate-to-first-layer yes
-)
-----
-
-
-[[movemouse-inherit-accel-state]]
-=== movemouse-inherit-accel-state
-<<table-of-contents,Back to ToC>>
-
-By default `movemouse-accel` actions will track the acceleration
-state for vertical and horizontal axes separately.
-
-When this setting is enabled, `movemouse-accel` will behave exactly like mouse movements in https://qmk.fm[QMK],
-i.e. the acceleration state of new mouse
-movement actions will be inherited if others are already being pressed.
-
-.Example:
-[source]
-----
-(defcfg
-  movemouse-inherit-accel-state yes
-)
-----
-
-[[movemouse-smooth-diagonals]]
-=== movemouse-smooth-diagonals
-<<table-of-contents,Back to ToC>>
-
-By default, mouse movements move one direction at a time
-and vertical/horizontal movements are on independent timers.
-
-This can result in non-smooth diagonals when drawing a line in some app.
-This option adds a small imperceptible amount of latency to
-synchronize the mouse movements.
-
-.Example:
-[source]
-----
-(defcfg
-  movemouse-smooth-diagonals yes
-)
-----
-
-=== dynamic-macro-max-presses [[dynamic-macro-max-presses]]
-<<table-of-contents,Back to ToC>>
-
-This configuration allows you to customize the length limit on dynamic macros.
-The default length limit is 128 keys.
-
-.Example:
-[source]
-----
-(defcfg
-  dynamic-macro-max-presses 1000
-)
-----
-
-=== concurrent-tap-hold [[concurrent-tap-hold]]
-This configuration makes multiple tap-hold actions
-that are activated near in time expire their timeout quicker.
-By default this is disabled.
-When disabled, the timeout for a following tap-hold
-will start from 0ms **after** the previous tap-hold expires.
-When enabled, the timeout will start
-as soon as the tap-hold action is pressed
-even if a previous tap-hold action is still held and has not expired.
-
-.Example:
-[source]
-----
-(defcfg
-  concurrent-tap-hold yes
-)
-----
-
-[[linux-only-linux-dev]]
-=== Linux only: linux-dev
-<<table-of-contents,Back to ToC>>
-By default, kanata will try to detect which input devices are keyboards and try
-to intercept them all. However, you may specify exact keyboard devices from the
-`/dev/input` directories using the `linux-dev` configuration.
-
-.Example:
-[source]
-----
-(defcfg
-  linux-dev /dev/input/by-path/platform-i8042-serio-0-event-kbd
-)
-----
-
-If you want to specify multiple keyboards, you can separate the paths with a
-colon `+:+`.
-
-.Example:
-[source]
-----
-(defcfg
-  linux-dev /dev/input/dev1:/dev/input/dev2
-)
-----
-
-Due to using the colon to separate devices, if you have a device with colons in
-its file name, you must escape those colons with backslashes:
-
-[source]
-----
-(defcfg
-  linux-dev /dev/input/path-to\:device
-)
-----
-
-Alternatively, you can use list syntax, where both backslashes and colons
-are parsed literally. List items are separated by spaces or newlines.
-Using quotation marks for each item is optional, and only required if an
-item contains spaces.
-
-[source]
-----
-(defcfg
-  linux-dev (
-    /dev/input/path:to:device
-    "/dev/input/path to device"
-  )
-)
-----
-
-[[linux-only-linux-dev-names-include]]
-=== Linux only: linux-dev-names-include
-<<table-of-contents,Back to ToC>>
-
-In the case that `linux-dev` is omitted,
-this option defines a list of device names that should be included.
-Device names that do not exist in the list will be ignored.
-This option is parsed identically to `linux-dev`.
-
-Kanata will print device names on startup with log lines that look like below:
-
-----
-registering /dev/input/eventX: "Name goes here"
-----
-
-.Example:
-[source]
-----
-(defcfg
-  linux-dev-names-include (
-    "Device name 1"
-    "Device name 2"
-  )
-)
-----
-
-[[linux-only-linux-dev-names-exclude]]
-=== Linux only: linux-dev-names-exclude
-<<table-of-contents,Back to ToC>>
-
-In the case that `linux-dev` is omitted,
-this option defines a list of device names that should be excluded.
-This option is parsed identically to `linux-dev`.
-
-The `linux-dev-names-include` and `linux-dev-names-exclude` options
-are not mutually exclusive
-but in practice it probably only makes sense to use one and not both.
-
-.Example:
-[source]
-----
-(defcfg
-  linux-dev-names-exclude (
-    "Device Name 1"
-    "Device Name 2"
-  )
-)
-----
-
-[[linux-only-linux-continue-if-no-devs-found]]
-=== Linux only: linux-continue-if-no-devs-found
-<<table-of-contents,Back to ToC>>
-
-By default, kanata will crash if no input devices are found. You can change
-this behaviour by setting `linux-continue-if-no-devs-found`.
-
-.Example:
-[source]
-----
-(defcfg
-  linux-continue-if-no-devs-found yes
-)
-----
-
-[[linux-only-linux-unicode-u-code]]
-=== Linux only: linux-unicode-u-code
-<<table-of-contents,Back to ToC>>
-
-Unicode on Linux works by pressing Ctrl+Shift+U, typing the unicode hex value,
-then pressing Enter. However, if you do remapping in userspace, e.g. via
-xmodmap/xkb, the keycode "U" that kanata outputs may not become a keysym "u"
-after the userspace remapping. This will be likely if you use non-US,
-non-European keyboards on top of kanata. For unicode to work, kanata needs to
-use the keycode that outputs the keysym "u", which might not be the keycode
-"U".
-
-You can use `evtest` or `kanata --debug`, set your userspace key remapping,
-then press the key that outputs the keysym "u" to see which underlying keycode
-is sent. Then you can use this configuration to change kanata's behaviour.
-
-.Example:
-[source]
-----
-(defcfg
-  linux-unicode-u-code v
-)
-----
-
-[[linux-only-linux-unicode-termination]]
-=== Linux only: linux-unicode-termination
-<<table-of-contents,Back to ToC>>
-
-Unicode on Linux terminates with the Enter key by default. This may not work in
-some applications. The termination is configurable with the following options:
-
-- `enter`
-- `space`
-- `enter-space`
-- `space-enter`
-
-.Example:
-[source]
-----
-(defcfg
-  linux-unicode-termination space
-)
-----
-
-=== Linux only: linux-x11-repeat-delay-rate[[linux-only-x11-repeat-rate]]
-<<table-of-contents,Back to ToC>>
-
-On Linux, you can tell kanata to run `xset r rate <delay> <rate>`
-on startup and on live reload
-via the configuration item `linux-only-x11-repeat-rate`.
-This takes two numbers separated by a comma.
-The first number is the delay in ms
-and the second number is the repeat rate in repeats/second.
-
-This configuration item does not affect Wayland or no-desktop environments.
-
-.Example:
-[source]
-----
-(defcfg
-  linux-x11-repeat-delay-rate 400,50
-)
-----
-
-[[macos-only-macos-dev-names-include]]
-=== macOS only: macos-dev-names-include
-<<table-of-contents,Back to ToC>>
-
-This option defines a list of device names that should be included.
-By default, kanata will try to detect which input devices are keyboards and try
-to intercept them all. However, you may specify exact keyboard devices to intercept
-using the `macos-dev-names-include` configuration.
-Device names that do not exist in the list will be ignored.
-This option is parsed identically to `linux-dev`.
-
-Use `kanata -l` or `kanata --list` to list the available keyboards.
-
-.Example:
-[source]
-----
-(defcfg
-  macos-dev-names-include (
-    "Device name 1"
-    "Device name 2"
-  )
-)
-----
-
-[[windows-only-windows-altgr]]
-=== Windows only: windows-altgr
-<<table-of-contents,Back to ToC>>
-
-There is an option for Windows to help mitigate the strange behaviour of AltGr
-(ralt) if you're using that key in your defsrc. This is applicable for many
-non-US layouts. You can use one of the listed values to change what kanata does
-with the key:
-
-* `cancel-lctl-press`
-** This will remove the `lctl` press that is generated alonside `ralt`
-* `add-lctl-release`
-** This adds an `lctl` release when `ralt` is released
-
-.Example:
-[source]
-----
-(defcfg
-  windows-altgr add-lctl-release
-)
-----
-
-For more context, see: https://github.com/jtroo/kanata/issues/55.
-
-NOTE: Even with these workarounds, putting `+lctl+`+`+ralt+` in your defsrc may not
-work properly with other applications that also use keyboard interception.
-Known application with issues: GWSL/VcXsrv
-
-=== Windows only: windows-interception-mouse-hwid[[windows-only-windows-interception-mouse-hwid]]
-<<table-of-contents,Back to ToC>>
-
-This defcfg item allows you to intercept mouse buttons for a specific mouse
-device. This only works with the Interception driver (the -wintercept variants
-of the binary).
-
-The intended use case for this is for laptops such as a Thinkpad, which have
-mouse buttons that may be desirable to activate kanata actions with.
-
-To know what numbers to put into the string, you can run the variant with this
-defcfg item defined with any numbers. Then when a button is first pressed on
-the mouse device, kanata will print its hwid in the log; you can then
-copy-paste that into this configuration entry. If this defcfg item is not
-defined, the log will not print.
-
-https://github.com/jtroo/kanata/issues/108[Relevant issue].
-
-.Example:
-[source]
-----
-(defcfg
-  windows-interception-mouse-hwid "70, 0, 60, 0"
-)
-----
-
-[[using-multiple-defcfg-entries]]
-=== Using multiple defcfg entries
-<<table-of-contents,Back to ToC>>
-
-The `defcfg` entry is treated as a list with pairs of strings. For example:
-
-[source]
-----
-(defcfg a 1 b 2)
-----
-
-This will be treated as configuration `a` having value `1` and configuration
-`b` having value `2`.
-
-An example defcfg containing many of the options is shown below. It should be
-noted options that are Linux-only, Windows-only, or macOS-only will be ignored when used on
-a non-applicable operating system.
-
-[source]
-----
-;; Don't actually use this exact configuration,
-;; it's almost certainly not what you want.
-(defcfg
-  process-unmapped-keys yes
-  danger-enable-cmd yes
-  sequence-timeout 2000
-  sequence-input-mode visible-backspaced
-  sequence-backtrack-modcancel no
-  log-layer-changes no
-  delegate-to-first-layer yes
-  movemouse-inherit-accel-state yes
-  movemouse-smooth-diagonals yes
-  dynamic-macro-max-presses 1000
-  linux-dev (/dev/input/dev1 /dev/input/dev2)
-  linux-dev-names-include ("Name 1" "Name 2")
-  linux-dev-names-exclude ("Name 3" "Name 4")
-  linux-continue-if-no-devs-found yes
-  linux-unicode-u-code v
-  linux-unicode-termination space
-  linux-x11-repeat-delay-rate 400,50
-  windows-altgr add-lctl-release
-  windows-interception-mouse-hwid "70, 0, 60, 0"
 )
 ----
 
@@ -899,11 +390,29 @@ Variables are referred to by prefixing their name with `$`.
 )
 ----
 
+[[concat-in-defvar]]
+==== concat in defvar
+
+Within the second item of `defvar`,
+a list that begins with the special keyword `concat` will concatenate all
+subsequent items in the list together into a single string value.
+Without using `concat`, lists are saved as-is.
+
+.Example:
+[source]
+----
+(defvar
+  rootpath "/home/myuser/mysubdir"
+  ;; $otherpath will be the string: /home/myuser/mysubdir/helloworld
+  otherpath (concat $rootpath "/helloworld")
+)
+----
+
 [[actions]]
 == Actions
 
-The actions kanata provides are what make it truly customizable. This section
-explains the available actions.
+The actions kanata provides are what make it truly customizable.
+This section explains the available actions.
 
 [[live-reload]]
 === Live reload
@@ -1891,14 +1400,26 @@ This can be useful for forcing unshifted keys while AltGr is still held.
 === cmd
 <<table-of-contents,Back to ToC>>
 
+WARNING: This action does not work unless you use the appropriate binary
+or - if compiling yourself - the appropriate feature flag.
+Additionally you must add the <<danger-enable-cmd>> `defcfg` option.
+
 The `+cmd+` action executes a program with arguments. It accepts one or more
 strings. The first string is the program that will be run and the following
 strings are arguments to that program. The arguments are provided to the
 program in the order written in the config file.
+Lists may also be used within `cmd`
+which you may desire to do for reuse via `defvar`.
+Lists will be flattened such that arguments are provided to the program
+in the order written in the config file, regardless of list nesting.
+To be technical, it would be a depth-first flattening (similar to DFS).
 
-NOTE: The command is executed directly and not via a shell, so you cannot make
-use of environment variables, e.g. `+~+` or `+$HOME+` in Linux will not be
+NOTE: commands are executed directly and not via a shell, so you cannot make
+use of environment variables or symbols with special meaning.
+For example `+~+` or `+$HOME+` in Linux will not be
 substituted with your home directory.
+If you want to execute with a shell program use `bash -c` or `powershell.exe`
+as the first parameter.
 
 .Example:
 [source]
@@ -2007,6 +1528,522 @@ The included files also cannot contain includes themselves.
 ;; This is in the other file
 (deflayer included-layer
   ;; ...
+)
+----
+
+[[optional-defcfg-options]]
+== defcfg options
+
+[[danger-enable-cmd]]
+=== danger-enable-cmd
+<<table-of-contents,Back to ToC>>
+
+This option can be used to enable the `cmd` action in your configuration. The
+`+cmd+` action allows kanata to execute programs with arguments passed to them.
+
+This requires using a kanata program that is compiled with the `cmd` action
+enabled. The reason for this is so that if you choose to, there is no way for
+kanata to execute arbitrary programs even if you download some random
+configuration from the internet.
+
+This configuration is disabled by default and can be enabled by giving it the
+value `yes`.
+
+.Example:
+[source]
+----
+(defcfg
+  danger-enable-cmd yes
+)
+----
+
+[[sequence-timeout]]
+=== sequence-timeout
+<<table-of-contents,Back to ToC>>
+
+This option customizes the key sequence timeout (unit: ms). Its default value
+is 1000. The purpose of this item is explained in <<sequences>>.
+
+.Example:
+[source]
+----
+(defcfg
+  sequence-timeout 2000
+)
+----
+
+[[sequence-input-mode]]
+=== sequence-input-mode
+<<table-of-contents,Back to ToC>>
+
+This option customizes the key sequence input mode. Its default value when not
+configured is `hidden-suppressed`.
+
+The options are:
+
+- `visible-backspaced`: types sequence characters as they are inputted. The
+  typed characters will be erased with backspaces for a valid sequence termination.
+- `hidden-suppressed`: hides sequence characters as they are typed. Does not
+  output the hidden characters for an invalid sequence termination.
+- `hidden-delay-type`: hides sequence characters as they are typed. Outputs the
+  hidden characters for an invalid sequence termination either after a
+  timeout or after a non-sequence key is typed.
+
+For `visible-backspaced` and `hidden-delay-type`, a sequence leader input will
+be ignored if a sequence is already active. For historical reasons, and in case
+it is desired behaviour, a sequence leader input using `hidden-suppressed` will
+reset the key sequence.
+
+See <<sequences>> for more about sequences.
+
+.Example:
+[source]
+----
+(defcfg
+  sequence-input-mode visible-backspaced
+)
+----
+
+
+[[sequence-backtrack-modcancel]]
+=== sequence-backtrack-modcancel
+<<table-of-contents,Back to ToC>>
+
+This option customizes the behaviour of key sequences
+when modifiers are used.
+The default is `yes` and can be overridden to `no` if desired.
+
+Setting it to `yes` allows both `fk1` and `fk2` to be activated
+in the following configuration, but with `no`,
+`fk1` will be impossible to activate
+
+----
+(defseq
+  fk1 (lsft a b)
+  fk2 (S-(c d))
+)
+----
+
+See <<sequences>> for more about sequences and
+https://github.com/jtroo/kanata/blob/main/docs/sequence-adding-chords-ideas.md[this document]
+for more context about this specific configuration.
+
+.Example:
+[source]
+----
+(defcfg
+  sequence-backtrack-modcancel no
+)
+----
+
+[[log-layer-changes]]
+=== log-layer-changes
+<<table-of-contents,Back to ToC>>
+
+By default, kanata will log layer changes. However, logging has some processing
+overhead. If you do not care for the logging, you can choose to disable it.
+
+.Example:
+[source]
+----
+(defcfg
+  log-layer-changes no
+)
+----
+
+[[delegate-to-first-layer]]
+=== delegate-to-first-layer
+<<table-of-contents,Back to ToC>>
+
+
+By default, transparent keys on layers
+will delegate to the corresponding defsrc key
+when found on a layer activated by `layer-switch`.
+
+This config entry changes the behaviour
+to delegate to the action in the same position on the first layer defined
+in the configuration, which is the active layer on startup.
+
+For more context, see https://github.com/jtroo/kanata/issues/435.
+
+.Example:
+[source]
+----
+(defcfg
+  delegate-to-first-layer yes
+)
+----
+
+
+[[movemouse-inherit-accel-state]]
+=== movemouse-inherit-accel-state
+<<table-of-contents,Back to ToC>>
+
+By default `movemouse-accel` actions will track the acceleration
+state for vertical and horizontal axes separately.
+
+When this setting is enabled, `movemouse-accel` will behave exactly like mouse movements in https://qmk.fm[QMK],
+i.e. the acceleration state of new mouse
+movement actions will be inherited if others are already being pressed.
+
+.Example:
+[source]
+----
+(defcfg
+  movemouse-inherit-accel-state yes
+)
+----
+
+[[movemouse-smooth-diagonals]]
+=== movemouse-smooth-diagonals
+<<table-of-contents,Back to ToC>>
+
+By default, mouse movements move one direction at a time
+and vertical/horizontal movements are on independent timers.
+
+This can result in non-smooth diagonals when drawing a line in some app.
+This option adds a small imperceptible amount of latency to
+synchronize the mouse movements.
+
+.Example:
+[source]
+----
+(defcfg
+  movemouse-smooth-diagonals yes
+)
+----
+
+=== dynamic-macro-max-presses [[dynamic-macro-max-presses]]
+<<table-of-contents,Back to ToC>>
+
+This configuration allows you to customize the length limit on dynamic macros.
+The default length limit is 128 keys.
+
+.Example:
+[source]
+----
+(defcfg
+  dynamic-macro-max-presses 1000
+)
+----
+
+=== concurrent-tap-hold [[concurrent-tap-hold]]
+This configuration makes multiple tap-hold actions
+that are activated near in time expire their timeout quicker.
+By default this is disabled.
+When disabled, the timeout for a following tap-hold
+will start from 0ms **after** the previous tap-hold expires.
+When enabled, the timeout will start
+as soon as the tap-hold action is pressed
+even if a previous tap-hold action is still held and has not expired.
+
+.Example:
+[source]
+----
+(defcfg
+  concurrent-tap-hold yes
+)
+----
+
+[[linux-only-linux-dev]]
+=== Linux only: linux-dev
+<<table-of-contents,Back to ToC>>
+By default, kanata will try to detect which input devices are keyboards and try
+to intercept them all. However, you may specify exact keyboard devices from the
+`/dev/input` directories using the `linux-dev` configuration.
+
+.Example:
+[source]
+----
+(defcfg
+  linux-dev /dev/input/by-path/platform-i8042-serio-0-event-kbd
+)
+----
+
+If you want to specify multiple keyboards, you can separate the paths with a
+colon `+:+`.
+
+.Example:
+[source]
+----
+(defcfg
+  linux-dev /dev/input/dev1:/dev/input/dev2
+)
+----
+
+Due to using the colon to separate devices, if you have a device with colons in
+its file name, you must escape those colons with backslashes:
+
+[source]
+----
+(defcfg
+  linux-dev /dev/input/path-to\:device
+)
+----
+
+Alternatively, you can use list syntax, where both backslashes and colons
+are parsed literally. List items are separated by spaces or newlines.
+Using quotation marks for each item is optional, and only required if an
+item contains spaces.
+
+[source]
+----
+(defcfg
+  linux-dev (
+    /dev/input/path:to:device
+    "/dev/input/path to device"
+  )
+)
+----
+
+[[linux-only-linux-dev-names-include]]
+=== Linux only: linux-dev-names-include
+<<table-of-contents,Back to ToC>>
+
+In the case that `linux-dev` is omitted,
+this option defines a list of device names that should be included.
+Device names that do not exist in the list will be ignored.
+This option is parsed identically to `linux-dev`.
+
+Kanata will print device names on startup with log lines that look like below:
+
+----
+registering /dev/input/eventX: "Name goes here"
+----
+
+.Example:
+[source]
+----
+(defcfg
+  linux-dev-names-include (
+    "Device name 1"
+    "Device name 2"
+  )
+)
+----
+
+[[linux-only-linux-dev-names-exclude]]
+=== Linux only: linux-dev-names-exclude
+<<table-of-contents,Back to ToC>>
+
+In the case that `linux-dev` is omitted,
+this option defines a list of device names that should be excluded.
+This option is parsed identically to `linux-dev`.
+
+The `linux-dev-names-include` and `linux-dev-names-exclude` options
+are not mutually exclusive
+but in practice it probably only makes sense to use one and not both.
+
+.Example:
+[source]
+----
+(defcfg
+  linux-dev-names-exclude (
+    "Device Name 1"
+    "Device Name 2"
+  )
+)
+----
+
+[[linux-only-linux-continue-if-no-devs-found]]
+=== Linux only: linux-continue-if-no-devs-found
+<<table-of-contents,Back to ToC>>
+
+By default, kanata will crash if no input devices are found. You can change
+this behaviour by setting `linux-continue-if-no-devs-found`.
+
+.Example:
+[source]
+----
+(defcfg
+  linux-continue-if-no-devs-found yes
+)
+----
+
+[[linux-only-linux-unicode-u-code]]
+=== Linux only: linux-unicode-u-code
+<<table-of-contents,Back to ToC>>
+
+Unicode on Linux works by pressing Ctrl+Shift+U, typing the unicode hex value,
+then pressing Enter. However, if you do remapping in userspace, e.g. via
+xmodmap/xkb, the keycode "U" that kanata outputs may not become a keysym "u"
+after the userspace remapping. This will be likely if you use non-US,
+non-European keyboards on top of kanata. For unicode to work, kanata needs to
+use the keycode that outputs the keysym "u", which might not be the keycode
+"U".
+
+You can use `evtest` or `kanata --debug`, set your userspace key remapping,
+then press the key that outputs the keysym "u" to see which underlying keycode
+is sent. Then you can use this configuration to change kanata's behaviour.
+
+.Example:
+[source]
+----
+(defcfg
+  linux-unicode-u-code v
+)
+----
+
+[[linux-only-linux-unicode-termination]]
+=== Linux only: linux-unicode-termination
+<<table-of-contents,Back to ToC>>
+
+Unicode on Linux terminates with the Enter key by default. This may not work in
+some applications. The termination is configurable with the following options:
+
+- `enter`
+- `space`
+- `enter-space`
+- `space-enter`
+
+.Example:
+[source]
+----
+(defcfg
+  linux-unicode-termination space
+)
+----
+
+=== Linux only: linux-x11-repeat-delay-rate[[linux-only-x11-repeat-rate]]
+<<table-of-contents,Back to ToC>>
+
+On Linux, you can tell kanata to run `xset r rate <delay> <rate>`
+on startup and on live reload
+via the configuration item `linux-only-x11-repeat-rate`.
+This takes two numbers separated by a comma.
+The first number is the delay in ms
+and the second number is the repeat rate in repeats/second.
+
+This configuration item does not affect Wayland or no-desktop environments.
+
+.Example:
+[source]
+----
+(defcfg
+  linux-x11-repeat-delay-rate 400,50
+)
+----
+
+[[macos-only-macos-dev-names-include]]
+=== macOS only: macos-dev-names-include
+<<table-of-contents,Back to ToC>>
+
+This option defines a list of device names that should be included.
+By default, kanata will try to detect which input devices are keyboards and try
+to intercept them all. However, you may specify exact keyboard devices to intercept
+using the `macos-dev-names-include` configuration.
+Device names that do not exist in the list will be ignored.
+This option is parsed identically to `linux-dev`.
+
+Use `kanata -l` or `kanata --list` to list the available keyboards.
+
+.Example:
+[source]
+----
+(defcfg
+  macos-dev-names-include (
+    "Device name 1"
+    "Device name 2"
+  )
+)
+----
+
+[[windows-only-windows-altgr]]
+=== Windows only: windows-altgr
+<<table-of-contents,Back to ToC>>
+
+There is an option for Windows to help mitigate the strange behaviour of AltGr
+(ralt) if you're using that key in your defsrc. This is applicable for many
+non-US layouts. You can use one of the listed values to change what kanata does
+with the key:
+
+* `cancel-lctl-press`
+** This will remove the `lctl` press that is generated alonside `ralt`
+* `add-lctl-release`
+** This adds an `lctl` release when `ralt` is released
+
+.Example:
+[source]
+----
+(defcfg
+  windows-altgr add-lctl-release
+)
+----
+
+For more context, see: https://github.com/jtroo/kanata/issues/55.
+
+NOTE: Even with these workarounds, putting `+lctl+`+`+ralt+` in your defsrc may not
+work properly with other applications that also use keyboard interception.
+Known application with issues: GWSL/VcXsrv
+
+=== Windows only: windows-interception-mouse-hwid[[windows-only-windows-interception-mouse-hwid]]
+<<table-of-contents,Back to ToC>>
+
+This defcfg item allows you to intercept mouse buttons for a specific mouse
+device. This only works with the Interception driver (the -wintercept variants
+of the binary).
+
+The intended use case for this is for laptops such as a Thinkpad, which have
+mouse buttons that may be desirable to activate kanata actions with.
+
+To know what numbers to put into the string, you can run the variant with this
+defcfg item defined with any numbers. Then when a button is first pressed on
+the mouse device, kanata will print its hwid in the log; you can then
+copy-paste that into this configuration entry. If this defcfg item is not
+defined, the log will not print.
+
+https://github.com/jtroo/kanata/issues/108[Relevant issue].
+
+.Example:
+[source]
+----
+(defcfg
+  windows-interception-mouse-hwid "70, 0, 60, 0"
+)
+----
+
+[[using-multiple-defcfg-options]]
+=== Using multiple defcfg options
+<<table-of-contents,Back to ToC>>
+
+The `defcfg` entry is treated as a list with pairs of strings. For example:
+
+[source]
+----
+(defcfg a 1 b 2)
+----
+
+This will be treated as configuration `a` having value `1` and configuration
+`b` having value `2`.
+
+An example defcfg containing many of the options is shown below. It should be
+noted options that are Linux-only, Windows-only, or macOS-only will be ignored when used on
+a non-applicable operating system.
+
+[source]
+----
+;; Don't actually use this exact configuration,
+;; it's almost certainly not what you want.
+(defcfg
+  process-unmapped-keys yes
+  danger-enable-cmd yes
+  sequence-timeout 2000
+  sequence-input-mode visible-backspaced
+  sequence-backtrack-modcancel no
+  log-layer-changes no
+  delegate-to-first-layer yes
+  movemouse-inherit-accel-state yes
+  movemouse-smooth-diagonals yes
+  dynamic-macro-max-presses 1000
+  linux-dev (/dev/input/dev1 /dev/input/dev2)
+  linux-dev-names-include ("Name 1" "Name 2")
+  linux-dev-names-exclude ("Name 3" "Name 4")
+  linux-continue-if-no-devs-found yes
+  linux-unicode-u-code v
+  linux-unicode-termination space
+  linux-x11-repeat-delay-rate 400,50
+  windows-altgr add-lctl-release
+  windows-interception-mouse-hwid "70, 0, 60, 0"
 )
 ----
 

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1418,8 +1418,8 @@ NOTE: commands are executed directly and not via a shell, so you cannot make
 use of environment variables or symbols with special meaning.
 For example `+~+` or `+$HOME+` in Linux will not be
 substituted with your home directory.
-If you want to execute with a shell program use `bash -c` or `powershell.exe`
-as the first parameter.
+If you want to execute with a shell program
+use the shell as the first parameter, e.g. `bash` or `powershell.exe`.
 
 .Example:
 [source]

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -936,18 +936,51 @@ fn parse_vars(exprs: &[&Vec<SExpr>], s: &mut ParsedState) -> Result<()> {
                 _ => bail_expr!(var_name_expr, "variable name must not be a list"),
             };
             let var_expr = match subexprs.next() {
-                Some(v) => v,
+                Some(v) => match v {
+                    SExpr::Atom(_) => v.clone(),
+                    SExpr::List(l) => parse_list_var(l, s)?,
+                },
                 None => bail_expr!(
                     var_name_expr,
                     "variable key name has no action - you should add an action."
                 ),
             };
-            if s.vars.insert(var_name.into(), var_expr.clone()).is_some() {
+            if s.vars.insert(var_name.into(), var_expr).is_some() {
                 bail_expr!(var_name_expr, "duplicate variable name: {}", var_name);
             }
         }
     }
     Ok(())
+}
+
+fn parse_list_var(expr: &Spanned<Vec<SExpr>>, s: &ParsedState) -> Result<SExpr> {
+    let ret = match expr.t.first() {
+        Some(SExpr::Atom(a)) => match a.t.as_str() {
+            "concat" => {
+                let mut concat_str = String::new();
+                for expr in expr.t.iter().skip(1) {
+                    if let Some(a) = expr.atom(s.vars()) {
+                        concat_str.push_str(a.trim_matches('"'));
+                    } else if let Some(l) = expr.span_list(s.vars()) {
+                        match parse_list_var(l, s)? {
+                            SExpr::Atom(a) => concat_str.push_str(a.t.trim_matches('"')),
+                            SExpr::List(_) => bail_expr!(
+                                expr,
+                                "concat must contain only strings or nested concat lists"
+                            ),
+                        };
+                    }
+                }
+                SExpr::Atom(Spanned {
+                    span: expr.span.clone(),
+                    t: concat_str,
+                })
+            }
+            _ => SExpr::List(expr.clone()),
+        },
+        _ => SExpr::List(expr.clone()),
+    };
+    Ok(ret)
 }
 
 /// Parse alias->action mappings from multiple exprs starting with defalias.

--- a/parser/src/cfg/sexpr.rs
+++ b/parser/src/cfg/sexpr.rs
@@ -164,6 +164,22 @@ impl SExpr {
         }
     }
 
+    pub fn span_list<'a>(
+        &'a self,
+        vars: Option<&'a HashMap<String, SExpr>>,
+    ) -> Option<&'a Spanned<Vec<SExpr>>> {
+        match self {
+            SExpr::List(l) => Some(l),
+            SExpr::Atom(a) => match (a.t.strip_prefix('$'), vars) {
+                (Some(varname), Some(vars)) => match vars.get(varname) {
+                    Some(var) => var.span_list(Some(vars)),
+                    None => None,
+                },
+                _ => None,
+            },
+        }
+    }
+
     pub fn span(&self) -> Span {
         match self {
             SExpr::Atom(a) => a.span.clone(),

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1480,6 +1480,10 @@ fn parse_defvar_concat() {
     xz (notconcat a b " " c " d")
     yx (concat a b " " c " d" (concat "efg" " hij ") "kl")
     yz (concat "abc"def"ghi""jkl")
+
+    rootpath "/home/myuser/mysubdir"
+    ;; $otherpath will be the string: /home/myuser/mysubdir/helloworld
+    otherpath (concat $rootpath "/helloworld")
 )
 "#;
     let mut s = ParsedState::default();
@@ -1523,6 +1527,10 @@ fn parse_defvar_concat() {
     }
     match s.vars().unwrap().get("yz").unwrap() {
         SExpr::Atom(a) => assert_eq!(&a.t, "abcdefghijkl"),
+        SExpr::List(l) => panic!("expected string not list: {l:?}"),
+    }
+    match s.vars().unwrap().get("otherpath").unwrap() {
+        SExpr::Atom(a) => assert_eq!(&a.t, "/home/myuser/mysubdir/helloworld"),
         SExpr::List(l) => panic!("expected string not list: {l:?}"),
     }
 }

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1460,3 +1460,124 @@ fn parse_cmd() {
     )
     .expect("succeeds");
 }
+
+#[test]
+fn parse_defvar_concat() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    let source = r#"
+(defsrc a)
+(deflayer base a)
+(defvar
+    x (concat a b c)
+    y (concat d (concat e f))
+    z (squish squash (splish splosh))
+    xx (concat $x $y)
+    xy (concat $x (concat $y))
+    xz (notconcat a b " " c " d")
+    yx (concat a b " " c " d" (concat "efg" " hij ") "kl")
+    yz (concat "abc"def"ghi""jkl")
+)
+"#;
+    let mut s = ParsedState::default();
+    parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+        DEF_LOCAL_KEYS,
+    )
+    .expect("succeeds");
+    match s.vars().unwrap().get("x").unwrap() {
+        SExpr::Atom(a) => assert_eq!(&a.t, "abc"),
+        SExpr::List(l) => panic!("expected string not list: {l:?}"),
+    }
+    match s.vars().unwrap().get("y").unwrap() {
+        SExpr::Atom(a) => assert_eq!(&a.t, "def"),
+        SExpr::List(l) => panic!("expected string not list: {l:?}"),
+    }
+    match s.vars().unwrap().get("z").unwrap() {
+        SExpr::Atom(a) => panic!("expected list not string: {a:?}"),
+        SExpr::List(_) => {}
+    }
+    match s.vars().unwrap().get("xx").unwrap() {
+        SExpr::Atom(a) => assert_eq!(&a.t, "abcdef"),
+        SExpr::List(l) => panic!("expected string not list: {l:?}"),
+    }
+    match s.vars().unwrap().get("xy").unwrap() {
+        SExpr::Atom(a) => assert_eq!(&a.t, "abcdef"),
+        SExpr::List(l) => panic!("expected string not list: {l:?}"),
+    }
+    match s.vars().unwrap().get("xz").unwrap() {
+        SExpr::Atom(a) => panic!("expected list not string {a:?}"),
+        SExpr::List(_) => {}
+    }
+    match s.vars().unwrap().get("yx").unwrap() {
+        SExpr::Atom(a) => assert_eq!(&a.t, "ab c defg hij kl"),
+        SExpr::List(l) => panic!("expected string not list: {l:?}"),
+    }
+    match s.vars().unwrap().get("yz").unwrap() {
+        SExpr::Atom(a) => assert_eq!(&a.t, "abcdefghijkl"),
+        SExpr::List(l) => panic!("expected string not list: {l:?}"),
+    }
+}
+
+#[test]
+fn parse_defvar_concat_err1() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    let source = r#"
+(defsrc a)
+(deflayer base a)
+(defvar
+    x (concat a b c (not nested concat))
+)
+"#;
+    let mut s = ParsedState::default();
+    parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+        DEF_LOCAL_KEYS,
+    )
+    .expect_err("fails");
+}
+
+#[test]
+fn parse_defvar_concat_err2() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    let source = r#"
+(defsrc a)
+(deflayer base a)
+(defvar
+    x (list var uh oh)
+    y (concat a b c $x)
+)
+"#;
+    let mut s = ParsedState::default();
+    parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+        DEF_LOCAL_KEYS,
+    )
+    .expect_err("fails");
+}


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add the `concat` keyword to `defvar`. Potentially a breaking change in case someone used the string `concat` as the first string in a list variable at some point. I find the probability of this to be low, but worth noting anyway.

Implements #712.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
