### PR TITLE
feat: windows-interception-keyboard-hwids

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -167,6 +167,15 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;;
   ;; windows-interception-mouse-hwid "70, 0, 90, 0, 20"
 
+  ;; List configuration for kanata-wintercept variants
+  ;; that allows intercepting only some connected keyboards.
+  ;; Use similarly to mouse-hwid above.
+  ;;
+  ;; windows-interception-keyboard-hwids (
+  ;;   "90, 80, 11, 34"
+  ;;   "99, 88, 77, 66"
+  ;; )
+
   ;; Transparent keys on layers will delegate to the corresponding defsrc key
   ;; when found on a layer activated by `layer-switch`. This config entry
   ;; changes the behaviour to delegate to the action of the first layer,

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1998,12 +1998,12 @@ Known application with issues: GWSL/VcXsrv
 === Windows only: windows-interception-mouse-hwid[[windows-only-windows-interception-mouse-hwid]]
 <<table-of-contents,Back to ToC>>
 
-This defcfg item allows you to intercept mouse buttons for a specific mouse
-device. This only works with the Interception driver (the -wintercept variants
-of the binary).
+This defcfg item allows you to intercept mouse buttons for a specific mouse device.
+This only works with the Interception driver
+(the -wintercept variants of the release binaries).
 
-The intended use case for this is for laptops such as a Thinkpad, which have
-mouse buttons that may be desirable to activate kanata actions with.
+The original use case for this is for laptops such as a Thinkpad,
+which have mouse buttons that may be desirable to activate kanata actions with.
 
 To know what numbers to put into the string, you can run the variant with this
 defcfg item defined with any numbers. Then when a button is first pressed on
@@ -2018,6 +2018,32 @@ https://github.com/jtroo/kanata/issues/108[Relevant issue].
 ----
 (defcfg
   windows-interception-mouse-hwid "70, 0, 60, 0"
+)
+----
+
+
+=== Windows only: windows-interception-keyboard-hwids[[windows-only-windows-interception-keyboard-hwids]]
+<<table-of-contents,Back to ToC>>
+
+This defcfg item allows you to intercept only specific keyboards.
+Its value must be a list of strings
+with each string representing one hardware ID.
+
+To know what numbers to put into the string,
+you can run the variant with this defcfg item empty.
+Then when a button is first pressed on the keyboard,
+kanata will print its hwid in the log.
+You can then copy-paste that into this configuration entry.
+If this defcfg item is not defined, the log will not print.
+
+.Example:
+[source]
+----
+(defcfg
+  windows-interception-keyboard-hwids (
+    "70, 0, 60, 0"
+    "71, 72, 73, 74"
+  )
 )
 ----
 

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -523,7 +523,7 @@ impl Default for AltGrBehaviour {
     all(feature = "interception_driver", target_os = "windows"),
     target_os = "unknown"
 ))]
-pub const HWID_ARR_SZ: usize = 128;
+pub const HWID_ARR_SZ: usize = 512;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ReplayDelayBehaviour {

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -523,7 +523,7 @@ impl Default for AltGrBehaviour {
     all(feature = "interception_driver", target_os = "windows"),
     target_os = "unknown"
 ))]
-pub const HWID_ARR_SZ: usize = 512;
+pub const HWID_ARR_SZ: usize = 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ReplayDelayBehaviour {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -127,6 +127,10 @@ pub struct Kanata {
     /// Used to know which input device to treat as a mouse for intercepting and processing inputs
     /// by kanata.
     intercept_mouse_hwid: Option<[u8; HWID_ARR_SZ]>,
+    #[cfg(all(feature = "interception_driver", target_os = "windows"))]
+    /// Used to know which input device to treat as a mouse for intercepting and processing inputs
+    /// by kanata.
+    intercept_kb_hwids: Option<Vec<[u8; HWID_ARR_SZ]>>,
     /// User configuration to do logging of layer changes or not.
     log_layer_changes: bool,
     /// Tracks the caps-word state. Is Some(...) if caps-word is active and None otherwise.
@@ -299,6 +303,8 @@ impl Kanata {
             exclude_names: cfg.items.linux_dev_names_exclude,
             #[cfg(all(feature = "interception_driver", target_os = "windows"))]
             intercept_mouse_hwid: cfg.items.windows_interception_mouse_hwid,
+            #[cfg(all(feature = "interception_driver", target_os = "windows"))]
+            intercept_kb_hwids: cfg.items.windows_interception_keyboard_hwids,
             dynamic_macro_replay_state: None,
             dynamic_macro_record_state: None,
             dynamic_macros: Default::default(),

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -19,6 +19,7 @@ impl Kanata {
             information: 0,
         }; 32];
 
+        let keyboards_to_intercept_hwids = kanata.lock().intercept_kb_hwids.clone();
         let mouse_to_intercept_hwid: Option<[u8; HWID_ARR_SZ]> = kanata.lock().intercept_mouse_hwid;
         if mouse_to_intercept_hwid.is_some() {
             intrcptn.set_filter(
@@ -35,6 +36,16 @@ impl Kanata {
                 for i in 0..num_strokes {
                     let mut key_event = match strokes[i] {
                         ic::Stroke::Keyboard { state, .. } => {
+                            if !is_keyboard_interceptable(
+                                dev,
+                                &intrcptn,
+                                &keyboards_to_intercept_hwids,
+                                &mut is_dev_interceptable,
+                            ) {
+                                log::debug!("stroke {:?} is from undesired device", strokes[i]);
+                                intrcptn.send(dev, &strokes[i..i + 1]);
+                                continue;
+                            }
                             log::debug!("got stroke {:?}", strokes[i]);
                             let code = match OsCodeWrapper::try_from(strokes[i]) {
                                 Ok(c) => c.0,
@@ -97,6 +108,29 @@ impl Kanata {
                 }
             }
         }
+    }
+}
+
+fn is_keyboard_interceptable(
+    input_dev: ic::Device,
+    intrcptn: &ic::Interception,
+    allowed_hwids: &Option<Vec<[u8; HWID_ARR_SZ]>>,
+    cache: &mut HashMap<ic::Device, bool>,
+) -> bool {
+    match allowed_hwids {
+        None => true,
+        Some(allowed) => match cache.get(&input_dev) {
+            Some(v) => *v,
+            None => {
+                let mut hwid = [0u8; HWID_ARR_SZ];
+                log::trace!("getting hardware id for input dev: {input_dev}");
+                let res = intrcptn.get_hardware_id(input_dev, &mut hwid);
+                let dev_is_interceptable = allowed.contains(&hwid);
+                log::info!("res {res}; device #{input_dev} hwid {hwid:?} matches allowed keyboard input: {dev_is_interceptable}");
+                cache.insert(input_dev, dev_is_interceptable);
+                dev_is_interceptable
+            }
+        },
     }
 }
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add capability in Windows+Interception to specify keyboards to intercept and passthrough others.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
