### PR TITLE
refactor: use struct with named fields instead of tuple for intermediate cfg

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -259,24 +259,24 @@ pub struct LayerInfo {
 #[allow(clippy::type_complexity)] // return type is not pub
 fn parse_cfg(p: &Path) -> MResult<Cfg> {
     let mut s = ParsedState::default();
-    let (items, mapped_keys, layer_info, klayers, sequences, overrides) = parse_cfg_raw(p, &mut s)?;
-    let key_outputs = create_key_outputs(&klayers, &overrides);
+    let icfg = parse_cfg_raw(p, &mut s)?;
+    let key_outputs = create_key_outputs(&icfg.klayers, &icfg.overrides);
     let switch_max_key_timing = s.switch_max_key_timing.get();
-    let mut layout = KanataLayout::new(Layout::new(klayers), s.a);
-    layout.bm().quick_tap_hold_timeout = items.concurrent_tap_hold;
-    layout.bm().oneshot.on_press_release_delay = items.rapid_event_delay;
+    let mut layout = KanataLayout::new(Layout::new(icfg.klayers), s.a);
+    layout.bm().quick_tap_hold_timeout = icfg.options.concurrent_tap_hold;
+    layout.bm().oneshot.on_press_release_delay = icfg.options.rapid_event_delay;
     let mut fake_keys: HashMap<String, usize> =
         s.fake_keys.iter().map(|(k, v)| (k.clone(), v.0)).collect();
     fake_keys.shrink_to_fit();
     log::info!("config file is valid");
     Ok(Cfg {
-        items,
-        mapped_keys,
-        layer_info,
+        items: icfg.options,
+        mapped_keys: icfg.mapped_keys,
+        layer_info: icfg.layer_info,
         key_outputs,
         layout,
-        sequences,
-        overrides,
+        sequences: icfg.sequences,
+        overrides: icfg.overrides,
         fake_keys,
         switch_max_key_timing,
     })
@@ -291,18 +291,18 @@ const DEF_LOCAL_KEYS: &str = "deflocalkeys-macos";
 #[cfg(any(target_os = "linux", target_os = "unknown"))]
 const DEF_LOCAL_KEYS: &str = "deflocalkeys-linux";
 
+#[derive(Debug)]
+pub struct IntermediateCfg {
+    pub options: CfgOptions,
+    pub mapped_keys: MappedKeys,
+    pub layer_info: Vec<LayerInfo>,
+    pub klayers: KanataLayers,
+    pub sequences: KeySeqsToFKeys,
+    pub overrides: Overrides,
+}
+
 #[allow(clippy::type_complexity)] // return type is not pub
-fn parse_cfg_raw(
-    p: &Path,
-    s: &mut ParsedState,
-) -> MResult<(
-    CfgOptions,
-    MappedKeys,
-    Vec<LayerInfo>,
-    KanataLayers,
-    KeySeqsToFKeys,
-    Overrides,
-)> {
+fn parse_cfg_raw(p: &Path, s: &mut ParsedState) -> MResult<IntermediateCfg> {
     const INVALID_PATH_ERROR: &str = "The provided config file path is not valid";
 
     let mut loaded_files: HashSet<PathBuf> = HashSet::default();
@@ -400,14 +400,7 @@ pub fn parse_cfg_raw_string(
     cfg_path: &Path,
     file_content_provider: &mut FileContentProvider,
     def_local_keys_variant_to_apply: &str,
-) -> Result<(
-    CfgOptions,
-    MappedKeys,
-    Vec<LayerInfo>,
-    KanataLayers,
-    KeySeqsToFKeys,
-    Overrides,
-)> {
+) -> Result<IntermediateCfg> {
     let spanned_root_exprs = sexpr::parse(text, &cfg_path.to_string_lossy())
         .and_then(|xs| expand_includes(xs, file_content_provider))
         .and_then(expand_templates)?;
@@ -628,14 +621,14 @@ pub fn parse_cfg_raw_string(
         }
     };
 
-    Ok((
-        cfg,
-        src,
+    Ok(IntermediateCfg {
+        options: cfg,
+        mapped_keys: src,
         layer_info,
-        s.a.bref_slice(klayers),
+        klayers: s.a.bref_slice(klayers),
         sequences,
         overrides,
-    ))
+    })
 }
 
 fn error_on_unknown_top_level_atoms(exprs: &[Spanned<Vec<SExpr>>]) -> Result<()> {

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -226,7 +226,7 @@ pub struct Cfg {
     /// Layer info used for printing to the logs.
     pub layer_info: Vec<LayerInfo>,
     /// Configuration items in `defcfg`.
-    pub items: CfgOptions,
+    pub options: CfgOptions,
     /// The keyberon layout state machine struct.
     pub layout: KanataLayout,
     /// Sequences defined in `defseq`.
@@ -270,7 +270,7 @@ fn parse_cfg(p: &Path) -> MResult<Cfg> {
     fake_keys.shrink_to_fit();
     log::info!("config file is valid");
     Ok(Cfg {
-        items: icfg.options,
+        options: icfg.options,
         mapped_keys: icfg.mapped_keys,
         layer_info: icfg.layer_info,
         key_outputs,

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -235,7 +235,7 @@ fn parse_delegate_to_default_layer_yes() {
     )
     .unwrap();
     assert_eq!(
-        res.3[2][0][OsCode::KEY_A.as_u16() as usize],
+        res.klayers[2][0][OsCode::KEY_A.as_u16() as usize],
         Action::KeyCode(KeyCode::B),
     );
 }
@@ -264,7 +264,7 @@ fn parse_delegate_to_default_layer_yes_but_base_transparent() {
     )
     .unwrap();
     assert_eq!(
-        res.3[2][0][OsCode::KEY_A.as_u16() as usize],
+        res.klayers[2][0][OsCode::KEY_A.as_u16() as usize],
         Action::KeyCode(KeyCode::A),
     );
 }
@@ -293,7 +293,7 @@ fn parse_delegate_to_default_layer_no() {
     )
     .unwrap();
     assert_eq!(
-        res.3[2][0][OsCode::KEY_A.as_u16() as usize],
+        res.klayers[2][0][OsCode::KEY_A.as_u16() as usize],
         Action::KeyCode(KeyCode::A),
     );
 }
@@ -305,13 +305,14 @@ fn parse_transparent_default() {
         Err(poisoned) => poisoned.into_inner(),
     };
     let mut s = ParsedState::default();
-    let (_, _, layer_strings, layers, _, _) = parse_cfg_raw(
+    let icfg = parse_cfg_raw(
         &std::path::PathBuf::from("./test_cfgs/transparent_default.kbd"),
         &mut s,
     )
     .unwrap();
+    let layers = icfg.klayers;
 
-    assert_eq!(layer_strings.len(), 4);
+    assert_eq!(icfg.layer_info.len(), 4);
 
     assert_eq!(
         layers[0][0][usize::from(OsCode::KEY_F13)],
@@ -816,7 +817,7 @@ fn parse_switch() {
     let (op7, op8) =
         OpCode::new_historical_input((NORMAL_KEY_ROW, u16::from(OsCode::KEY_LEFTSHIFT)), 7);
     assert_eq!(
-        res.3[0][0][OsCode::KEY_A.as_u16() as usize],
+        res.klayers[0][0][OsCode::KEY_A.as_u16() as usize],
         Action::Switch(&Switch {
             cases: &[
                 (
@@ -983,7 +984,7 @@ fn parse_on_idle_fakekey() {
     })
     .unwrap();
     assert_eq!(
-        res.3[0][0][OsCode::KEY_A.as_u16() as usize],
+        res.klayers[0][0][OsCode::KEY_A.as_u16() as usize],
         Action::Custom(
             &[&CustomAction::FakeKeyOnIdle(FakeKeyOnIdle {
                 coord: Coord { x: 1, y: 0 },

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -266,7 +266,7 @@ impl Kanata {
             );
         }
 
-        update_kbd_out(&cfg.items, &kbd_out)?;
+        update_kbd_out(&cfg.options, &kbd_out)?;
 
         #[cfg(target_os = "windows")]
         set_win_altgr_behaviour(cfg.items.windows_altgr);
@@ -288,7 +288,7 @@ impl Kanata {
             move_mouse_state_vertical: None,
             move_mouse_state_horizontal: None,
             move_mouse_speed_modifiers: Vec::new(),
-            sequence_backtrack_modcancel: cfg.items.sequence_backtrack_modcancel,
+            sequence_backtrack_modcancel: cfg.options.sequence_backtrack_modcancel,
             sequence_state: None,
             sequences: cfg.sequences,
             last_tick: time::Instant::now(),
@@ -299,13 +299,13 @@ impl Kanata {
             #[cfg(target_os = "macos")]
             include_names: cfg.items.macos_dev_names_include,
             #[cfg(target_os = "linux")]
-            kbd_in_paths: cfg.items.linux_dev,
+            kbd_in_paths: cfg.options.linux_dev,
             #[cfg(target_os = "linux")]
-            continue_if_no_devices: cfg.items.linux_continue_if_no_devs_found,
+            continue_if_no_devices: cfg.options.linux_continue_if_no_devs_found,
             #[cfg(target_os = "linux")]
-            include_names: cfg.items.linux_dev_names_include,
+            include_names: cfg.options.linux_dev_names_include,
             #[cfg(target_os = "linux")]
-            exclude_names: cfg.items.linux_dev_names_exclude,
+            exclude_names: cfg.options.linux_dev_names_exclude,
             #[cfg(all(feature = "interception_driver", target_os = "windows"))]
             intercept_mouse_hwids: cfg.items.windows_interception_mouse_hwids,
             #[cfg(all(feature = "interception_driver", target_os = "windows"))]
@@ -313,16 +313,16 @@ impl Kanata {
             dynamic_macro_replay_state: None,
             dynamic_macro_record_state: None,
             dynamic_macros: Default::default(),
-            log_layer_changes: cfg.items.log_layer_changes,
+            log_layer_changes: cfg.options.log_layer_changes,
             caps_word: None,
-            movemouse_smooth_diagonals: cfg.items.movemouse_smooth_diagonals,
-            movemouse_inherit_accel_state: cfg.items.movemouse_inherit_accel_state,
-            dynamic_macro_max_presses: cfg.items.dynamic_macro_max_presses,
+            movemouse_smooth_diagonals: cfg.options.movemouse_smooth_diagonals,
+            movemouse_inherit_accel_state: cfg.options.movemouse_inherit_accel_state,
+            dynamic_macro_max_presses: cfg.options.dynamic_macro_max_presses,
             dynamic_macro_replay_behaviour: ReplayBehaviour {
-                delay: cfg.items.dynamic_macro_replay_delay_behaviour,
+                delay: cfg.options.dynamic_macro_replay_delay_behaviour,
             },
             #[cfg(target_os = "linux")]
-            x11_repeat_rate: cfg.items.linux_x11_repeat_delay_rate,
+            x11_repeat_rate: cfg.options.linux_x11_repeat_delay_rate,
             waiting_for_idle: HashSet::default(),
             ticks_since_idle: 0,
             movemouse_buffer: None,
@@ -348,21 +348,21 @@ impl Kanata {
                 bail!("failed to parse config file");
             }
         };
-        update_kbd_out(&cfg.items, &self.kbd_out)?;
+        update_kbd_out(&cfg.options, &self.kbd_out)?;
         #[cfg(target_os = "windows")]
         set_win_altgr_behaviour(cfg.items.windows_altgr);
-        self.sequence_backtrack_modcancel = cfg.items.sequence_backtrack_modcancel;
+        self.sequence_backtrack_modcancel = cfg.options.sequence_backtrack_modcancel;
         self.layout = cfg.layout;
         self.key_outputs = cfg.key_outputs;
         self.layer_info = cfg.layer_info;
         self.sequences = cfg.sequences;
         self.overrides = cfg.overrides;
-        self.log_layer_changes = cfg.items.log_layer_changes;
-        self.movemouse_smooth_diagonals = cfg.items.movemouse_smooth_diagonals;
-        self.movemouse_inherit_accel_state = cfg.items.movemouse_inherit_accel_state;
-        self.dynamic_macro_max_presses = cfg.items.dynamic_macro_max_presses;
+        self.log_layer_changes = cfg.options.log_layer_changes;
+        self.movemouse_smooth_diagonals = cfg.options.movemouse_smooth_diagonals;
+        self.movemouse_inherit_accel_state = cfg.options.movemouse_inherit_accel_state;
+        self.dynamic_macro_max_presses = cfg.options.dynamic_macro_max_presses;
         self.dynamic_macro_replay_behaviour = ReplayBehaviour {
-            delay: cfg.items.dynamic_macro_replay_delay_behaviour,
+            delay: cfg.options.dynamic_macro_replay_delay_behaviour,
         };
         #[cfg(feature = "tcp_server")]
         {
@@ -372,7 +372,7 @@ impl Kanata {
 
         *MAPPED_KEYS.lock() = cfg.mapped_keys;
         #[cfg(target_os = "linux")]
-        Kanata::set_repeat_rate(cfg.items.linux_x11_repeat_delay_rate)?;
+        Kanata::set_repeat_rate(cfg.options.linux_x11_repeat_delay_rate)?;
         log::info!("Live reload successful");
         #[cfg(feature = "tcp_server")]
         if let Some(tx) = _tx {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -269,7 +269,7 @@ impl Kanata {
         update_kbd_out(&cfg.options, &kbd_out)?;
 
         #[cfg(target_os = "windows")]
-        set_win_altgr_behaviour(cfg.items.windows_altgr);
+        set_win_altgr_behaviour(cfg.options.windows_altgr);
 
         *MAPPED_KEYS.lock() = cfg.mapped_keys;
 
@@ -297,7 +297,7 @@ impl Kanata {
             overrides: cfg.overrides,
             override_states: OverrideStates::new(),
             #[cfg(target_os = "macos")]
-            include_names: cfg.items.macos_dev_names_include,
+            include_names: cfg.options.macos_dev_names_include,
             #[cfg(target_os = "linux")]
             kbd_in_paths: cfg.options.linux_dev,
             #[cfg(target_os = "linux")]
@@ -307,9 +307,9 @@ impl Kanata {
             #[cfg(target_os = "linux")]
             exclude_names: cfg.options.linux_dev_names_exclude,
             #[cfg(all(feature = "interception_driver", target_os = "windows"))]
-            intercept_mouse_hwids: cfg.items.windows_interception_mouse_hwids,
+            intercept_mouse_hwids: cfg.options.windows_interception_mouse_hwids,
             #[cfg(all(feature = "interception_driver", target_os = "windows"))]
-            intercept_kb_hwids: cfg.items.windows_interception_keyboard_hwids,
+            intercept_kb_hwids: cfg.options.windows_interception_keyboard_hwids,
             dynamic_macro_replay_state: None,
             dynamic_macro_record_state: None,
             dynamic_macros: Default::default(),
@@ -350,7 +350,7 @@ impl Kanata {
         };
         update_kbd_out(&cfg.options, &self.kbd_out)?;
         #[cfg(target_os = "windows")]
-        set_win_altgr_behaviour(cfg.items.windows_altgr);
+        set_win_altgr_behaviour(cfg.options.windows_altgr);
         self.sequence_backtrack_modcancel = cfg.options.sequence_backtrack_modcancel;
         self.layout = cfg.layout;
         self.key_outputs = cfg.key_outputs;


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

cherry-picked refactor from #775 + rename
