### PR TITLE
add missing english/non-symbol modifier prefixes

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -627,14 +627,14 @@ You may want to remap a key to automatically be pressed in combination with
 modifiers such as Control or Shift. You can achieve this by prefixing the
 normal key name with one or more of:
 
-* `+C-+`: Left Control (also `+‹⎈+` `+‹⌃+`)
-* `+⎈›+`: Right Control (also `+⌃›+`)
+* `+C-+`: Left Control (also `+‹⎈+` )
+* `+RC-+`: Right Control (also `+⎈›+` `+⌃›+`)
 * `+A-+`: Left Alt (also `+‹⎇+` `+‹⌥+`)
+* `+RA-+`: Right Alt, a.k.a. AltGr (also `+AG+` `+⎇›+` `+⌥›+`)
 * `+S-+`: Left Shift (also `+‹⇧+`)
-* `+⇧›+`: Right Shift
-* `+M-+`: Left Meta, a.k.a. Windows, GUI, Command, Super (also `+‹◆+` `+‹⌘+` `+‹❖+`)
-* `+◆›+`: Right Meta (also `+⌘›+` `+❖›+`)
-* `+RA-+` or `+AG+`: Right Alt, a.k.a. AltGr (also `+⎇›+` `+⌥›+`)
+* `+RS-+`: Right Shift (also `+⇧›+`)
+* `+M-+`: Left Meta, a.k.a. Windows, GUI, Command, Super (also `+‹⌘+` `+‹❖+` `+‹◆+`)
+* `+RM-+`: Right Meta (also `+⌘›+` `+❖›+` `+◆›+`)
 
 These modifiers may be combined together if desired.
 

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1826,15 +1826,17 @@ fn parse_mods_held_for_submacro<'a>(
     Ok((mod_keys, unparsed_str))
 }
 
-static KEYMODI: [(&str, KeyCode); 22] = [
+static KEYMODI: [(&str, KeyCode); 25] = [
     ("S-", KeyCode::LShift),
     ("‹⇧", KeyCode::LShift),
     ("⇧›", KeyCode::RShift),
+    ("RS-", KeyCode::RShift),
     ("C-", KeyCode::LCtrl),
     ("‹⎈", KeyCode::LCtrl),
     ("‹⌃", KeyCode::LCtrl),
     ("⎈›", KeyCode::RCtrl),
     ("⌃›", KeyCode::RCtrl),
+    ("RC-", KeyCode::RCtrl),
     ("M-", KeyCode::LGui),
     ("‹◆", KeyCode::LGui),
     ("‹⌘", KeyCode::LGui),
@@ -1842,6 +1844,7 @@ static KEYMODI: [(&str, KeyCode); 22] = [
     ("◆›", KeyCode::RGui),
     ("⌘›", KeyCode::RGui),
     ("❖›", KeyCode::RGui),
+    ("RM-", KeyCode::RGui),
     ("‹⎇", KeyCode::LAlt),
     ("A-", KeyCode::LAlt),
     ("‹⌥", KeyCode::LAlt),


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
add missing english/non-symbol modifier prefixes

some people, including me, prefer using the prefixes that do not have the Unicode symbols, they would argue that the English-letter-initials-only prefixes are more readable and less ambiguous:
- `RC-` means **R**ight  **C**trl
- `RS-` means **R**ight **S**hift
- `RM-` means **R**ight **M**eta
- `RA-` means **R**ight **A**lt (didn't add, already in the code)

they mirror the syntax of `C-`, `S-`, `M-`, `A-`, respectively.
...more readable and less ambiguous than `◆›`, `⌘›`, `❖›`, `⎈›`, `⌃›`, `⇧›`,
which mean right meta, right meta, right meta, right ctrl, right ctrl, right shift, respectively. 

(also having/allowing multiple symbols/prefixes/names for one key is a mistake, IMHO, they make other people's configs less readable)

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
    - manual testing