### PR TITLE
tcp: add layer names request and response

### DIFF
--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -163,6 +163,7 @@ pub struct Kanata {
     unshifted_keys: Vec<KeyCode>,
     /// Keep track of last pressed key for [`CustomAction::Repeat`].
     last_pressed_key: KeyCode,
+    pub tcp_send_layer_names_requested: bool,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -324,6 +325,7 @@ impl Kanata {
             unmodded_keys: vec![],
             unshifted_keys: vec![],
             last_pressed_key: KeyCode::No,
+            tcp_send_layer_names_requested: false,
         })
     }
 
@@ -451,6 +453,8 @@ impl Kanata {
             // would make a difference, so may as well reduce the amount of processing.
             self.check_handle_layer_change(tx);
         }
+
+        self.check_handle_request_layer_names(tx);
 
         if self.live_reload_requested
             && ((self.prev_keys.is_empty() && self.cur_keys.is_empty())
@@ -1426,6 +1430,29 @@ impl Kanata {
                     Err(error) => {
                         log::error!("could not send event notification: {}", error);
                     }
+                }
+            }
+        }
+    }
+
+    pub fn check_handle_request_layer_names(&mut self, tx: &Option<Sender<ServerMessage>>) {
+        if self.tcp_send_layer_names_requested {
+            self.tcp_send_layer_names_requested = false
+        } else {
+            return;
+        }
+        let names = self
+            .layer_info
+            .iter()
+            .map(|info| info.name.clone())
+            .collect::<Vec<_>>();
+
+        #[cfg(feature = "tcp_server")]
+        if let Some(tx) = tx {
+            match tx.try_send(ServerMessage::LayerNames { names }) {
+                Ok(_) => {}
+                Err(error) => {
+                    log::error!("could not send event notification: {}", error);
                 }
             }
         }

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -124,7 +124,21 @@ impl TcpServer {
                                                 kanata.lock().change_layer(new);
                                             }
                                             ClientMessage::RequestLayerNames {} => {
-                                                kanata.lock().tcp_send_layer_names_requested = true;
+                                                let msg = ServerMessage::LayerNames {
+                                                    names: kanata
+                                                        .lock()
+                                                        .layer_info
+                                                        .iter()
+                                                        .map(|info| info.name.clone())
+                                                        .collect::<Vec<_>>(),
+                                                };
+                                                match stream.write(&msg.as_bytes()) {
+                                                    Ok(_) => {}
+                                                    Err(err) => log::error!(
+                                                        "server could not send response: {}",
+                                                        err
+                                                    ),
+                                                }
                                             }
                                         }
                                     } else {

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -16,19 +16,6 @@ pub enum ServerMessage {
     LayerChange { new: String },
 }
 
-#[test]
-fn layer_change_serializes() {
-    serde_json::to_string(&ServerMessage::LayerChange {
-        new: "hello".into(),
-    })
-    .expect("ServerMessage serializes");
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub enum ClientMessage {
-    ChangeLayer { new: String },
-}
-
 #[cfg(feature = "tcp_server")]
 impl ServerMessage {
     pub fn as_bytes(&self) -> Vec<u8> {
@@ -36,6 +23,11 @@ impl ServerMessage {
         msg.push(b'\n');
         msg
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ClientMessage {
+    ChangeLayer { new: String },
 }
 
 impl FromStr for ClientMessage {
@@ -160,4 +152,12 @@ impl TcpServer {
 
     #[cfg(not(feature = "tcp_server"))]
     pub fn start(&mut self, _kanata: Arc<Mutex<Kanata>>) {}
+}
+
+#[test]
+fn layer_change_serializes() {
+    serde_json::to_string(&ServerMessage::LayerChange {
+        new: "hello".into(),
+    })
+    .expect("ServerMessage serializes");
 }

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -14,6 +14,7 @@ use std::net::{TcpListener, TcpStream};
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ServerMessage {
     LayerChange { new: String },
+    LayerNames { names: Vec<String> },
 }
 
 #[cfg(feature = "tcp_server")]
@@ -28,6 +29,7 @@ impl ServerMessage {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ClientMessage {
     ChangeLayer { new: String },
+    RequestLayerNames {},
 }
 
 impl FromStr for ClientMessage {
@@ -120,6 +122,9 @@ impl TcpServer {
                                         match event {
                                             ClientMessage::ChangeLayer { new } => {
                                                 kanata.lock().change_layer(new);
+                                            }
+                                            ClientMessage::RequestLayerNames {} => {
+                                                kanata.lock().tcp_send_layer_names_requested = true;
                                             }
                                         }
                                     } else {

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -129,15 +129,8 @@ impl TcpServer {
                                                         .lock()
                                                         .layer_info
                                                         .iter()
-                                                        .enumerate()
-                                                        .filter_map(|(i, info)| {
-                                                            if i % 2 == 0 {
-                                                                Some(info.name.clone())
-                                                            } else {
-                                                                // skip every other name, which is a duplicate
-                                                                None
-                                                            }
-                                                        })
+                                                        .step_by(2) // skip every other name, which is a duplicate
+                                                        .map(|info| info.name.clone())
                                                         .collect::<Vec<_>>(),
                                                 };
                                                 match stream.write(&msg.as_bytes()) {

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -129,7 +129,15 @@ impl TcpServer {
                                                         .lock()
                                                         .layer_info
                                                         .iter()
-                                                        .map(|info| info.name.clone())
+                                                        .enumerate()
+                                                        .filter_map(|(i, info)| {
+                                                            if i % 2 == 0 {
+                                                                Some(info.name.clone())
+                                                            } else {
+                                                                // skip every other name, which is a duplicate
+                                                                None
+                                                            }
+                                                        })
                                                         .collect::<Vec<_>>(),
                                                 };
                                                 match stream.write(&msg.as_bytes()) {


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

It seems like it's useful to provide layer info to TCP client, since it's quite properly parsing layer names is not trivial, and may be done wrong if client attempted to do so themselves.  

Inspiration to make this PR: https://github.com/reidprichard/window_tools/issues/1#issue-2145533738

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [ ] Yes
