### PR TITLE
feat: bail on keys that would not work be processed as expected in key-list-based conditionals

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -277,6 +277,7 @@ const DEF_LOCAL_KEYS: &str = "deflocalkeys-macos";
 #[cfg(any(target_os = "linux", target_os = "unknown"))]
 const DEF_LOCAL_KEYS: &str = "deflocalkeys-linux";
 
+#[derive(Debug)]
 pub struct IntermediateCfg {
     pub cfg: CfgOptions,
     pub layer_info: Vec<LayerInfo>,

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -235,7 +235,7 @@ fn parse_delegate_to_default_layer_yes() {
     )
     .unwrap();
     assert_eq!(
-        res.3[2][0][OsCode::KEY_A.as_u16() as usize],
+        res.klayers[2][0][OsCode::KEY_A.as_u16() as usize],
         Action::KeyCode(KeyCode::B),
     );
 }
@@ -264,7 +264,7 @@ fn parse_delegate_to_default_layer_yes_but_base_transparent() {
     )
     .unwrap();
     assert_eq!(
-        res.3[2][0][OsCode::KEY_A.as_u16() as usize],
+        res.klayers[2][0][OsCode::KEY_A.as_u16() as usize],
         Action::KeyCode(KeyCode::A),
     );
 }
@@ -293,7 +293,7 @@ fn parse_delegate_to_default_layer_no() {
     )
     .unwrap();
     assert_eq!(
-        res.3[2][0][OsCode::KEY_A.as_u16() as usize],
+        res.klayers[2][0][OsCode::KEY_A.as_u16() as usize],
         Action::KeyCode(KeyCode::A),
     );
 }
@@ -305,13 +305,14 @@ fn parse_transparent_default() {
         Err(poisoned) => poisoned.into_inner(),
     };
     let mut s = ParsedState::default();
-    let (_, _, layer_strings, layers, _, _) = parse_cfg_raw(
+    let icfg = parse_cfg_raw(
         &std::path::PathBuf::from("./test_cfgs/transparent_default.kbd"),
         &mut s,
     )
     .unwrap();
+    let layers = icfg.klayers;
 
-    assert_eq!(layer_strings.len(), 4);
+    assert_eq!(icfg.layer_info.len(), 4);
 
     assert_eq!(
         layers[0][0][usize::from(OsCode::KEY_F13)],
@@ -798,7 +799,7 @@ fn parse_switch() {
     )
     .unwrap();
     assert_eq!(
-        res.3[0][0][OsCode::KEY_A.as_u16() as usize],
+        res.klayers[0][0][OsCode::KEY_A.as_u16() as usize],
         Action::Switch(&Switch {
             cases: &[
                 (
@@ -916,7 +917,7 @@ fn parse_on_idle_fakekey() {
     })
     .unwrap();
     assert_eq!(
-        res.3[0][0][OsCode::KEY_A.as_u16() as usize],
+        res.klayers[0][0][OsCode::KEY_A.as_u16() as usize],
         Action::Custom(
             &[&CustomAction::FakeKeyOnIdle(FakeKeyOnIdle {
                 coord: Coord { x: 1, y: 0 },


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Currently, when `(defcfg process-unmapped-keys false)` or `(defcfg block-unmapped-keys true)` 
or is set, the trigger keys in `fork` will parse fine, but will not correctly work, because they're not processed by kanata.

This PR, adds checks to not let parsing to pass when any of the keys in fork is not mapped (or passed-though).

Initially I wanted to do this change specifically just for `fork`, but I noticed that `parse_key_list` was also used in `caps-word-custom` and in `tap-hold-except-keys`. IG It makes sense to apply this parsing rule to these too, so I did so.

This potentially is a breaking change for some users, but actually these config are already broken, so at least now it's explicit.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [ ] (TODO)
