### PR TITLE
feat(wintercept): add mouse hwids list defcfg item

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -167,6 +167,13 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;; entry. If this defcfg item is not defined, the log will not print.
   ;;
   ;; windows-interception-mouse-hwid "70, 0, 90, 0, 20"
+  
+  ;; There is also a list version of windows-interception-mouse-hwid:
+  ;;
+  ;; windows-interception-mouse-hwids (
+  ;;   "70, 0, 60, 0"
+  ;;   "71, 0, 62, 0"
+  ;; )
 
   ;; List configuration for kanata-wintercept variants
   ;; that allows intercepting only some connected keyboards.

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2073,6 +2073,24 @@ https://github.com/jtroo/kanata/issues/108[Relevant issue].
 )
 ----
 
+=== Windows only: windows-interception-mouse-hwids[[windows-only-windows-interception-mouse-hwids]]
+<<table-of-contents,Back to ToC>>
+
+This item has a similar purpose as the singular version documented above,
+but is instead a list of strings that allows multiple mice to be intercepted.
+
+If both the singular and list items are used,
+the singular version will behave as if added to the list.
+
+.Example:
+[source]
+----
+(defcfg
+  windows-interception-mouse-hwids (
+    "70, 0, 60, 0"
+    "71, 0, 62, 0"
+  )
+)
 
 === Windows only: windows-interception-keyboard-hwids[[windows-only-windows-interception-keyboard-hwids]]
 <<table-of-contents,Back to ToC>>

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -321,7 +321,7 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                             }
                             match cfg.windows_interception_mouse_hwids.as_mut() {
                                 Some(v) => {
-                                    v.extend(parsed_hwids.into_iter());
+                                    v.extend(parsed_hwids);
                                 }
                                 None => {
                                     cfg.windows_interception_mouse_hwids = Some(parsed_hwids);

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1328,6 +1328,7 @@ fn parse_all_defcfg() {
   linux-x11-repeat-delay-rate 400,50
   windows-altgr add-lctl-release
   windows-interception-mouse-hwid "70, 0, 60, 0"
+  windows-interception-mouse-hwids ("0, 0, 0" "1, 1, 1")
   windows-interception-keyboard-hwids ("0, 0, 0" "1, 1, 1")
 )
 (defsrc a)

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -126,7 +126,7 @@ pub struct Kanata {
     #[cfg(all(feature = "interception_driver", target_os = "windows"))]
     /// Used to know which input device to treat as a mouse for intercepting and processing inputs
     /// by kanata.
-    intercept_mouse_hwid: Option<[u8; HWID_ARR_SZ]>,
+    intercept_mouse_hwids: Option<Vec<[u8; HWID_ARR_SZ]>>,
     #[cfg(all(feature = "interception_driver", target_os = "windows"))]
     /// Used to know which input device to treat as a mouse for intercepting and processing inputs
     /// by kanata.
@@ -305,7 +305,7 @@ impl Kanata {
             #[cfg(target_os = "linux")]
             exclude_names: cfg.items.linux_dev_names_exclude,
             #[cfg(all(feature = "interception_driver", target_os = "windows"))]
-            intercept_mouse_hwid: cfg.items.windows_interception_mouse_hwid,
+            intercept_mouse_hwids: cfg.items.windows_interception_mouse_hwids,
             #[cfg(all(feature = "interception_driver", target_os = "windows"))]
             intercept_kb_hwids: cfg.items.windows_interception_keyboard_hwids,
             dynamic_macro_replay_state: None,

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -20,8 +20,9 @@ impl Kanata {
         }; 32];
 
         let keyboards_to_intercept_hwids = kanata.lock().intercept_kb_hwids.clone();
-        let mouse_to_intercept_hwid: Option<[u8; HWID_ARR_SZ]> = kanata.lock().intercept_mouse_hwid;
-        if mouse_to_intercept_hwid.is_some() {
+        let mouse_to_intercept_hwids: Option<Vec<[u8; HWID_ARR_SZ]>> =
+            kanata.lock().intercept_mouse_hwids.clone();
+        if mouse_to_intercept_hwids.is_some() {
             intrcptn.set_filter(
                 ic::is_mouse,
                 ic::Filter::MouseFilter(ic::MouseState::all() & (!ic::MouseState::MOVE)),
@@ -36,7 +37,7 @@ impl Kanata {
                 for i in 0..num_strokes {
                     let mut key_event = match strokes[i] {
                         ic::Stroke::Keyboard { state, .. } => {
-                            if !is_keyboard_interceptable(
+                            if !is_device_interceptable(
                                 dev,
                                 &intrcptn,
                                 &keyboards_to_intercept_hwids,
@@ -62,11 +63,11 @@ impl Kanata {
                             KeyEvent { code, value }
                         }
                         ic::Stroke::Mouse { state, rolling, .. } => {
-                            if let Some(hwid) = mouse_to_intercept_hwid {
+                            if let Some(_) = mouse_to_intercept_hwids {
                                 log::trace!("checking mouse stroke {:?}", strokes[i]);
                                 if let Some(event) = mouse_state_to_event(
                                     dev,
-                                    &hwid,
+                                    &mouse_to_intercept_hwids,
                                     state,
                                     rolling,
                                     &intrcptn,
@@ -111,7 +112,7 @@ impl Kanata {
     }
 }
 
-fn is_keyboard_interceptable(
+fn is_device_interceptable(
     input_dev: ic::Device,
     intrcptn: &ic::Interception,
     allowed_hwids: &Option<Vec<[u8; HWID_ARR_SZ]>>,
@@ -134,38 +135,18 @@ fn is_keyboard_interceptable(
     }
 }
 
-fn is_mouse_dev_interceptable(
-    input_dev: ic::Device,
-    intrcptn: &ic::Interception,
-    allowed_hwid: &[u8; HWID_ARR_SZ],
-    cache: &mut HashMap<ic::Device, bool>,
-) -> bool {
-    match cache.get(&input_dev) {
-        Some(v) => *v,
-        None => {
-            let mut hwid = [0u8; HWID_ARR_SZ];
-            log::trace!("getting hardware id for input dev: {input_dev}");
-            let res = intrcptn.get_hardware_id(input_dev, &mut hwid);
-            let dev_is_interceptable = hwid == *allowed_hwid;
-            log::info!("res {res}; device #{input_dev} hwid {hwid:?} matches allowed mouse input: {dev_is_interceptable}");
-            cache.insert(input_dev, dev_is_interceptable);
-            dev_is_interceptable
-        }
-    }
-}
-
 fn mouse_state_to_event(
     input_dev: ic::Device,
-    allowed_hwid: &[u8; HWID_ARR_SZ],
+    allowed_hwids: &Option<Vec<[u8; HWID_ARR_SZ]>>,
     state: ic::MouseState,
     rolling: i16,
     intrcptn: &ic::Interception,
     device_interceptability_cache: &mut HashMap<ic::Device, bool>,
 ) -> Option<KeyEvent> {
-    if !is_mouse_dev_interceptable(
+    if !is_device_interceptable(
         input_dev,
         intrcptn,
-        allowed_hwid,
+        allowed_hwids,
         device_interceptability_cache,
     ) {
         return None;

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -63,7 +63,7 @@ impl Kanata {
                             KeyEvent { code, value }
                         }
                         ic::Stroke::Mouse { state, rolling, .. } => {
-                            if let Some(_) = mouse_to_intercept_hwids {
+                            if mouse_to_intercept_hwids.is_some() {
                                 log::trace!("checking mouse stroke {:?}", strokes[i]);
                                 if let Some(event) = mouse_state_to_event(
                                     dev,


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add a list defcfg item for intercepted mouse device hwids with Windows-Interception. The original, single device defcfg item is kept. When both the list and single items exist in defcfg, the single hwid is included in the list.

Closes #764.

~~Currently zero testing, will do later~~

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
