### PR TITLE
fix(win-llhook): clear-on-idle logic bugs

### DIFF
--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1526,8 +1526,8 @@ impl Kanata {
                         These keys refer to defsrc input, meaning BEFORE kanata remaps keys."
             );
 
+            #[cfg(all(not(feature = "interception_driver"), target_os = "windows"))]
             let mut idle_clear_happened = false;
-
             #[cfg(all(not(feature = "interception_driver"), target_os = "windows"))]
             let mut last_input_time = time::Instant::now();
 
@@ -1577,7 +1577,9 @@ impl Kanata {
                                 // the states that might be stuck. A real use case might be to have
                                 // a fake key pressed for a long period of time, so make sure those
                                 // are not cleared.
-                                if (now - last_input_time) > time::Duration::from_secs(LLHOOK_IDLE_TIME_CLEAR_INPUTS) {
+                                if (now - last_input_time)
+                                    > time::Duration::from_secs(LLHOOK_IDLE_TIME_CLEAR_INPUTS)
+                                {
                                     log::debug!(
                                         "clearing keyberon normal key states due to inactivity"
                                     );
@@ -1627,7 +1629,13 @@ impl Kanata {
                             {
                                 last_input_time = now;
                             }
-                            idle_clear_happened = false;
+                            #[cfg(all(
+                                not(feature = "interception_driver"),
+                                target_os = "windows"
+                            ))]
+                            {
+                                idle_clear_happened = false;
+                            }
 
                             #[cfg(feature = "perf_logging")]
                             log::info!(
@@ -1670,7 +1678,13 @@ impl Kanata {
                             {
                                 last_input_time = std::time::Instant::now();
                             }
-                            idle_clear_happened = false;
+                            #[cfg(all(
+                                not(feature = "interception_driver"),
+                                target_os = "windows"
+                            ))]
+                            {
+                                idle_clear_happened = false;
+                            }
 
                             #[cfg(feature = "perf_logging")]
                             log::info!(

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1577,7 +1577,7 @@ impl Kanata {
                                 // the states that might be stuck. A real use case might be to have
                                 // a fake key pressed for a long period of time, so make sure those
                                 // are not cleared.
-                                if (now - last_input_time) > time::Duration::from_secs(5) {
+                                if (now - last_input_time) > time::Duration::from_secs(LLHOOK_IDLE_TIME_CLEAR_INPUTS) {
                                     log::debug!(
                                         "clearing keyberon normal key states due to inactivity"
                                     );
@@ -1726,7 +1726,7 @@ impl Kanata {
                                 // a fake key pressed for a long period of time, so make sure those
                                 // are not cleared.
                                 if (std::time::Instant::now() - (last_input_time))
-                                    > time::Duration::from_secs(5)
+                                    > time::Duration::from_secs(LLHOOK_IDLE_TIME_CLEAR_INPUTS)
                                     && !idle_clear_happened
                                 {
                                     idle_clear_happened = true;

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1578,24 +1578,31 @@ impl Kanata {
                                     log::debug!(
                                         "clearing keyberon normal key states due to inactivity"
                                     );
-                                    k.layout.bm().states.retain(|s| {
-                                        !matches!(
-                                            s,
+                                    let mut coords_to_release = vec![];
+                                    let layout = k.layout.bm();
+                                    for state in layout.states.iter().copied() {
+                                        match state {
                                             State::NormalKey {
-                                                coord: (NORMAL_KEY_ROW, _),
+                                                coord: (NORMAL_KEY_ROW, y),
                                                 ..
                                             } | State::LayerModifier {
-                                                coord: (NORMAL_KEY_ROW, _),
+                                                coord: (NORMAL_KEY_ROW, y),
                                                 ..
                                             } | State::Custom {
-                                                coord: (NORMAL_KEY_ROW, _),
+                                                coord: (NORMAL_KEY_ROW, y),
                                                 ..
                                             } | State::RepeatingSequence {
-                                                coord: (NORMAL_KEY_ROW, _),
+                                                coord: (NORMAL_KEY_ROW, y),
                                                 ..
+                                            } => {
+                                                coords_to_release.push((NORMAL_KEY_ROW, y));
                                             }
-                                        )
-                                    });
+                                            _ => {}
+                                        }
+                                    }
+                                    for coord in coords_to_release.into_iter() {
+                                        layout.event(Event::Release(coord.0, coord.1));
+                                    }
                                     PRESSED_KEYS.lock().clear();
                                 }
                             }
@@ -1702,24 +1709,32 @@ impl Kanata {
                                     log::debug!(
                                         "clearing keyberon normal key states due to inactivity"
                                     );
-                                    k.layout.bm().states.retain(|s| {
-                                        !matches!(
-                                            s,
+                                    let mut coords_to_release = vec![];
+                                    let layout = k.layout.bm();
+                                    for state in layout.states.iter().copied() {
+                                        match state {
                                             State::NormalKey {
-                                                coord: (NORMAL_KEY_ROW, _),
+                                                coord: (NORMAL_KEY_ROW, y),
                                                 ..
                                             } | State::LayerModifier {
-                                                coord: (NORMAL_KEY_ROW, _),
+                                                coord: (NORMAL_KEY_ROW, y),
                                                 ..
                                             } | State::Custom {
-                                                coord: (NORMAL_KEY_ROW, _),
+                                                coord: (NORMAL_KEY_ROW, y),
                                                 ..
                                             } | State::RepeatingSequence {
-                                                coord: (NORMAL_KEY_ROW, _),
+                                                coord: (NORMAL_KEY_ROW, y),
                                                 ..
+                                            } => {
+                                                coords_to_release.push((NORMAL_KEY_ROW, y));
                                             }
-                                        )
-                                    });
+                                            _ => {}
+                                        }
+                                    }
+                                    for coord in coords_to_release.into_iter() {
+                                        layout.event(Event::Release(coord.0, coord.1));
+                                    }
+                                        
                                     PRESSED_KEYS.lock().clear();
                                 }
                             }

--- a/src/oskbd/windows/llhook.rs
+++ b/src/oskbd/windows/llhook.rs
@@ -17,6 +17,8 @@ use crate::oskbd::{KeyEvent, KeyValue};
 use kanata_parser::custom_action::*;
 use kanata_parser::keys::*;
 
+pub const LLHOOK_IDLE_TIME_CLEAR_INPUTS: u64 = 60;
+
 type HookFn = dyn FnMut(InputEvent) -> bool;
 
 thread_local! {

--- a/src/oskbd/windows/llhook.rs
+++ b/src/oskbd/windows/llhook.rs
@@ -5,7 +5,6 @@
 
 use std::cell::Cell;
 use std::io;
-use std::time::Instant;
 use std::{mem, ptr};
 
 use winapi::ctypes::*;
@@ -149,20 +148,15 @@ unsafe extern "system" fn hook_proc(code: c_int, wparam: WPARAM, lparam: LPARAM)
 }
 
 /// Handle for writing keys to the OS.
-pub struct KbdOut {
-    pub last_action_time: Instant,
-}
+pub struct KbdOut {}
 
 impl KbdOut {
     pub fn new() -> Result<Self, io::Error> {
-        Ok(Self {
-            last_action_time: Instant::now(),
-        })
+        Ok(Self {})
     }
 
     pub fn write(&mut self, event: InputEvent) -> Result<(), io::Error> {
         super::send_key_sendinput(event.code as u16, event.up);
-        self.last_action_time = Instant::now();
         Ok(())
     }
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

The following behaviour is changed:

- clear could previously happen multiple times when looping, now it does not
- time until clear is reset on input key input instead of on key output
- releases are done using a keyberon release event instead of clearing the state, which allows custom release handlers to activate

Hopefully closes #785 

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
