### PR TITLE
better output print for simulated events

### DIFF
--- a/src/oskbd/simulated.rs
+++ b/src/oskbd/simulated.rs
@@ -31,7 +31,7 @@ impl KbdOut {
     }
 
     pub fn write(&mut self, event: InputEvent) -> Result<(), io::Error> {
-        println!("out:{event:?}");
+        println!("out:{event}");
         Ok(())
     }
 

--- a/src/oskbd/windows/llhook.rs
+++ b/src/oskbd/windows/llhook.rs
@@ -3,6 +3,7 @@
 // This file is taken from kbremap with minor modifications.
 // https://github.com/timokroeger/kbremap
 
+use core::fmt;
 use std::cell::Cell;
 use std::io;
 use std::{mem, ptr};
@@ -14,6 +15,7 @@ use winapi::um::winuser::*;
 
 use crate::kanata::CalculatedMouseMove;
 use crate::oskbd::{KeyEvent, KeyValue};
+use kanata_keyberon::key_code::KeyCode;
 use kanata_parser::custom_action::*;
 use kanata_parser::keys::*;
 
@@ -71,6 +73,14 @@ pub struct InputEvent {
 
     /// Key was released
     pub up: bool,
+}
+
+impl fmt::Display for InputEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let direction = if self.up { "↑" } else { "↓" };
+        let key_name = KeyCode::from(OsCode::from(self.code));
+        write!(f, "{}{:?}", direction, key_name)
+    }
 }
 
 impl InputEvent {


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Added a better formatted output for simulated events 

- `new` out:↑RAlt 
- `old` out:InputEvent { code: 165, up: true }


## Checklist

- Add documentation to docs/config.adoc
  -  N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  -  N/A
- Update error messages
  -  N/A
- Added tests, or did manual testing
  - manual
