### PR TITLE
after lrld: print layer and send LayerChange event (#811,  #813)

### DIFF
--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -391,9 +391,8 @@ impl Kanata {
                 }
             }
         }
+
         let cur_layer = self.layout.bm().current_layer();
-        //don't wrap in if cur_layer != self.prev_layer, a new deflayer prepended to top of config
-        //then would not send the layer change event, because it would have the same index, 0
         self.prev_layer = cur_layer;
         self.print_layer(cur_layer);
 

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -340,7 +340,7 @@ impl Kanata {
         Ok(Arc::new(Mutex::new(Self::new(args)?)))
     }
 
-    fn do_live_reload(&mut self) -> Result<()> {
+    fn do_live_reload(&mut self, _tx: &Option<Sender<ServerMessage>>) -> Result<()> {
         let cfg = match cfg::new_from_file(&self.cfg_paths[self.cur_cfg_idx]) {
             Ok(c) => c,
             Err(e) => {
@@ -515,7 +515,7 @@ impl Kanata {
             // activate. Having this fallback allows live reload to happen which resets the
             // kanata states.
             self.live_reload_requested = false;
-            if let Err(e) = self.do_live_reload() {
+            if let Err(e) = self.do_live_reload(tx) {
                 log::error!("live reload failed {e}");
             }
         }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -394,12 +394,12 @@ impl Kanata {
         let cur_layer = self.layout.bm().current_layer();
         //don't wrap in if cur_layer != self.prev_layer, a new deflayer prepended to top of config
         //then would not send the layer change event, because it would have the same index, 0
-        let new = self.layer_info[cur_layer].name.clone();
         self.prev_layer = cur_layer;
         self.print_layer(cur_layer);
 
         #[cfg(feature = "tcp_server")]
         if let Some(tx) = _tx {
+            let new = self.layer_info[cur_layer].name.clone();
             match tx.try_send(ServerMessage::LayerChange { new }) {
                 Ok(_) => {}
                 Err(error) => {

--- a/tcp_protocol/src/lib.rs
+++ b/tcp_protocol/src/lib.rs
@@ -6,6 +6,7 @@ pub enum ServerMessage {
     LayerChange { new: String },
     LayerNames { names: Vec<String> },
     CurrentLayerInfo { name: String, cfg_text: String },
+    ConfigFileReload { new: String },
     Error { msg: String },
 }
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
after live reload: print layer and send LayerChange event

This PR may supersede/replace PR #813 if you accept this additional change
this PR feature-branch has no conflicts with main as of now, #813's feature-branch does
may partially resolve #811:
> *currently when a file is reloaded and the layer is changed, TCP server does not send a LayerChange event, maybe it should, but I think we still should have this event type



## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
