### PR TITLE
feat!(concat,template): allow nested list in concat, allow concat in template

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2731,11 +2731,6 @@ a list beginning with `concat` within the content of `deftemplate`
 will be replaced with a single string that consists of
 all the subsequent items in the list concatenated to each other.
 
-Within the second item of `defvar`,
-a list that begins with the special keyword `concat` will concatenate all
-subsequent items in the list together into a single string value.
-Without using `concat`, lists are saved as-is.
-
 [[custom-tap-hold-behaviour]]
 === Custom tap-hold behaviour
 <<table-of-contents,Back to ToC>>

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2712,6 +2712,30 @@ then the whole `if-equal` list is removed from the template.
 )
 ----
 
+Similar to `if-equal` are three more conditional operators for templates:
+
+* `if-not-equal`
+** the content is used if the first two string parameters are not equal
+* `if-in-list`
+** the content is used if the first string parameter exists in
+the second list-of-strings parameter
+* `if-not-in-list`
+** the content is used if the first string parameter does not exist in
+the second list-of-strings parameter
+
+[[concat-in-deftemplate]]
+==== concat in deftemplate
+
+Like <<concat-in-defvar,concat in defvar>>,
+a list beginning with `concat` within the content of `deftemplate`
+will be replaced with a single string that consists of
+all the subsequent items in the list concatenated to each other.
+
+Within the second item of `defvar`,
+a list that begins with the special keyword `concat` will concatenate all
+subsequent items in the list together into a single string value.
+Without using `concat`, lists are saved as-is.
+
 [[custom-tap-hold-behaviour]]
 === Custom tap-hold behaviour
 <<table-of-contents,Back to ToC>>

--- a/parser/src/cfg/deftemplate.rs
+++ b/parser/src/cfg/deftemplate.rs
@@ -245,6 +245,8 @@ fn expand(exprs: &mut Vec<SExpr>, templates: &[Template]) -> Result<()> {
                     }
                 });
 
+                while evaluate_conditionals(&mut expanded_template)? {}
+
                 replacements.push(Replacement {
                     insert_index: expr_index,
                     exprs: expanded_template,
@@ -268,10 +270,6 @@ fn expand(exprs: &mut Vec<SExpr>, templates: &[Template]) -> Result<()> {
             .collect();
         *exprs = new_vec;
     }
-
-    // TODO: probably best to move this into scope template expansion
-    // instead of the scope of all expressions, like with the TBD concat code.
-    while evaluate_conditionals(exprs)? {}
 
     Ok(())
 }

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -953,7 +953,7 @@ fn parse_vars(exprs: &[&Vec<SExpr>], s: &mut ParsedState) -> Result<()> {
                 },
                 None => bail_expr!(
                     var_name_expr,
-                    "variable key name has no action - you should add an action."
+                    "variable name must have a subsequent value"
                 ),
             };
             if s.vars.insert(var_name.into(), var_expr).is_some() {

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1475,12 +1475,12 @@ fn parse_defvar_concat() {
 (deflayer base a)
 (defvar
     x (concat a b c)
-    y (concat d (concat e f))
+    y (concat d (e f))
     z (squish squash (splish splosh))
     xx (concat $x $y)
-    xy (concat $x (concat $y))
+    xy (concat $x ($y))
     xz (notconcat a b " " c " d")
-    yx (concat a b " " c " d" (concat "efg" " hij ") "kl")
+    yx (concat a b " " c " d" ("efg" " hij ") "kl")
     yz (concat "abc"def"ghi""jkl")
 
     rootpath "/home/myuser/mysubdir"
@@ -1535,61 +1535,6 @@ fn parse_defvar_concat() {
         SExpr::Atom(a) => assert_eq!(&a.t, "/home/myuser/mysubdir/helloworld"),
         SExpr::List(l) => panic!("expected string not list: {l:?}"),
     }
-}
-
-#[test]
-fn parse_defvar_concat_err1() {
-    let _lk = match CFG_PARSE_LOCK.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-
-    let source = r#"
-(defsrc a)
-(deflayer base a)
-(defvar
-    x (concat a b c (not nested concat))
-)
-"#;
-    let mut s = ParsedState::default();
-    parse_cfg_raw_string(
-        source,
-        &mut s,
-        &PathBuf::from("test"),
-        &mut FileContentProvider {
-            get_file_content_fn: &mut |_| unimplemented!(),
-        },
-        DEF_LOCAL_KEYS,
-    )
-    .expect_err("fails");
-}
-
-#[test]
-fn parse_defvar_concat_err2() {
-    let _lk = match CFG_PARSE_LOCK.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-
-    let source = r#"
-(defsrc a)
-(deflayer base a)
-(defvar
-    x (list var uh oh)
-    y (concat a b c $x)
-)
-"#;
-    let mut s = ParsedState::default();
-    parse_cfg_raw_string(
-        source,
-        &mut s,
-        &PathBuf::from("test"),
-        &mut FileContentProvider {
-            get_file_content_fn: &mut |_| unimplemented!(),
-        },
-        DEF_LOCAL_KEYS,
-    )
-    .expect_err("fails");
 }
 
 #[test]

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1644,7 +1644,7 @@ fn parse_template_3() {
 
     let source = r#"
 (deftemplate home-row (version)
-  a s d f g h 
+  a s d f g h
   (if-equal $version v1 j)
   (if-equal $version v2 (tap-hold 200 200 j (if-equal $version v2 k)))
    k l ; '
@@ -1657,7 +1657,7 @@ fn parse_template_3() {
   lsft z    x    c    v    b    n    m    ,    .    /    rsft
   lctl lmet lalt           spc            ralt rmet rctl
 )
-  
+
 (deflayer base
   grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
   tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
@@ -1691,7 +1691,7 @@ fn parse_template_4() {
 
     let source = r#"
 (deftemplate home-row (version)
-  a s d f g h 
+  a s d f g h
   (if-not-equal $version v2 j)
   (if-not-equal $version v1 (tap-hold 200 200 j (if-not-equal $version v1 k)))
    k l ; '
@@ -1700,7 +1700,7 @@ fn parse_template_4() {
 (defsrc
   (template-expand home-row v1)
 )
-  
+
 (deflayer base
   (template-expand home-row v2)
 )
@@ -1730,7 +1730,7 @@ fn parse_template_5() {
 
     let source = r#"
 (deftemplate home-row (version)
-  a s d f g h 
+  a s d f g h
   (if-in-list $version (v0 v3 v1 v4) j)
   (if-in-list $version (v0 v2 v3 v4) (tap-hold 200 200 j (if-in-list $version (v0 v3 v4 v2) k)))
    k l ; '
@@ -1739,7 +1739,7 @@ fn parse_template_5() {
 (defsrc
   (template-expand home-row v1)
 )
-  
+
 (deflayer base
   (template-expand home-row v2)
 )
@@ -1769,7 +1769,7 @@ fn parse_template_6() {
 
     let source = r#"
 (deftemplate home-row (version)
-  a s d f g h 
+  a s d f g h
   (if-not-in-list $version (v2 v3 v4) j)
   (if-not-in-list $version (v1 v3 v4) (tap-hold 200 200 j (if-not-in-list $version (v1 v3 v4) k)))
    k l ; '
@@ -1778,7 +1778,46 @@ fn parse_template_6() {
 (defsrc
   (template-expand home-row v1)
 )
-  
+
+(deflayer base
+  (template-expand home-row v2)
+)
+"#;
+    let mut s = ParsedState::default();
+    parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+        DEF_LOCAL_KEYS,
+    )
+    .map_err(|e| {
+        eprintln!("{:?}", miette::Error::from(e));
+    })
+    .expect("parses");
+}
+
+#[test]
+fn parse_template_7() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    let source = r#"
+(deftemplate home-row (version)
+  a s d f g h
+  (if-in-list $version (v0 v3 (concat v 1) v4) (concat j))
+  (if-in-list $version ((concat v 0) (concat v 2) v3 v4) (tap-hold 200 200 (concat j) (if-in-list $version (v0 v3 v4 v2) (concat "k"))))
+   k l ; '
+)
+
+(defsrc
+  (template-expand home-row v1)
+)
+
 (deflayer base
   (template-expand home-row v2)
 )


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Breaking change: nested lists are now allowed in templates. Since `concat` is only in pre-release versions so far, this seems reasonable to do.

The concat feature is also added into deftemplate to allow using a variable within a string.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes
