### PR TITLE
feat(tcp): add config file reload event (#811)

### DIFF
--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -340,7 +340,7 @@ impl Kanata {
         Ok(Arc::new(Mutex::new(Self::new(args)?)))
     }
 
-    fn do_live_reload(&mut self, tx: &Option<Sender<ServerMessage>>) -> Result<()> {
+    fn do_live_reload(&mut self, _tx: &Option<Sender<ServerMessage>>) -> Result<()> {
         let cfg = match cfg::new_from_file(&self.cfg_paths[self.cur_cfg_idx]) {
             Ok(c) => c,
             Err(e) => {
@@ -375,7 +375,7 @@ impl Kanata {
         Kanata::set_repeat_rate(cfg.items.linux_x11_repeat_delay_rate)?;
         log::info!("Live reload successful");
         #[cfg(feature = "tcp_server")]
-        if let Some(tx) = tx {
+        if let Some(tx) = _tx {
             match tx.try_send(ServerMessage::ConfigFileReload {
                 new: self.cfg_paths[self.cur_cfg_idx]
                     .to_str()

--- a/tcp_protocol/src/lib.rs
+++ b/tcp_protocol/src/lib.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 pub enum ServerMessage {
     LayerChange { new: String },
     LayerNames { names: Vec<String> },
+    ConfigFileReload { new: String },
     Error { msg: String },
 }
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
add `ConfigFileReload` TCP server event type

potentially may partially resolve #811

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
    - manual testing
