### PR TITLE
feat: add block-unmapped-keys to defcfg

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -150,6 +150,10 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;;
   ;; process-unmapped-keys yes
 
+  ;; Disable all keys not mapped in defsrc.
+  ;; Only works if process-unmapped-keys is also yes.
+  ;; block-unmapped-keys yes
+
   ;; Intercept mouse buttons for a specific mouse device.
   ;; The intended use case for this is for laptops such as a Thinkpad, which have
   ;; mouse buttons that may be useful to activate kanata actions with. This only

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -287,14 +287,14 @@ it will be useful to first learn about aliases and variables.
 Using the `defalias` configuration entry, you can introduce a shortcut label
 for an action.
 
-Similar to how `defcfg` works, `defalias` reads pairs of items in a sequence
+The `defalias` entry reads pairs of items in a sequence
 where the first item in the pair is the alias name and the second item is the
-action it can be substituted for. However, unlike `+defcfg+`, the second item
-in `defalias` may be a "list" as opposed to a single string like it was in
-`defcfg`.
+action it can be substituted for.
 
-A list is a sequence of strings separated by whitespace, surrounded by
-parentheses. All of the configuration entries we've looked at so far are lists;
+A list is a sequence of strings
+or nested lists separated by whitespace,
+surrounded by parentheses.
+All of the configuration entries we've looked at so far are lists;
 `defalias` is where we'll first see nested lists in this guide.
 
 .Example:
@@ -1742,6 +1742,25 @@ even if a previous tap-hold action is still held and has not expired.
 ----
 (defcfg
   concurrent-tap-hold yes
+)
+----
+
+[[block-unmapped-keys]]
+=== block-unmapped-keys
+<<table-of-contents,Back to ToC>>
+
+If you desire to use only a subset of your keyboard
+you can use `block-unmapped-keys` to make every key
+other than those that exist in `defsrc` a no-op.
+
+NOTE: this only functions correctly if you also set
+<<process-unmapped-keys>> to yes.
+
+.Example:
+[source]
+----
+(defcfg
+  block-unmapped-keys yes
 )
 ----
 

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -9,6 +9,7 @@ use crate::{anyhow_expr, anyhow_span, bail, bail_expr, bail_span};
 #[derive(Debug)]
 pub struct CfgOptions {
     pub process_unmapped_keys: bool,
+    pub block_unmapped_keys: bool,
     pub enable_cmd: bool,
     pub sequence_timeout: u16,
     pub sequence_input_mode: SequenceInputMode,
@@ -49,6 +50,7 @@ impl Default for CfgOptions {
     fn default() -> Self {
         Self {
             process_unmapped_keys: false,
+            block_unmapped_keys: false,
             enable_cmd: false,
             sequence_timeout: 1000,
             sequence_input_mode: SequenceInputMode::HiddenSuppressed,
@@ -274,6 +276,9 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
 
                     "process-unmapped-keys" => {
                         cfg.process_unmapped_keys = parse_defcfg_val_bool(val, label)?
+                    }
+                    "block-unmapped-keys" => {
+                        cfg.block_unmapped_keys = parse_defcfg_val_bool(val, label)?
                     }
                     "danger-enable-cmd" => cfg.enable_cmd = parse_defcfg_val_bool(val, label)?,
                     "sequence-backtrack-modcancel" => {

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -451,7 +451,6 @@ pub fn parse_cfg_raw_string(
             "Only one defcfg is allowed, found more. Delete the extras."
         )
     }
-
     let src_expr = root_exprs
         .iter()
         .find(gen_first_atom_filter("defsrc"))
@@ -559,6 +558,7 @@ pub fn parse_cfg_raw_string(
         delegate_to_first_layer: cfg.delegate_to_first_layer,
         default_sequence_timeout: cfg.sequence_timeout,
         default_sequence_input_mode: cfg.sequence_input_mode,
+        block_unmapped_keys: cfg.block_unmapped_keys,
         ..Default::default()
     };
 
@@ -886,6 +886,7 @@ pub struct ParsedState {
     delegate_to_first_layer: bool,
     default_sequence_timeout: u16,
     default_sequence_input_mode: SequenceInputMode,
+    block_unmapped_keys: bool,
     a: Arc<Allocations>,
 }
 
@@ -911,6 +912,7 @@ impl Default for ParsedState {
             delegate_to_first_layer: default_cfg.delegate_to_first_layer,
             default_sequence_timeout: default_cfg.sequence_timeout,
             default_sequence_input_mode: default_cfg.sequence_input_mode,
+            block_unmapped_keys: default_cfg.block_unmapped_keys,
             a: unsafe { Allocations::new() },
         }
     }
@@ -2545,15 +2547,17 @@ fn parse_layers(s: &mut ParsedState) -> Result<Box<KanataLayers>> {
             if *layer_action == Action::Trans {
                 *layer_action = defsrc_action;
             }
-            // If there is no corresponding action in defsrc, default to the OsCode at the
-            // position. This is done so that `process-unmapped-keys` works correctly.
-            if *layer_action == Action::Trans {
-                *layer_action = OsCode::from_u16(i as u16)
-                    .and_then(|osc| match KeyCode::from(osc) {
-                        KeyCode::No => None,
-                        kc => Some(Action::KeyCode(kc)),
-                    })
-                    .unwrap_or(Action::Trans);
+            if !s.block_unmapped_keys {
+                // If there is no corresponding action in defsrc, default to the OsCode at the
+                // position. This is done so that `process-unmapped-keys` works correctly.
+                if *layer_action == Action::Trans {
+                    *layer_action = OsCode::from_u16(i as u16)
+                        .and_then(|osc| match KeyCode::from(osc) {
+                            KeyCode::No => None,
+                            kc => Some(Action::KeyCode(kc)),
+                        })
+                        .unwrap_or(Action::Trans);
+                }
             }
         }
         // Set fake keys on the `layer-switch` version of each layer.


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Add a new defcfg option to block all unmapped (meaning not in defsrc) keys from doing anything. Implements #688.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
