### PR TITLE
Send extended scancodes for keys that require them

### DIFF
--- a/src/oskbd/windows/mod.rs
+++ b/src/oskbd/windows/mod.rs
@@ -6,6 +6,9 @@ use encode_unicode::CharExt;
 
 use crate::oskbd::KeyValue;
 
+#[cfg(feature = "win_sendinput_send_scancodes")]
+use kanata_parser::keys::OsCode;
+
 #[cfg(not(feature = "interception_driver"))]
 mod llhook;
 #[cfg(not(feature = "interception_driver"))]
@@ -79,6 +82,13 @@ fn send_key_sendinput(code: u16, is_key_up: bool) {
                 let code_u32 = code as u32;
                 kb_input.dwFlags |= KEYEVENTF_SCANCODE;
                 kb_input.wScan = MapVirtualKeyA(code_u32, 0) as u16;
+                match OsCode::from(code) {
+                    OsCode::KEY_PREVIOUSSONG|OsCode::KEY_NEXTSONG|OsCode::KEY_KPENTER|OsCode::KEY_RIGHTCTRL|OsCode::KEY_MUTE|OsCode::KEY_PLAYPAUSE|OsCode::KEY_VOLUMEDOWN|OsCode::KEY_VOLUMEUP|OsCode::KEY_KPSLASH|OsCode::KEY_PRINT|OsCode::KEY_RIGHTALT|OsCode::KEY_HOME|OsCode::KEY_UP|OsCode::KEY_PAGEUP|OsCode::KEY_LEFT|OsCode::KEY_RIGHT|OsCode::KEY_END|OsCode::KEY_DOWN|OsCode::KEY_PAGEDOWN|OsCode::KEY_INSERT|OsCode::KEY_DELETE|OsCode::KEY_LEFTMETA|OsCode::KEY_RIGHTMETA|OsCode::KEY_FORWARD|OsCode::KEY_BACK|OsCode::KEY_COMPOSE => {
+                        kb_input.wScan |= 0xE000;
+                        kb_input.dwFlags |= KEYEVENTF_EXTENDEDKEY;
+                    }
+                    _ => {}
+                }
             }
         }
         #[cfg(not(feature = "win_sendinput_send_scancodes"))]


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Set the `KEYEVENTF_EXTENDEDKEY` flag for keys that map to extended scancodes.

This change applies to the `win_sendinput_send_scancodes` feature. Currently, the scancode is determined by the `MapVirtualKeyA` function, which does not output extended scancodes. This causes navigation keys (arrows, Home/End, PgUp/PgDn) to be mapped to the Numpad versions, and completely breaks the functionality of media keys.

I'm not very familiar with Rust, so let me know if there's a better way to address the issue.

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
