### PR TITLE
POC for #816

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,19 @@ repository = "https://github.com/jtroo/kanata"
 readme = "README.md"
 license = "LGPL-3.0"
 edition = "2021"
+default-run = "kanata"
+
+[lib]
+name = "kanata_state_machine"
+path = "src/lib.rs"
+
+[[bin]]
+name = "kanata"
+path = "src/main.rs"
+
+[[bin]]
+name = "kanata_filesim"
+path = "src/filesim.rs"
 
 [dependencies]
 anyhow = "1"

--- a/src/filesim.rs
+++ b/src/filesim.rs
@@ -1,0 +1,84 @@
+use anyhow::{anyhow, bail, Result};
+use kanata_parser::keys::str_to_oscode;
+use kanata_state_machine::{oskbd::*, *};
+use simplelog::*;
+
+#[cfg(test)]
+mod tests;
+
+fn log_init() {
+    let mut log_cfg = ConfigBuilder::new();
+    if let Err(e) = log_cfg.set_time_offset_to_local() {
+        eprintln!("WARNING: could not set log TZ to local: {e:?}");
+    };
+    log_cfg.set_time_format_rfc3339();
+    CombinedLogger::init(vec![TermLogger::new(
+        LevelFilter::Debug,
+        log_cfg.build(),
+        TerminalMode::Mixed,
+        ColorChoice::AlwaysAnsi,
+    )])
+    .expect("logger can init");
+}
+
+fn arg_init() -> Result<ValidatedArgs> {
+    let cfg_paths = default_cfg();
+
+    Ok(ValidatedArgs {
+        paths: cfg_paths,
+        #[cfg(feature = "tcp_server")]
+        port: None,
+        #[cfg(target_os = "linux")]
+        symlink_path: None,
+        nodelay: true,
+    })
+}
+
+fn main_impl() -> Result<()> {
+    log_init();
+    let args = arg_init()?;
+    let mut k = Kanata::new(&args)?;
+
+    let s = std::fs::read_to_string("testing/sim.txt")?;
+    for l in s.lines() {
+        match l.split_once(':') {
+            Some((kind, val)) => match kind {
+                "tick" => {
+                    k.tick_ms(str::parse::<u128>(val)?)?;
+                }
+                "press" => {
+                    k.handle_input_event(&KeyEvent {
+                        code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
+                        value: KeyValue::Press,
+                    })?;
+                }
+                "release" => {
+                    k.handle_input_event(&KeyEvent {
+                        code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
+                        value: KeyValue::Release,
+                    })?;
+                }
+                "repeat" => {
+                    k.handle_input_event(&KeyEvent {
+                        code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
+                        value: KeyValue::Repeat,
+                    })?;
+                }
+                _ => bail!("invalid line prefix: {kind}"),
+            },
+            None => bail!("invalid line: {l}"),
+        }
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let ret = main_impl();
+    if let Err(ref e) = ret {
+        log::error!("{e}\n");
+    }
+    eprintln!("\nPress enter to exit");
+    let _ = std::io::stdin().read_line(&mut String::new());
+    ret
+}

--- a/src/filesim.rs
+++ b/src/filesim.rs
@@ -1,10 +1,45 @@
 use anyhow::{anyhow, bail, Result};
+use clap::Parser;
 use kanata_parser::keys::str_to_oscode;
 use kanata_state_machine::{oskbd::*, *};
 use simplelog::*;
 
+use std::path::PathBuf;
+
 #[cfg(test)]
 mod tests;
+
+#[derive(Parser, Debug)]
+#[command(author, version, verbatim_doc_comment)]
+///
+/// kanata_filesim is a helper cli tool that helps debug kanata's user configuration:
+/// - it reads a text file with a sequence of key events, including key delays
+/// - interprets them with kanata
+/// - prints out which key|mouse events/actions kanata would execute if the keys were
+/// pressed by a user
+struct Args {
+    // Display different platform specific paths based on the target OS
+    #[cfg_attr(
+        target_os = "windows",
+        doc = r"Configuration file(s) to use with kanata. If not specified, defaults to
+kanata.kbd in the current working directory and
+'C:\Users\user\AppData\Roaming\kanata\kanata.kbd'"
+    )]
+    #[cfg_attr(
+        target_os = "macos",
+        doc = "Configuration file(s) to use with kanata. If not specified, defaults to
+kanata.kbd in the current working directory and
+'$HOME/Library/Application Support/kanata/kanata.kbd.'"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "macos", target_os = "windows")),
+        doc = "Configuration file(s) to use with kanata. If not specified, defaults to
+kanata.kbd in the current working directory and
+'$XDG_CONFIG_HOME/kanata/kanata.kbd'"
+    )]
+    #[arg(short, long, verbatim_doc_comment)]
+    cfg: Option<Vec<PathBuf>>,
+}
 
 fn log_init() {
     let mut log_cfg = ConfigBuilder::new();
@@ -21,8 +56,28 @@ fn log_init() {
     .expect("logger can init");
 }
 
-fn arg_init() -> Result<ValidatedArgs> {
-    let cfg_paths = default_cfg();
+
+/// Parse CLI arguments
+fn cli_init() -> Result<ValidatedArgs> {
+    let args = Args::parse();
+    let cfg_paths = args.cfg.unwrap_or_else(default_cfg);
+
+    log::info!("kanata_filesim v{} starting", env!("CARGO_PKG_VERSION"));
+    #[cfg(all(not(feature = "interception_driver"), target_os = "windows"))]
+    log::info!("using LLHOOK+SendInput for keyboard IO");
+    #[cfg(all(feature = "interception_driver", target_os = "windows"))]
+    log::info!("using the Interception driver for keyboard IO");
+
+    if let Some(config_file) = cfg_paths.first() {
+        if !config_file.exists() {
+            bail!(
+                "Could not find the config file ({})\nFor more info, pass the `-h` or `--help` flags.",
+                cfg_paths[0].to_str().unwrap_or("?")
+            )
+        }
+    } else {
+        bail!("No config files provided\nFor more info, pass the `-h` or `--help` flags.");
+    }
 
     Ok(ValidatedArgs {
         paths: cfg_paths,
@@ -36,7 +91,7 @@ fn arg_init() -> Result<ValidatedArgs> {
 
 fn main_impl() -> Result<()> {
     log_init();
-    let args = arg_init()?;
+    let args = cli_init()?;
     let mut k = Kanata::new(&args)?;
 
     let s = std::fs::read_to_string("testing/sim.txt")?;

--- a/src/filesim.rs
+++ b/src/filesim.rs
@@ -12,10 +12,10 @@ mod tests;
 #[derive(Parser, Debug)]
 #[command(author, version, verbatim_doc_comment)]
 ///
-/// kanata_filesim is a helper cli tool that helps debug kanata's user configuration:
-/// - it reads a text file with a sequence of key events, including key delays
-/// - interprets them with kanata
-/// - prints out which key|mouse events/actions kanata would execute if the keys were
+/// kanata_filesim: a cli tool that helps debug kanata's user configuration by:
+/// - reading a text file with a sequence of key events, including key delays
+/// - interpreting them with kanata
+/// - printing out which actions or key/mouse events kanata would execute if the keys were
 /// pressed by a user
 struct Args {
     // Display different platform specific paths based on the target OS
@@ -39,6 +39,28 @@ kanata.kbd in the current working directory and
     )]
     #[arg(short, long, verbatim_doc_comment)]
     cfg: Option<Vec<PathBuf>>,
+
+    // Display different platform specific paths based on the target OS
+    #[cfg_attr(
+        target_os = "windows",
+        doc = r"Simulation file(s) to use with kanata_filesim. If not specified, defaults to
+test\sim.txt in the current working directory and
+'C:\Users\user\AppData\Roaming\kanata\test\sim.txt'"
+    )]
+    #[cfg_attr(
+        target_os = "macos",
+        doc = "Simulation file(s) to use with kanata_filesim. If not specified, defaults to
+test/sim.txt in the current working directory and
+'$HOME/Library/Application Support/kanata/test/sim.txt.'"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "macos", target_os = "windows")),
+        doc = "Simulation file(s) to use with kanata_filesim. If not specified, defaults to
+test/sim.txt in the current working directory and
+'$XDG_CONFIG_HOME/kanata/test/sim.txt'"
+    )]
+    #[arg(short='s', long, verbatim_doc_comment)]
+    sim: Option<Vec<PathBuf>>,
 }
 
 fn log_init() {
@@ -61,6 +83,7 @@ fn log_init() {
 fn cli_init() -> Result<ValidatedArgs> {
     let args = Args::parse();
     let cfg_paths = args.cfg.unwrap_or_else(default_cfg);
+    let sim_paths = args.sim.unwrap_or_else(default_sim);
 
     log::info!("kanata_filesim v{} starting", env!("CARGO_PKG_VERSION"));
     #[cfg(all(not(feature = "interception_driver"), target_os = "windows"))]
@@ -79,8 +102,20 @@ fn cli_init() -> Result<ValidatedArgs> {
         bail!("No config files provided\nFor more info, pass the `-h` or `--help` flags.");
     }
 
+    if let Some(config_sim_file) = sim_paths.first() {
+        if !config_sim_file.exists() {
+            bail!(
+                "Could not find the simulation file ({})\nFor more info, pass the `-h` or `--help` flags.",
+                sim_paths[0].to_str().unwrap_or("?")
+            )
+        }
+    } else {
+        bail!("No simulation files provided\nFor more info, pass the `-h` or `--help` flags.");
+    }
+
     Ok(ValidatedArgs {
         paths: cfg_paths,
+        sim_paths: Some(sim_paths),
         #[cfg(feature = "tcp_server")]
         port: None,
         #[cfg(target_os = "linux")]
@@ -92,37 +127,40 @@ fn cli_init() -> Result<ValidatedArgs> {
 fn main_impl() -> Result<()> {
     log_init();
     let args = cli_init()?;
-    let mut k = Kanata::new(&args)?;
 
-    let s = std::fs::read_to_string("testing/sim.txt")?;
-    let send = false; // do not send key/mouse events, just print debug info
-    for l in s.lines() {
-        match l.split_once(':') {
-            Some((kind, val)) => match kind {
-                "tick"|"🕐" => {
-                    k.tick_ms(str::parse::<u128>(val)?,send)?;
-                }
-                "press"|"↓" => {
-                    k.handle_input_event(&KeyEvent {
-                        code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
-                        value: KeyValue::Press,
-                    })?;
-                }
-                "release"|"↑" => {
-                    k.handle_input_event(&KeyEvent {
-                        code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
-                        value: KeyValue::Release,
-                    })?;
-                }
-                "repeat"|"⟳" => {
-                    k.handle_input_event(&KeyEvent {
-                        code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
-                        value: KeyValue::Repeat,
-                    })?;
-                }
-                _ => bail!("invalid line prefix: {kind}"),
-            },
-            None => bail!("invalid line: {l}"),
+    for config_sim_file in &args.sim_paths.clone().unwrap() {
+        let mut k = Kanata::new(&args)?;
+        println!("Evaluating simulation file = {:?}", config_sim_file);
+        let s = std::fs::read_to_string(config_sim_file)?;
+        let send = false; // do not send key/mouse events, just print debug info
+        for l in s.lines() {
+            match l.split_once(':') {
+                Some((kind, val)) => match kind {
+                    "tick"|"🕐" => {
+                        k.tick_ms(str::parse::<u128>(val)?,send)?;
+                    }
+                    "press"|"↓" => {
+                        k.handle_input_event(&KeyEvent {
+                            code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
+                            value: KeyValue::Press,
+                        })?;
+                    }
+                    "release"|"↑" => {
+                        k.handle_input_event(&KeyEvent {
+                            code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
+                            value: KeyValue::Release,
+                        })?;
+                    }
+                    "repeat"|"⟳" => {
+                        k.handle_input_event(&KeyEvent {
+                            code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
+                            value: KeyValue::Repeat,
+                        })?;
+                    }
+                    _ => bail!("invalid line prefix: {kind}"),
+                },
+                None => bail!("invalid line: {l}"),
+            }
         }
     }
 

--- a/src/filesim.rs
+++ b/src/filesim.rs
@@ -40,11 +40,12 @@ fn main_impl() -> Result<()> {
     let mut k = Kanata::new(&args)?;
 
     let s = std::fs::read_to_string("testing/sim.txt")?;
+    let send = false; // do not send key/mouse events, just print debug info
     for l in s.lines() {
         match l.split_once(':') {
             Some((kind, val)) => match kind {
                 "tick" => {
-                    k.tick_ms(str::parse::<u128>(val)?)?;
+                    k.tick_ms(str::parse::<u128>(val)?,send)?;
                 }
                 "press" => {
                     k.handle_input_event(&KeyEvent {

--- a/src/filesim.rs
+++ b/src/filesim.rs
@@ -59,7 +59,7 @@ test/sim.txt in the current working directory and
 test/sim.txt in the current working directory and
 '$XDG_CONFIG_HOME/kanata/test/sim.txt'"
     )]
-    #[arg(short='s', long, verbatim_doc_comment)]
+    #[arg(short = 's', long, verbatim_doc_comment)]
     sim: Option<Vec<PathBuf>>,
 }
 
@@ -77,7 +77,6 @@ fn log_init() {
     )])
     .expect("logger can init");
 }
-
 
 /// Parse CLI arguments
 fn cli_init() -> Result<ValidatedArgs> {
@@ -137,24 +136,27 @@ fn main_impl() -> Result<()> {
             for pair in l.split_whitespace() {
                 match pair.split_once(':') {
                     Some((kind, val)) => match kind {
-                        "tick"|"🕐" => {
-                            k.tick_ms(str::parse::<u128>(val)?,send)?;
+                        "tick" | "🕐" => {
+                            k.tick_ms(str::parse::<u128>(val)?, send)?;
                         }
-                        "press"|"↓" => {
+                        "press" | "↓" => {
                             k.handle_input_event(&KeyEvent {
-                                code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
+                                code: str_to_oscode(val)
+                                    .ok_or_else(|| anyhow!("unknown key: {val}"))?,
                                 value: KeyValue::Press,
                             })?;
                         }
-                        "release"|"↑" => {
+                        "release" | "↑" => {
                             k.handle_input_event(&KeyEvent {
-                                code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
+                                code: str_to_oscode(val)
+                                    .ok_or_else(|| anyhow!("unknown key: {val}"))?,
                                 value: KeyValue::Release,
                             })?;
                         }
-                        "repeat"|"⟳" => {
+                        "repeat" | "⟳" => {
                             k.handle_input_event(&KeyEvent {
-                                code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
+                                code: str_to_oscode(val)
+                                    .ok_or_else(|| anyhow!("unknown key: {val}"))?,
                                 value: KeyValue::Repeat,
                             })?;
                         }

--- a/src/filesim.rs
+++ b/src/filesim.rs
@@ -44,22 +44,22 @@ fn main_impl() -> Result<()> {
     for l in s.lines() {
         match l.split_once(':') {
             Some((kind, val)) => match kind {
-                "tick" => {
+                "tick"|"🕐" => {
                     k.tick_ms(str::parse::<u128>(val)?,send)?;
                 }
-                "press" => {
+                "press"|"↓" => {
                     k.handle_input_event(&KeyEvent {
                         code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
                         value: KeyValue::Press,
                     })?;
                 }
-                "release" => {
+                "release"|"↑" => {
                     k.handle_input_event(&KeyEvent {
                         code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
                         value: KeyValue::Release,
                     })?;
                 }
-                "repeat" => {
+                "repeat"|"⟳" => {
                     k.handle_input_event(&KeyEvent {
                         code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
                         value: KeyValue::Repeat,

--- a/src/filesim.rs
+++ b/src/filesim.rs
@@ -134,32 +134,34 @@ fn main_impl() -> Result<()> {
         let s = std::fs::read_to_string(config_sim_file)?;
         let send = false; // do not send key/mouse events, just print debug info
         for l in s.lines() {
-            match l.split_once(':') {
-                Some((kind, val)) => match kind {
-                    "tick"|"🕐" => {
-                        k.tick_ms(str::parse::<u128>(val)?,send)?;
-                    }
-                    "press"|"↓" => {
-                        k.handle_input_event(&KeyEvent {
-                            code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
-                            value: KeyValue::Press,
-                        })?;
-                    }
-                    "release"|"↑" => {
-                        k.handle_input_event(&KeyEvent {
-                            code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
-                            value: KeyValue::Release,
-                        })?;
-                    }
-                    "repeat"|"⟳" => {
-                        k.handle_input_event(&KeyEvent {
-                            code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
-                            value: KeyValue::Repeat,
-                        })?;
-                    }
-                    _ => bail!("invalid line prefix: {kind}"),
-                },
-                None => bail!("invalid line: {l}"),
+            for pair in l.split_whitespace() {
+                match pair.split_once(':') {
+                    Some((kind, val)) => match kind {
+                        "tick"|"🕐" => {
+                            k.tick_ms(str::parse::<u128>(val)?,send)?;
+                        }
+                        "press"|"↓" => {
+                            k.handle_input_event(&KeyEvent {
+                                code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
+                                value: KeyValue::Press,
+                            })?;
+                        }
+                        "release"|"↑" => {
+                            k.handle_input_event(&KeyEvent {
+                                code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
+                                value: KeyValue::Release,
+                            })?;
+                        }
+                        "repeat"|"⟳" => {
+                            k.handle_input_event(&KeyEvent {
+                                code: str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?,
+                                value: KeyValue::Repeat,
+                            })?;
+                        }
+                        _ => bail!("invalid pair prefix: {kind}"),
+                    },
+                    None => bail!("invalid pair: {l}"),
+                }
             }
         }
     }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1213,7 +1213,9 @@ impl Kanata {
                                         if send {
                                             match key_action {
                                                 KeyAction::Press => self.kbd_out.press_key(osc)?,
-                                                KeyAction::Release => self.kbd_out.release_key(osc)?,
+                                                KeyAction::Release => {
+                                                    self.kbd_out.release_key(osc)?
+                                                }
                                             }
                                         }
                                     }
@@ -1234,7 +1236,9 @@ impl Kanata {
                         CustomAction::Delay(delay) => {
                             log::debug!("on-press: sleeping for {delay} ms");
                             if send {
-                                std::thread::sleep(std::time::Duration::from_millis((*delay).into()));
+                                std::thread::sleep(std::time::Duration::from_millis(
+                                    (*delay).into(),
+                                ));
                             }
                         }
                         CustomAction::SequenceCancel => {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -410,7 +410,7 @@ impl Kanata {
     }
 
     /// Update keyberon layout state for press/release, handle repeat separately
-    fn handle_input_event(&mut self, event: &KeyEvent) -> Result<()> {
+    pub fn handle_input_event(&mut self, event: &KeyEvent) -> Result<()> {
         log::debug!("process recv ev {event:?}");
         let evc: u16 = event.code.into();
         self.ticks_since_idle = 0;
@@ -456,49 +456,21 @@ impl Kanata {
         let ms_elapsed = ns_elapsed_with_rem / NS_IN_MS;
         self.time_remainder = ns_elapsed_with_rem % NS_IN_MS;
 
-        let mut extra_ticks: u16 = 0;
-        for _ in 0..ms_elapsed {
-            self.tick_states()?;
-            if let Some(event) = tick_replay_state(
-                &mut self.dynamic_macro_replay_state,
-                self.dynamic_macro_replay_behaviour,
-            ) {
-                self.layout.bm().event(event.key_event());
-                extra_ticks = extra_ticks.saturating_add(event.delay());
-                log::debug!("dyn macro extra ticks: {extra_ticks}, ms_elapsed: {ms_elapsed}");
-            }
-        }
+        self.tick_ms(ms_elapsed)?;
 
-        if ms_elapsed > 0 {
-            for i in 0..(extra_ticks.saturating_sub(ms_elapsed as u16)) {
-                self.tick_states()?;
-                if tick_replay_state(
-                    &mut self.dynamic_macro_replay_state,
-                    self.dynamic_macro_replay_behaviour,
-                )
-                .is_some()
-                {
-                    log::error!("overshot to next event at iteration #{i}, the code is broken!");
-                    break;
-                }
-            }
+        self.last_tick = match ms_elapsed {
+            0..=10 => now,
+            // If too many ms elapsed, probably doing a tight loop of something that's quite
+            // expensive, e.g. click spamming. To avoid a growing ms_elapsed due to trying and
+            // failing to catch up, reset last_tick to the "actual now" instead the "past now"
+            // even though that means ticks will be missed - meaning there will be fewer than
+            // 1000 ticks in 1ms on average. In practice, there will already be fewer than 1000
+            // ticks in 1ms when running expensive operations, this just avoids having tens to
+            // thousands of ticks all happening as soon as the expensive operations end.
+            _ => time::Instant::now(),
+        };
 
-            self.last_tick = match ms_elapsed {
-                0..=10 => now,
-                // If too many ms elapsed, probably doing a tight loop of something that's quite
-                // expensive, e.g. click spamming. To avoid a growing ms_elapsed due to trying and
-                // failing to catch up, reset last_tick to the "actual now" instead the "past now"
-                // even though that means ticks will be missed - meaning there will be fewer than
-                // 1000 ticks in 1ms on average. In practice, there will already be fewer than 1000
-                // ticks in 1ms when running expensive operations, this just avoids having tens to
-                // thousands of ticks all happening as soon as the expensive operations end.
-                _ => time::Instant::now(),
-            };
-
-            // Handle layer change outside the loop. I don't see any practical scenario where it
-            // would make a difference, so may as well reduce the amount of processing.
-            self.check_handle_layer_change(tx);
-        }
+        self.check_handle_layer_change(tx);
 
         if self.live_reload_requested
             && ((self.prev_keys.is_empty() && self.cur_keys.is_empty())
@@ -525,6 +497,36 @@ impl Kanata {
         // end up being wrong. Prefer to do the cheaper operation, as compared to doing the min of
         // u16::MAX and ms_elapsed.
         Ok(ms_elapsed as u16)
+    }
+
+    pub fn tick_ms(&mut self, ms_elapsed: u128) -> Result<()> {
+        let mut extra_ticks: u16 = 0;
+        for _ in 0..ms_elapsed {
+            self.tick_states()?;
+            if let Some(event) = tick_replay_state(
+                &mut self.dynamic_macro_replay_state,
+                self.dynamic_macro_replay_behaviour,
+            ) {
+                self.layout.bm().event(event.key_event());
+                extra_ticks = extra_ticks.saturating_add(event.delay());
+                log::debug!("dyn macro extra ticks: {extra_ticks}, ms_elapsed: {ms_elapsed}");
+            }
+        }
+        if ms_elapsed > 0 {
+            for i in 0..(extra_ticks.saturating_sub(ms_elapsed as u16)) {
+                self.tick_states()?;
+                if tick_replay_state(
+                    &mut self.dynamic_macro_replay_state,
+                    self.dynamic_macro_replay_behaviour,
+                )
+                .is_some()
+                {
+                    log::error!("overshot to next event at iteration #{i}, the code is broken!");
+                    break;
+                }
+            }
+        }
+        Ok(())
     }
 
     fn tick_states(&mut self) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,37 @@
+use std::path::PathBuf;
+
+pub mod kanata;
+pub mod oskbd;
+pub mod tcp_server;
+
+pub use kanata::Kanata;
+pub use tcp_server::TcpServer;
+
+type CfgPath = PathBuf;
+
+pub struct ValidatedArgs {
+    pub paths: Vec<CfgPath>,
+    #[cfg(feature = "tcp_server")]
+    pub port: Option<i32>,
+    #[cfg(target_os = "linux")]
+    pub symlink_path: Option<String>,
+    pub nodelay: bool,
+}
+
+pub fn default_cfg() -> Vec<PathBuf> {
+    let mut cfgs = Vec::new();
+
+    let default = PathBuf::from("kanata.kbd");
+    if default.is_file() {
+        cfgs.push(default);
+    }
+
+    if let Some(config_dir) = dirs::config_dir() {
+        let fallback = config_dir.join("kanata").join("kanata.kbd");
+        if fallback.is_file() {
+            cfgs.push(fallback);
+        }
+    }
+
+    cfgs
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ type CfgPath = PathBuf;
 
 pub struct ValidatedArgs {
     pub paths: Vec<CfgPath>,
+    pub sim_paths: Option<Vec<CfgPath>>,
     #[cfg(feature = "tcp_server")]
     pub port: Option<i32>,
     #[cfg(target_os = "linux")]
@@ -28,6 +29,24 @@ pub fn default_cfg() -> Vec<PathBuf> {
 
     if let Some(config_dir) = dirs::config_dir() {
         let fallback = config_dir.join("kanata").join("kanata.kbd");
+        if fallback.is_file() {
+            cfgs.push(fallback);
+        }
+    }
+
+    cfgs
+}
+
+pub fn default_sim() -> Vec<PathBuf> {
+    let mut cfgs = Vec::new();
+
+    let default = PathBuf::from("test/sim.txts");
+    if default.is_file() {
+        cfgs.push(default);
+    }
+
+    if let Some(config_dir) = dirs::config_dir() {
+        let fallback = config_dir.join("kanata").join("test").join("sim.txt");
         if fallback.is_file() {
             cfgs.push(fallback);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,7 @@ fn cli_init() -> Result<ValidatedArgs> {
 
     Ok(ValidatedArgs {
         paths: cfg_paths,
+        sim_paths: None,
         #[cfg(feature = "tcp_server")]
         port: args.port,
         #[cfg(target_os = "linux")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,49 +1,14 @@
 use anyhow::{bail, Result};
 use clap::Parser;
 use kanata_parser::cfg;
+use kanata_state_machine::*;
 use log::info;
 use simplelog::*;
 
 use std::path::PathBuf;
 
-mod kanata;
-mod oskbd;
-mod tcp_server;
-
-use kanata::Kanata;
-use tcp_server::TcpServer;
-
 #[cfg(test)]
 mod tests;
-
-type CfgPath = PathBuf;
-
-pub struct ValidatedArgs {
-    paths: Vec<CfgPath>,
-    #[cfg(feature = "tcp_server")]
-    port: Option<i32>,
-    #[cfg(target_os = "linux")]
-    symlink_path: Option<String>,
-    nodelay: bool,
-}
-
-fn default_cfg() -> Vec<PathBuf> {
-    let mut cfgs = Vec::new();
-
-    let default = PathBuf::from("kanata.kbd");
-    if default.is_file() {
-        cfgs.push(default);
-    }
-
-    if let Some(config_dir) = dirs::config_dir() {
-        let fallback = config_dir.join("kanata").join("kanata.kbd");
-        if fallback.is_file() {
-            cfgs.push(fallback);
-        }
-    }
-
-    cfgs
-}
 
 #[derive(Parser, Debug)]
 #[command(author, version, verbatim_doc_comment)]


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

POC for #816 based on https://github.com/jtroo/kanata/pull/825, but

- adding support for custom config and
- custom simulation files
- also not sending real output, but just debug-printing what said output would be if a real user were pressing the keys
- and allowing `↑` instead of `release`
- and allows short space-separated sequences


instead of this
```
↓:j
🕐:100
↓:l
🕐:5000
↓:1
🕐:50
↑:1
🕐:50
↓:1
🕐:50
↑:1
🕐:50
↑:j
🕐:50
↑:l
🕐:50
```

you'd be able to input
`↓:j 🕐:100 ↓:l 🕐:5000 ↓:1 🕐:50 ↑:1 🕐:50 ↓:1 🕐:50 ↑:1 🕐:50 ↑:j 🕐:50 ↑:l 🕐:50`


I think ideally you should be able to save output in a similar file and compare it on next runs - this would make regression testing easier, but also regular testing as you'd have cleaner output-only view without `2024-11-11T11:11:11.1111111+11:11 [DEBUG] (1) kanata_state_machine::kanata:` taking most of the space :), so something like 
```
  ↓RShift ↓RAlt ↓Kb1  ↑Kb1 ↓Kb1 ↑Kb1 ↑RShift ↑RAlt`
🕐1000    0     4100  50   50   50   50      0
```
(this assumes j/l are modtaps that trigger after 1second)

## Checklist

- Add documentation to docs/config.adoc
  - [ ] tbd
- Add example and basic docs to cfg_samples/kanata.kbd
  - n/a
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes manual testing
