### PR TITLE
[WIP] feat(tcp): add SetMouse action (#623)

### DIFF
--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -178,6 +178,25 @@ impl TcpServer {
                                                         })
                                                         .expect("write key event");
                                                 }
+                                                ClientMessage::SetMouse { x, y } => {
+                                                    log::info!(
+                                                        "client message: set Mouse: x {x} y {y}"
+                                                    );
+                                                    //let _ = kanata.lock().kbd_out.set_mouse(x, y);
+                                                    match kanata.lock().kbd_out.set_mouse(x, y) {
+                                                        Ok(_) => {
+                                                            log::info!("sucessfully did set mouse position to: x {x} y {y}");
+                                                            // Optionally send a success message to the client
+                                                        }
+                                                        Err(e) => {
+                                                            log::error!(
+                                                                "Failed to set mouse position: {}",
+                                                                e
+                                                            );
+                                                            // Implement any error handling logic here, such as sending an error response to the client
+                                                        }
+                                                    }
+                                                }
                                             }
                                         }
                                         Err(e) => {

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -180,9 +180,8 @@ impl TcpServer {
                                                 }
                                                 ClientMessage::SetMouse { x, y } => {
                                                     log::info!(
-                                                        "client message: set Mouse: x {x} y {y}"
+                                                        "tcp server SetMouse action: x {x} y {y}"
                                                     );
-                                                    //let _ = kanata.lock().kbd_out.set_mouse(x, y);
                                                     match kanata.lock().kbd_out.set_mouse(x, y) {
                                                         Ok(_) => {
                                                             log::info!("sucessfully did set mouse position to: x {x} y {y}");

--- a/tcp_protocol/src/lib.rs
+++ b/tcp_protocol/src/lib.rs
@@ -26,6 +26,10 @@ pub enum ClientMessage {
         name: String,
         action: FakeKeyActionMessage,
     },
+    SetMouse {
+        x: u16,
+        y: u16,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
add `SetMouse` as a TCP server action, with x and y as parameters, as described in #623 

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
  I did manual testing with the following command on Windows:
  ``` sh
  echo '{"SetMouse": { "x": 500, "y": 1000 } }' |  winsocat.exe STDIO TCP:127.0.0.1:8089
  ```
but when testing it moves the mouse cursor to an incorrect position, not a random position, the same position every time, but obviously not a position with the specified coordinates, (500, 1000), I'd guesstimate the position to be (20, 40)

 Edit: when running the above command with `"y": 5000` it moves the cursor to a position that seems to have the same X coord but the Y coord is 5 times as much, so 200, I'd guesstimate, which is odd, because my screen is a ~4K screen, its height is 2160, but I specified y=5000.