### PR TITLE
Add messages for fake key actions

### DIFF
--- a/example_tcp_client/src/main.rs
+++ b/example_tcp_client/src/main.rs
@@ -5,6 +5,7 @@ use std::io::{stdin, BufRead, BufReader, Write};
 use std::net::{SocketAddr, TcpStream};
 use std::process::exit;
 use std::time::Duration;
+use std::str::FromStr;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -58,6 +59,18 @@ fn print_usage() {
 \n\
     Requests to change kanata's layer look like:\n\
     {}
+\n\
+    Requests to press a fake key look like:\n\
+    {}
+\n\
+    Requests to release a fake key look like:\n\
+    {}
+\n\
+    Requests to tap a fake key look like:\n\
+    {}
+\n\
+    Requests to toggle a fake key look like:\n\
+    {}
     ",
         serde_json::to_string(&ServerMessage::LayerChange {
             new: "newly-changed-to-layer".into()
@@ -67,6 +80,22 @@ fn print_usage() {
             new: "requested-layer".into()
         })
         .expect("deserializable"),
+        serde_json::to_string(&ClientMessage::ActOnFakeKey {
+            name: "fake-key-name".into(),
+            action: "Press".into()
+        }).expect("deserializable"),
+        serde_json::to_string(&ClientMessage::ActOnFakeKey {
+            name: "fake-key-name".into(),
+            action: "Release".into()
+        }).expect("deserializable"),
+        serde_json::to_string(&ClientMessage::ActOnFakeKey {
+            name: "fake-key-name".into(),
+            action: "Tap".into()
+        }).expect("deserializable"),
+        serde_json::to_string(&ClientMessage::ActOnFakeKey {
+            name: "fake-key-name".into(),
+            action: "Toggle".into()
+        }).expect("deserializable"),
     )
 }
 

--- a/example_tcp_client/src/main.rs
+++ b/example_tcp_client/src/main.rs
@@ -82,19 +82,19 @@ fn print_usage() {
         .expect("deserializable"),
         serde_json::to_string(&ClientMessage::ActOnFakeKey {
             name: "fake-key-name".into(),
-            action: "Press".into()
+            action: "Press".try_into().expect("Valid fake key action")
         }).expect("deserializable"),
         serde_json::to_string(&ClientMessage::ActOnFakeKey {
             name: "fake-key-name".into(),
-            action: "Release".into()
+            action: "Release".try_into().expect("Valid fake key action")
         }).expect("deserializable"),
         serde_json::to_string(&ClientMessage::ActOnFakeKey {
             name: "fake-key-name".into(),
-            action: "Tap".into()
+            action: "Tap".try_into().expect("Valid fake key action")
         }).expect("deserializable"),
         serde_json::to_string(&ClientMessage::ActOnFakeKey {
             name: "fake-key-name".into(),
-            action: "Toggle".into()
+            action: "Toggle".try_into().expect("Valid fake key action")
         }).expect("deserializable"),
     )
 }

--- a/example_tcp_client/src/main.rs
+++ b/example_tcp_client/src/main.rs
@@ -5,7 +5,6 @@ use std::io::{stdin, BufRead, BufReader, Write};
 use std::net::{SocketAddr, TcpStream};
 use std::process::exit;
 use std::time::Duration;
-use std::str::FromStr;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]

--- a/example_tcp_client/src/main.rs
+++ b/example_tcp_client/src/main.rs
@@ -81,19 +81,19 @@ fn print_usage() {
         .expect("deserializable"),
         serde_json::to_string(&ClientMessage::ActOnFakeKey {
             name: "fake-key-name".into(),
-            action: "Press".try_into().expect("Valid fake key action")
+            action: FakeKeyActionMessage::Press
         }).expect("deserializable"),
         serde_json::to_string(&ClientMessage::ActOnFakeKey {
             name: "fake-key-name".into(),
-            action: "Release".try_into().expect("Valid fake key action")
+            action: FakeKeyActionMessage::Release
         }).expect("deserializable"),
         serde_json::to_string(&ClientMessage::ActOnFakeKey {
             name: "fake-key-name".into(),
-            action: "Tap".try_into().expect("Valid fake key action")
+            action: FakeKeyActionMessage::Tap
         }).expect("deserializable"),
         serde_json::to_string(&ClientMessage::ActOnFakeKey {
             name: "fake-key-name".into(),
-            action: "Toggle".try_into().expect("Valid fake key action")
+            action: FakeKeyActionMessage::Toggle
         }).expect("deserializable"),
     )
 }
@@ -128,8 +128,44 @@ fn write_to_kanata(mut s: TcpStream) {
     loop {
         stdin().read_line(&mut layer).expect("stdin is readable");
         let new = layer.trim_end().to_owned();
-        if new.starts_with("fk:") {
-            let fkname = new.trim_start_matches("fk:").into();
+        if new.starts_with("fkpress:") {
+            let fkname = new.trim_start_matches("fkpress:").into();
+            log::info!("writer: telling kanata to press fake key \"{fkname}\"");
+            let msg = serde_json::to_string(&ClientMessage::ActOnFakeKey {
+                name: fkname,
+                action: FakeKeyActionMessage::Press,
+            })
+            .expect("deserializable");
+            s.write_all(msg.as_bytes()).expect("stream writable");
+            layer.clear();
+            continue;
+        }
+        if new.starts_with("fkrelease:") {
+            let fkname = new.trim_start_matches("fkrelease:").into();
+            log::info!("writer: telling kanata to release fake key \"{fkname}\"");
+            let msg = serde_json::to_string(&ClientMessage::ActOnFakeKey {
+                name: fkname,
+                action: FakeKeyActionMessage::Release,
+            })
+            .expect("deserializable");
+            s.write_all(msg.as_bytes()).expect("stream writable");
+            layer.clear();
+            continue;
+        }
+        if new.starts_with("fktap:") {
+            let fkname = new.trim_start_matches("fktap:").into();
+            log::info!("writer: telling kanata to tap fake key \"{fkname}\"");
+            let msg = serde_json::to_string(&ClientMessage::ActOnFakeKey {
+                name: fkname,
+                action: FakeKeyActionMessage::Tap,
+            })
+            .expect("deserializable");
+            s.write_all(msg.as_bytes()).expect("stream writable");
+            layer.clear();
+            continue;
+        }
+        if new.starts_with("fktap:") {
+            let fkname = new.trim_start_matches("fktap:").into();
             log::info!("writer: telling kanata to tap fake key \"{fkname}\"");
             let msg = serde_json::to_string(&ClientMessage::ActOnFakeKey {
                 name: fkname,

--- a/tcp_protocol/src/lib.rs
+++ b/tcp_protocol/src/lib.rs
@@ -44,14 +44,15 @@ impl FromStr for ClientMessage {
     }
 }
 
-impl From<&str> for FakeKeyActionMessage {
-    fn from(s: &str) -> FakeKeyActionMessage {
+impl TryFrom<&str> for FakeKeyActionMessage {
+    type Error = &'static str;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
-            "Press" => FakeKeyActionMessage::Press,
-            "Release" => FakeKeyActionMessage::Release,
-            "Tap" => FakeKeyActionMessage::Tap,
-            "Toggle" => FakeKeyActionMessage::Toggle,
-            _ => FakeKeyActionMessage::Press,   // What's the best practice here?
+            "Press" => Ok(FakeKeyActionMessage::Press),
+            "Release" => Ok(FakeKeyActionMessage::Release),
+            "Tap" => Ok(FakeKeyActionMessage::Tap),
+            "Toggle" => Ok(FakeKeyActionMessage::Toggle),
+            _ => Err("Invalid FakeKeyAction"),
         }
     }
 }

--- a/tcp_protocol/src/lib.rs
+++ b/tcp_protocol/src/lib.rs
@@ -43,3 +43,15 @@ impl FromStr for ClientMessage {
         serde_json::from_str(s)
     }
 }
+
+impl From<&str> for FakeKeyActionMessage {
+    fn from(s: &str) -> FakeKeyActionMessage {
+        match s {
+            "Press" => FakeKeyActionMessage::Press,
+            "Release" => FakeKeyActionMessage::Release,
+            "Tap" => FakeKeyActionMessage::Tap,
+            "Toggle" => FakeKeyActionMessage::Toggle,
+            _ => FakeKeyActionMessage::Press,   // What's the best practice here?
+        }
+    }
+}

--- a/tcp_protocol/src/lib.rs
+++ b/tcp_protocol/src/lib.rs
@@ -43,16 +43,3 @@ impl FromStr for ClientMessage {
         serde_json::from_str(s)
     }
 }
-
-impl TryFrom<&str> for FakeKeyActionMessage {
-    type Error = &'static str;
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        match s {
-            "Press" => Ok(FakeKeyActionMessage::Press),
-            "Release" => Ok(FakeKeyActionMessage::Release),
-            "Tap" => Ok(FakeKeyActionMessage::Tap),
-            "Toggle" => Ok(FakeKeyActionMessage::Toggle),
-            _ => Err("Invalid FakeKeyAction"),
-        }
-    }
-}


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add messages to example TCP client demonstrating fake key actions.

First Rust I've written besides Hello World so hope I didn't butcher it! Seems like my `print_usage` code could be written more tersely but I wanted to follow the pattern I saw.

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [X] Yes
