### PR TITLE
tcp: fix server messages not emitting newline terminator

### DIFF
--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -32,10 +32,9 @@ pub enum ClientMessage {
 #[cfg(feature = "tcp_server")]
 impl ServerMessage {
     pub fn as_bytes(&self) -> Vec<u8> {
-        serde_json::to_string(self)
-            .expect("ServerMessage should serialize")
-            .as_bytes()
-            .to_vec()
+        let mut msg = serde_json::to_string(self).expect("ServerMessage should serialize");
+        msg.push('\n');
+        msg.as_bytes().to_vec()
     }
 }
 

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -32,9 +32,9 @@ pub enum ClientMessage {
 #[cfg(feature = "tcp_server")]
 impl ServerMessage {
     pub fn as_bytes(&self) -> Vec<u8> {
-        let mut msg = serde_json::to_string(self).expect("ServerMessage should serialize");
-        msg.push('\n');
-        msg.as_bytes().to_vec()
+        let mut msg = serde_json::to_vec(self).expect("ServerMessage should serialize");
+        msg.push(b'\n');
+        msg
     }
 }
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
As specified in comment https://github.com/jtroo/kanata/pull/728/files#diff-c204c9e519dac1f19421bbd6234962c60bdae1ca1e617ca696441fdb03247b43R56, server messages should be separated by newlines, but currently aren't. 

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Did manual testing
  - [x] Yes
