### PR TITLE
feat: add action that sends any message to clients (#854)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
 name = "kanata-tcp-protocol"
 version = "0.160.1"
 dependencies = [
+ "kanata-parser",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,7 @@ dependencies = [
  "radix_trie",
  "rustc-hash",
  "sd-notify",
+ "serde_json",
  "signal-hook",
  "simplelog",
  "winapi",
@@ -518,7 +519,6 @@ dependencies = [
 name = "kanata-tcp-protocol"
 version = "0.160.1"
 dependencies = [
- "kanata-parser",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ parking_lot = "0.12"
 radix_trie = "0.2"
 rustc-hash = "1.1.0"
 simplelog = "0.12.0"
+serde_json = { version = "1", features = ["alloc"], default_features = false, optional = true }
 
 # kanata-keyberon = "0.160.1"
 # kanata-parser = "0.160.1"
@@ -80,7 +81,7 @@ kanata-interception = { version = "0.2.0", optional = true }
 [features]
 default = ["tcp_server"]
 perf_logging = []
-tcp_server = []
+tcp_server = ["serde_json"]
 win_sendinput_send_scancodes = []
 cmd = ["kanata-parser/cmd"]
 interception_driver = ["kanata-interception", "kanata-parser/interception_driver"]

--- a/parser/src/cfg/list_actions.rs
+++ b/parser/src/cfg/list_actions.rs
@@ -52,6 +52,7 @@ pub const DYNAMIC_MACRO_RECORD: &str = "dynamic-macro-record";
 pub const DYNAMIC_MACRO_PLAY: &str = "dynamic-macro-play";
 pub const ARBITRARY_CODE: &str = "arbitrary-code";
 pub const CMD: &str = "cmd";
+pub const PUSH_MESSAGE: &str = "push-msg";
 pub const CMD_OUTPUT_KEYS: &str = "cmd-output-keys";
 pub const FORK: &str = "fork";
 pub const CAPS_WORD: &str = "caps-word";
@@ -117,6 +118,7 @@ pub fn is_list_action(ac: &str) -> bool {
         ARBITRARY_CODE,
         CMD,
         CMD_OUTPUT_KEYS,
+        PUSH_MESSAGE,
         FORK,
         CAPS_WORD,
         CAPS_WORD_CUSTOM,

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -48,7 +48,7 @@ pub use key_override::*;
 mod custom_tap_hold;
 use custom_tap_hold::*;
 
-mod list_actions;
+pub mod list_actions;
 use list_actions::*;
 
 mod defcfg;
@@ -1843,9 +1843,6 @@ fn test_collect_strings() {
 }
 
 fn parse_push_message(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
-    //if !s.is_tcp_enabled {
-    //    bail!("using {PUSH_MESSAGE} but TCP server is not enabled!");
-    //}
     if ac_params.is_empty() {
         bail!(
              "{PUSH_MESSAGE} expects at least one item, an item can be a list or an atom, found 0, none"

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1849,9 +1849,7 @@ fn parse_push_message(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static K
         );
     }
     let message = to_simple_expr(ac_params, s);
-    Ok(s.a.sref(Action::Custom(
-        s.a.sref(s.a.sref_slice(CustomAction::PushMessage(message))),
-    )))
+    custom(CustomAction::PushMessage(message), &s.a)
 }
 
 fn to_simple_expr(params: &[SExpr], s: &ParsedState) -> Vec<SimpleSExpr> {

--- a/parser/src/custom_action.rs
+++ b/parser/src/custom_action.rs
@@ -6,12 +6,13 @@
 use anyhow::{anyhow, Result};
 use kanata_keyberon::key_code::KeyCode;
 
-use crate::keys::OsCode;
+use crate::{cfg::SimpleSExpr, keys::OsCode};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CustomAction {
     Cmd(Vec<String>),
     CmdOutputKeys(Vec<String>),
+    PushMessage(Vec<SimpleSExpr>),
     Unicode(char),
     Mouse(Btn),
     MouseTap(Btn),

--- a/src/filesim.rs
+++ b/src/filesim.rs
@@ -156,7 +156,7 @@ fn main_impl() -> Result<()> {
                 match pair.split_once(':') {
                     Some((kind, val)) => match kind {
                         "tick" | "🕐" | "t" => {
-                            k.tick_ms(str::parse::<u128>(val)?)?;
+                            k.tick_ms(str::parse::<u128>(val)?, &None)?;
                         }
                         "press" | "↓" | "d" | "down" => {
                             k.handle_input_event(&KeyEvent {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -14,13 +14,13 @@ use std::sync::Arc;
 use std::time;
 
 use crate::oskbd::{KeyEvent, *};
+#[cfg(feature = "tcp_server")]
+use crate::tcp_server::simple_sexpr_to_json_array;
 use crate::ValidatedArgs;
 use kanata_parser::cfg;
 use kanata_parser::cfg::*;
 use kanata_parser::custom_action::*;
 use kanata_parser::keys::*;
-#[cfg(feature = "tcp_server")]
-use kanata_tcp_protocol::simple_sexpr_to_json_array;
 use kanata_tcp_protocol::ServerMessage;
 
 mod dynamic_macro;

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -19,7 +19,9 @@ use kanata_parser::cfg;
 use kanata_parser::cfg::*;
 use kanata_parser::custom_action::*;
 use kanata_parser::keys::*;
-use kanata_tcp_protocol::{simple_sexpr_to_json_array, ServerMessage};
+#[cfg(feature = "tcp_server")]
+use kanata_tcp_protocol::simple_sexpr_to_json_array;
+use kanata_tcp_protocol::ServerMessage;
 
 mod dynamic_macro;
 use dynamic_macro::*;
@@ -1181,12 +1183,12 @@ impl Kanata {
                                 }
                             }
                         }
-                        CustomAction::PushMessage(message) => {
+                        CustomAction::PushMessage(_message) => {
                             log::debug!("Action push-msg message");
                             #[cfg(feature = "tcp_server")]
                             if let Some(tx) = _tx {
                                 match tx.try_send(ServerMessage::MessagePush {
-                                    message: simple_sexpr_to_json_array(message),
+                                    message: simple_sexpr_to_json_array(_message),
                                 }) {
                                     Ok(_) => {}
                                     Err(error) => {

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 #[cfg(feature = "tcp_server")]
 type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 #[cfg(feature = "tcp_server")]
+use kanata_parser::cfg::SimpleSExpr;
+#[cfg(feature = "tcp_server")]
 use std::io::{Read, Write};
 #[cfg(feature = "tcp_server")]
 use std::net::{TcpListener, TcpStream};
@@ -259,4 +261,18 @@ impl TcpServer {
 
     #[cfg(not(feature = "tcp_server"))]
     pub fn start(&mut self, _kanata: Arc<Mutex<Kanata>>) {}
+}
+
+#[cfg(feature = "tcp_server")]
+pub fn simple_sexpr_to_json_array(exprs: &[SimpleSExpr]) -> serde_json::Value {
+    let mut result = Vec::new();
+
+    for expr in exprs.iter() {
+        match expr {
+            SimpleSExpr::Atom(s) => result.push(serde_json::Value::String(s.clone())),
+            SimpleSExpr::List(list) => result.push(simple_sexpr_to_json_array(list)),
+        }
+    }
+
+    serde_json::Value::Array(result)
 }

--- a/tcp_protocol/Cargo.toml
+++ b/tcp_protocol/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 serde = { version = "1", features = ["alloc", "derive"], default_features = false }
 serde_derive = "1.0"
 serde_json = { version = "1", features = ["alloc"], default_features = false }
+
+kanata-parser = { path = "../parser" }

--- a/tcp_protocol/Cargo.toml
+++ b/tcp_protocol/Cargo.toml
@@ -7,5 +7,3 @@ edition = "2021"
 serde = { version = "1", features = ["alloc", "derive"], default_features = false }
 serde_derive = "1.0"
 serde_json = { version = "1", features = ["alloc"], default_features = false }
-
-kanata-parser = { path = "../parser" }

--- a/tcp_protocol/src/lib.rs
+++ b/tcp_protocol/src/lib.rs
@@ -55,7 +55,7 @@ impl FromStr for ClientMessage {
     }
 }
 
-pub fn simple_sexpr_to_json_array(exprs: &Vec<SimpleSExpr>) -> serde_json::Value {
+pub fn simple_sexpr_to_json_array(exprs: &[SimpleSExpr]) -> serde_json::Value {
     let mut result = Vec::new();
 
     for expr in exprs.iter() {

--- a/tcp_protocol/src/lib.rs
+++ b/tcp_protocol/src/lib.rs
@@ -1,4 +1,3 @@
-use kanata_parser::cfg::SimpleSExpr;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -53,17 +52,4 @@ impl FromStr for ClientMessage {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
     }
-}
-
-pub fn simple_sexpr_to_json_array(exprs: &[SimpleSExpr]) -> serde_json::Value {
-    let mut result = Vec::new();
-
-    for expr in exprs.iter() {
-        match expr {
-            SimpleSExpr::Atom(s) => result.push(serde_json::Value::String(s.clone())),
-            SimpleSExpr::List(list) => result.push(simple_sexpr_to_json_array(list)),
-        }
-    }
-
-    serde_json::Value::Array(result)
 }

--- a/tcp_protocol/src/lib.rs
+++ b/tcp_protocol/src/lib.rs
@@ -1,3 +1,4 @@
+use kanata_parser::cfg::SimpleSExpr;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -8,6 +9,7 @@ pub enum ServerMessage {
     CurrentLayerInfo { name: String, cfg_text: String },
     ConfigFileReload { new: String },
     CurrentLayerName { name: String },
+    MessagePush { message: serde_json::Value },
     Error { msg: String },
 }
 
@@ -51,4 +53,17 @@ impl FromStr for ClientMessage {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
     }
+}
+
+pub fn simple_sexpr_to_json_array(exprs: &Vec<SimpleSExpr>) -> serde_json::Value {
+    let mut result = Vec::new();
+
+    for expr in exprs.iter() {
+        match expr {
+            SimpleSExpr::Atom(s) => result.push(serde_json::Value::String(s.clone())),
+            SimpleSExpr::List(list) => result.push(simple_sexpr_to_json_array(list)),
+        }
+    }
+
+    serde_json::Value::Array(result)
 }


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
add an action that sends _any arbitrary_ message to TCP clients

  may resolve #854 

~~- ⚠️ adds serde dependency to parser/Cargo.toml~~

https://github.com/jtroo/kanata/blob/066740939207fa39a0844ccab97173e9e11749fd/parser/Cargo.toml#L23-L25

~~- ⚠️ removes `Hash` derive attribute from `CustomAction` ~~
~~   - (i'm not experienced enough in Rust to implement Hash for CustomAction and keep the Hash attribute)~~

https://github.com/jtroo/kanata/blob/066740939207fa39a0844ccab97173e9e11749fd/parser/src/custom_action.rs#L11-L14


~~I hope you do not mind adding serde as a dependency to the parser, since almost every rust projects under the sun depends on serde.~~

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
    - manual testing 