### PR TITLE
feat(parse) allow direct use of 1-"char" unicode symbols in layers

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -548,10 +548,12 @@ will do nothing as opposed to typing a letter.
 === Unicode
 <<table-of-contents,Back to ToC>>
 
-The `+unicode+` (or `+🔣+`) action accepts a single unicode character. The character will
-not be repeatedly typed if you hold the key down.
+The `+unicode+` (or `+🔣+`) action accepts a single unicode character (but not
+a composed character, so 🤲, but not 🤲🏿). The character will not be repeatedly
+typed if you hold the key down.
 
-You may use a unicode character as an alias if desired.
+You may use a unicode character as an alias if desired or in its simplified form `+🔣😀+`
+(vs the usual `+(🔣 😀)+`).
 
 NOTE: The unicode action may not be correctly accepted by the active
 application.
@@ -567,7 +569,7 @@ NOTE: If using Linux, make sure to look at the
   🙁 (unicode 🙁)
 )
 (deflayer has-happy-sad
-  @sml @🙁 @😀 s d f
+  @sml @🙁 @😀 🔣😀 d f
 )
 ----
 

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1244,7 +1244,12 @@ fn parse_action_atom(ac_span: &Spanned<String>, s: &ParsedState) -> Result<&'sta
             ),
         };
     }
-
+    if let Some(unisym) = ac.strip_prefix('🔣') {
+        // TODO: when unicode accepts multiple chars, change this to feed the whole string, not just the first char
+        return Ok(s.a.sref(Action::Custom(s.a.sref(s.a.sref_slice(
+            CustomAction::Unicode(unisym.chars().next().expect("1 char")),
+        )))));
+    }
     // Parse a sequence like `C-S-v` or `C-A-del`
     let (mut keys, unparsed_str) = parse_mod_prefix(ac)?;
     keys.push(
@@ -1817,7 +1822,7 @@ pub fn parse_mod_prefix(mods: &str) -> Result<(Vec<KeyCode>, &str)> {
 }
 
 fn parse_unicode(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
-    const ERR_STR: &str = "unicode expects exactly one unicode character as an argument";
+    const ERR_STR: &str = "unicode expects exactly one (not combos looking like one) unicode character as an argument";
     if ac_params.len() != 1 {
         bail!(ERR_STR)
     }


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Use 🔣✗ to print ✗ without having to add an alias and reference it via `@✗` or with `(🔣 ✗)`

Also clarifies the limitation that composed unicode chars (that still look like 1) are not accepted


## Checklist

- Add documentation to docs/config.adoc
  - [+] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A, though docs have an example
- Update error messages
  - N/A
- Added tests, or did manual testing
  - [x] manual

partically fixes #838