### PR TITLE
doc: fix formatting of rapid-event-delay example

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1799,6 +1799,7 @@ If you are negatively impacted by the latency increase of these events
 and your environment is not impacted by increased rapidity,
 you can set reduce the value to a number 0 to 4.
 
+.Example:
 [source]
 ----
 (defcfg

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1799,10 +1799,13 @@ If you are negatively impacted by the latency increase of these events
 and your environment is not impacted by increased rapidity,
 you can set reduce the value to a number 0 to 4.
 
+[source]
+----
 (defcfg
   ;; If your environment is particularly buggy, might need to delay even more
   rapid-event-delay 20
 )
+----
 
 [[linux-only-linux-dev]]
 === Linux only: linux-dev


### PR DESCRIPTION
- Add documentation to docs/config.adoc
  - [x] Yes
