### PR TITLE
feat: add `deflayer-custom-map`

### DIFF
--- a/cfg_samples/deflayer-custom-map.kbd
+++ b/cfg_samples/deflayer-custom-map.kbd
@@ -1,0 +1,26 @@
+;; A configuration showcasing deflayer-custom-map.
+;;
+;; The process-unmapped-keys defcfg item is not used
+;; and the lctl and ralt keys are unmapped
+;; because mapping them can cause problems on Windows
+;; with non-US layouts.
+
+(defsrc
+  grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
+  tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
+  caps a    s    d    f    g    h    j    k    l    ;    '    ret
+  lsft z    x    c    v    b    n    m    ,    .    /    rsft
+       lmet lalt           spc                 rmet rctl
+)
+
+(deflayer-custom-map (base)
+  caps : (tap-hold 200 200 (caps-word 2000) lctl)
+  spc  : (tap-hold 200 200 spc (layer-while-held nav))
+)
+
+(deflayer-custom-map (nav)
+  i : up
+  j : left
+  k : down
+  l : right
+)

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -319,6 +319,15 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   lctl lmet lalt           spc           @ralt rmet @rcl
 )
 
+;; This is an alternative to deflayer and does not rely on defsrc.
+;; It has the advantage of simpler config if only remapping a few keys.
+;; You might still prefer the standard deflayer for its visual printing in
+;; the log as you are learning a new configuration.
+(deflayer-custom-map (custom-map-example)
+  caps : esc
+  esc  : caps
+)
+
 ;; defvar can be used to declare commonly-used values
 (defvar
   tap-timeout   100

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -150,17 +150,18 @@ The very first item must be the layer name,
 but the layer name must be in parentheses unlike before.
 The reason for this is for better error messages when forgetting the name.
 After the layer name, the layer is configured via triples of items:
-- input key
-- map string
-- output action
 
-An example, complete and minimal config that maps Caps Lock to Escape is:
+* input key
+* map string
+* output action
+
+An example complete configuration that maps Caps Lock to Escape is:
 
 [source]
 ----
 ;; defsrc is still necessary
 (defsrc spc)
-(deflayer-custom-map base-layer
+(deflayer-custom-map (base-layer)
   caps : esc
 )
 ----

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -167,9 +167,20 @@ An example complete configuration that maps Caps Lock to Escape is:
 ----
 
 The input key takes the same role as `defsrc` keys.
-The map string is an arbitrary string of your liking;
-it exists for ease of visual differentiation.
-The output action takes the role that all items in the normal `deflayer` have.
+The output action takes the role that items in the normal `deflayer` have.
+
+The map string can be any of the following strings, to your liking:
+
+[source]
+----
+=
+:
+->
+>>
+maps-to
+→
+🞂
+----
 
 [[review-of-required-configuration-entries]]
 === Review of required configuration entries

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -142,6 +142,34 @@ would be:
 )
 ----
 
+==== deflayer-custom-map
+
+An alternative method for defining a layer exists: `deflayer-custom-map`.
+This method does not rely on `defsrc`.
+The very first item must be the layer name,
+but the layer name must be in parentheses unlike before.
+The reason for this is for better error messages when forgetting the name.
+After the layer name, the layer is configured via triples of items:
+- input key
+- map string
+- output action
+
+An example, complete and minimal config that maps Caps Lock to Escape is:
+
+[source]
+----
+;; defsrc is still necessary
+(defsrc spc)
+(deflayer-custom-map base-layer
+  caps : esc
+)
+----
+
+The input key takes the same role as `defsrc` keys.
+The map string is an arbitrary string of your liking;
+it exists for ease of visual differentiation.
+The output action takes the role that all items in the normal `deflayer` have.
+
 [[review-of-required-configuration-entries]]
 === Review of required configuration entries
 <<table-of-contents,Back to ToC>>

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -401,7 +401,7 @@ fn expand_includes(
 }
 
 const DEFLAYER: &str = "deflayer";
-const DEFLAYER_MAPPED: &str = "deflayer-mapped";
+const DEFLAYER_MAPPED: &str = "deflayer-custom-map";
 
 #[allow(clippy::type_complexity)] // return type is not pub
 pub fn parse_cfg_raw_string(

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -494,7 +494,7 @@ pub fn parse_cfg_raw_string(
     }
     let (mut mapped_keys, mapping_order) = parse_defsrc(src_expr, &cfg)?;
 
-    let deflayer_names =[DEFLAYER, DEFLAYER_MAPPED];
+    let deflayer_names = [DEFLAYER, DEFLAYER_MAPPED];
     let deflayer_spanned_filter = |exprs: &&Spanned<Vec<SExpr>>| -> bool {
         if exprs.t.is_empty() {
             return false;
@@ -894,7 +894,7 @@ fn parse_layer_indexes(exprs: &[SpannedLayerExprs], expected_len: usize) -> Resu
         let (mut subexprs, expr, do_element_count_check) = match expr {
             SpannedLayerExprs::DefsrcMapping(e) => {
                 (check_first_expr(e.t.iter(), DEFLAYER)?, e, true)
-            },
+            }
             SpannedLayerExprs::ManualMapping(e) => {
                 (check_first_expr(e.t.iter(), DEFLAYER_MAPPED)?, e, false)
             }
@@ -944,7 +944,7 @@ fn parse_layer_indexes(exprs: &[SpannedLayerExprs], expected_len: usize) -> Resu
                     layer_name,
                     num_actions,
                     expected_len
-                    )
+                )
             }
         }
         layer_indexes.insert(layer_name, i);
@@ -2597,7 +2597,7 @@ fn parse_layers(s: &mut ParsedState, mapped_keys: &mut MappedKeys) -> Result<Int
     let mut layers_cfg = new_layers(s.layer_exprs.len());
     for (layer_level, layer) in s.layer_exprs.iter().enumerate() {
         match layer {
-        // The skip is done to skip the the `deflayer` and layer name tokens.
+            // The skip is done to skip the the `deflayer` and layer name tokens.
             LayerExprs::DefsrcMapping(layer) => {
                 // Parse actions in the layer and place them appropriately according
                 // to defsrc mapping order.
@@ -2615,7 +2615,8 @@ fn parse_layers(s: &mut ParsedState, mapped_keys: &mut MappedKeys) -> Result<Int
                     let input = &triplet[0];
                     let mapstr = &triplet[1];
                     let action = &triplet[2];
-                    let input_key = input.atom(s.vars())
+                    let input_key = input
+                        .atom(s.vars())
                         .and_then(str_to_oscode)
                         .ok_or_else(|| anyhow_expr!(input, "input must be a key name"))?;
                     mapped_keys.insert(input_key);
@@ -2631,14 +2632,17 @@ fn parse_layers(s: &mut ParsedState, mapped_keys: &mut MappedKeys) -> Result<Int
                 }
                 let rem = triplets.remainder();
                 match rem.len() {
-                    0 => {},
+                    0 => {}
                     1 => {
-                        bail_expr!(&rem[0], "an input must be followed by a mapping string and an action");
+                        bail_expr!(
+                            &rem[0],
+                            "an input must be followed by a mapping string and an action"
+                        );
                     }
                     2 => {
                         bail_expr!(&rem[1], "a mapping string must be followed by an action");
-                    },
-                    _ => unreachable!()
+                    }
+                    _ => unreachable!(),
                 }
             }
         }

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -2624,7 +2624,7 @@ fn parse_layers(s: &mut ParsedState, mapped_keys: &mut MappedKeys) -> Result<Int
                         bail_expr!(input, "input key must not be repeated within a layer")
                     }
                     mapstr.atom(s.vars())
-                        .ok_or_else(|| anyhow_expr!(input, "mapping string must not be a list\n\
+                        .ok_or_else(|| anyhow_expr!(mapstr, "mapping string must not be a list\n\
                                                     suggested strings: = | : | -> | >> | maps-to | → | 🞂"))?;
                     let action = parse_action(action, s)?;
                     layers_cfg[layer_level * 2][0][usize::from(input_key)] = *action;

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -2012,7 +2012,7 @@ fn test_new_layer_type() {
 
     let source = r#"
 (defsrc a b l)
-(deflayer-mapped base
+(deflayer-custom-map base
   d      ->  (macro a b c)
   e maps-to  e
   f       :  0

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -2018,6 +2018,8 @@ fn test_new_layer_type() {
   f       :  0
   j       →  1
   k       =  2
+  l       🞂  3
+  m      >>  4
 )
 "#;
     let mut s = ParsedState::default();

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -2012,7 +2012,7 @@ fn test_new_layer_type() {
 
     let source = r#"
 (defsrc a b l)
-(deflayer-custom-map base
+(deflayer-custom-map (blah)
   d      ->  (macro a b c)
   e maps-to  e
   f       :  0

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -2002,3 +2002,35 @@ fn parse_template_7() {
     })
     .expect("parses");
 }
+
+#[test]
+fn test_new_layer_type() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    let source = r#"
+(defsrc a b l)
+(deflayer-mapped base
+  d      ->  (macro a b c)
+  e maps-to  e
+  f       :  0
+  j       →  1
+)
+"#;
+    let mut s = ParsedState::default();
+    parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+        DEF_LOCAL_KEYS,
+    )
+    .map_err(|e| {
+        eprintln!("{:?}", miette::Error::from(e));
+    })
+    .expect("parses");
+}

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -2017,6 +2017,7 @@ fn test_new_layer_type() {
   e maps-to  e
   f       :  0
   j       →  1
+  k       =  2
 )
 "#;
     let mut s = ParsedState::default();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -22,6 +22,18 @@ fn parse_minimal() {
 }
 
 #[test]
+fn parse_deflayer_custom_map() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    new_from_file(&std::path::PathBuf::from(
+        "./cfg_samples/deflayer-custom-map.kbd",
+    ))
+    .unwrap();
+}
+
+#[test]
 fn parse_default() {
     let _lk = match CFG_PARSE_LOCK.lock() {
         Ok(guard) => guard,


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add `deflayer-custom-map` which enables an alternate layer definition syntax which is not dependent on `defsrc`, though a `defsrc` is still required (for now).

Closes #842 

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes
- Update error messages
  - [x] Yes
- Added tests, and did manual testing
  - [x] Yes
