### PR TITLE
feat(parser) add alternative symbols for transparent and empty

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -514,16 +514,17 @@ key in a `+deflayer+`. The behaviour depends if `+_+` is on a base layer or a
 while-held layer. When `+_+` is pressed on the active base layer, the key will
 default to the corresponding `defsrc` key. If `+_+` is pressed on the active
 while-held layer, the base layer's behaviour will activate.
+(alternatively you can use `+‗+` `+≝+`)
 
 .Example:
 [source]
 ----
 (defsrc
-  a b c
+  a b c d
 )
 
 (deflayer remap-only-c-to-d
-  _ _ d
+  _ ‗ d ≝
 )
 ----
 
@@ -535,12 +536,13 @@ You may use the action `+XX+` as a "no operation" key, meaning pressing the key
 will do nothing. This might be desirable in place of a transparent key on a
 layer that is not fully mapped so that a key that is intentionally not mapped
 will do nothing as opposed to typing a letter.
+(alternatively you can use `+✗+` `+‿+` `+∅+`)
 
 .Example:
 [source]
 ----
 (deflayer contains-no-op
-  XX a s d f
+  XX ‿ ✗ d f
 )
 ----
 

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -536,13 +536,13 @@ You may use the action `+XX+` as a "no operation" key, meaning pressing the key
 will do nothing. This might be desirable in place of a transparent key on a
 layer that is not fully mapped so that a key that is intentionally not mapped
 will do nothing as opposed to typing a letter.
-(alternatively you can use `+✗+` `+‿+` `+∅+`)
+(alternatively you can use `+✗+` `+∅+`)
 
 .Example:
 [source]
 ----
 (deflayer contains-no-op
-  XX ‿ ✗ d f
+  XX ✗ d f
 )
 ----
 

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1112,7 +1112,7 @@ fn parse_action_atom(ac_span: &Spanned<String>, s: &ParsedState) -> Result<&'sta
     }
     match ac {
         "_" | "‗" | "≝" => return Ok(s.a.sref(Action::Trans)),
-        "XX" | "✗" | "∅" | "‿" => return Ok(s.a.sref(Action::NoOp)),
+        "XX" | "✗" | "∅" => return Ok(s.a.sref(Action::NoOp)),
         "lrld" => {
             return Ok(s.a.sref(Action::Custom(
                 s.a.sref(s.a.sref_slice(CustomAction::LiveReload)),

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1111,8 +1111,8 @@ fn parse_action_atom(ac_span: &Spanned<String>, s: &ParsedState) -> Result<&'sta
         );
     }
     match ac {
-        "_" => return Ok(s.a.sref(Action::Trans)),
-        "XX" => return Ok(s.a.sref(Action::NoOp)),
+        "_" | "‗" | "≝" => return Ok(s.a.sref(Action::Trans)),
+        "XX" | "✗" | "∅" | "‿" => return Ok(s.a.sref(Action::NoOp)),
         "lrld" => {
             return Ok(s.a.sref(Action::Custom(
                 s.a.sref(s.a.sref_slice(CustomAction::LiveReload)),


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

- Use a slightly more meaningful symbol for transparent config `‗` or `≝`
- Use 1 symbol instead of 2 for noop `✗` or `‿` or `∅`

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] no, docs have an example
- Update error messages
  - N/A
- Added tests, or did manual testing
  - [x] manual
