### PR TITLE
feat: allow more participating labels in `defchords`

### DIFF
--- a/keyberon/src/action.rs
+++ b/keyberon/src/action.rs
@@ -282,7 +282,7 @@ impl<'a, T> ChordsGroup<'a, T> {
 /// A set of virtual keys (represented as a bit mask) pressed together.
 /// The keys do not directly correspond to physical keys. They are unique to a given [ChordGroup] and their mapping from physical keys is definied in [ChordGroup.coords].
 /// As such, each chord group can effectively have at most 32 different keys (though multiple physical keys may be mapped to the same virtual key).
-pub type ChordKeys = u32;
+pub type ChordKeys = u128;
 
 /// Defines the maximum number of (virtual) keys that can be used in a single chords group.
 pub const MAX_CHORD_KEYS: usize = ChordKeys::BITS as usize;

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -593,7 +593,7 @@ impl<'a, T: std::fmt::Debug> WaitingState<'a, T> {
         queued: &mut Queue,
         action_queue: &mut ActionQueue<'a, T>,
     ) {
-        let mut chord_key_order = [0u32; ChordKeys::BITS as usize];
+        let mut chord_key_order = [0u128; ChordKeys::BITS as usize];
 
         // Default to the initial coordinate. But if a key is released early (before the timeout
         // occurs), use that key for action releases. That way the chord is released as early as

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -943,7 +943,7 @@ struct ChordGroup {
     name: String,
     keys: Vec<String>,
     coords: Vec<((u8, u16), ChordKeys)>,
-    chords: HashMap<u32, SExpr>,
+    chords: HashMap<u128, SExpr>,
     timeout: u16,
 }
 
@@ -1969,7 +1969,7 @@ fn parse_chord(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAc
             ),
         })
         .ok_or_else(|| anyhow_expr!(&ac_params[0], "{ERR_MSG}"))??;
-    let chord_keys = 1 << chord_key_index;
+    let chord_keys: u128 = 1 << chord_key_index;
 
     // We don't yet know at this point what the entire chords group will look like nor at which
     // coords this action will end up. So instead we store a dummy action which will be properly
@@ -2064,7 +2064,7 @@ fn parse_chord_groups(exprs: &[&Spanned<Vec<SExpr>>], s: &mut ParsedState) -> Re
                     })
                 })
                 .ok_or_else(|| anyhow_expr!(keys_expr, "Chord must be a list/set of keys"))?;
-            let mask = keys.try_fold(0, |mask, key| {
+            let mask: u128 = keys.try_fold(0, |mask, key| {
                 let key = key?;
                 let index = match group.keys.iter().position(|k| k == key) {
                     Some(i) => i,


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
allow defining more chords in `defchords` then just 32, allow up to 128

potentially closes #792 

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
    - manual testing
