### PR TITLE
feat(sym): add a symbol action for shorter unicode definition

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -548,7 +548,7 @@ will do nothing as opposed to typing a letter.
 === Unicode
 <<table-of-contents,Back to ToC>>
 
-The `+unicode+` action accepts a single unicode character. The character will
+The `+unicode+` (or `+🔣+`) action accepts a single unicode character. The character will
 not be repeatedly typed if you hold the key down.
 
 You may use a unicode character as an alias if desired.
@@ -563,10 +563,11 @@ NOTE: If using Linux, make sure to look at the
 ----
 (defalias
   sml (unicode 😀)
+  😀 (🔣 😀)
   🙁 (unicode 🙁)
 )
 (deflayer has-happy-sad
-  @sml @🙁 a s d f
+  @sml @🙁 @😀 s d f
 )
 ----
 

--- a/parser/src/cfg/list_actions.rs
+++ b/parser/src/cfg/list_actions.rs
@@ -18,6 +18,7 @@ pub const MACRO_REPEAT: &str = "macro-repeat";
 pub const MACRO_RELEASE_CANCEL: &str = "macro-release-cancel";
 pub const MACRO_REPEAT_RELEASE_CANCEL: &str = "macro-repeat-release-cancel";
 pub const UNICODE: &str = "unicode";
+pub const SYM: &str = "🔣";
 pub const ONE_SHOT: &str = "one-shot";
 pub const ONE_SHOT_PRESS: &str = "one-shot-press";
 pub const ONE_SHOT_RELEASE: &str = "one-shot-release";
@@ -81,6 +82,7 @@ pub fn is_list_action(ac: &str) -> bool {
         MACRO_RELEASE_CANCEL,
         MACRO_REPEAT_RELEASE_CANCEL,
         UNICODE,
+        SYM,
         ONE_SHOT,
         ONE_SHOT_PRESS,
         ONE_SHOT_RELEASE,

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1298,6 +1298,7 @@ fn parse_action_list(ac: &[SExpr], s: &ParsedState) -> Result<&'static KanataAct
         MACRO_RELEASE_CANCEL => parse_macro_release_cancel(&ac[1..], s, RepeatMacro::No),
         MACRO_REPEAT_RELEASE_CANCEL => parse_macro_release_cancel(&ac[1..], s, RepeatMacro::Yes),
         UNICODE => parse_unicode(&ac[1..], s),
+        SYM => parse_unicode(&ac[1..], s),
         ONE_SHOT | ONE_SHOT_PRESS => parse_one_shot(&ac[1..], s, OneShotEndConfig::EndOnFirstPress),
         ONE_SHOT_RELEASE => parse_one_shot(&ac[1..], s, OneShotEndConfig::EndOnFirstRelease),
         ONE_SHOT_PRESS_PCANCEL => {


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Allow shorter definition of unicode symbols
- unicode 🙁
- 🔣 😀


## Checklist

- Add documentation to docs/config.adoc
  - [x ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - think that for such a tiny change docs are fine, they have an example
- Update error messages
  -  N/A
- Added tests, or did manual testing
  - manual
