### PR TITLE
feat(parser): treat modifier symbols without a side indicator as left

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -627,13 +627,13 @@ You may want to remap a key to automatically be pressed in combination with
 modifiers such as Control or Shift. You can achieve this by prefixing the
 normal key name with one or more of:
 
-* `+C-+`: Left Control (also `+‹⎈+` `+‹⌃+`)
+* `+C-+`: Left Control (also `+‹⎈+` `+‹⌃+` or without the `+‹+` side indicator)
 * `+RC-+`: Right Control (also `+⎈›+` `+⌃›+`)
-* `+A-+`: Left Alt (also `+‹⎇+` `+‹⌥+`)
+* `+A-+`: Left Alt (also `+‹⎇+` `+‹⌥+` or without the `+‹+` side indicator))
 * `+RA-+`: Right Alt, a.k.a. AltGr (also `+AG+` `+⎇›+` `+⌥›+`)
-* `+S-+`: Left Shift (also `+‹⇧+`)
+* `+S-+`: Left Shift (also `+‹⇧+` or without the `+‹+` side indicator))
 * `+RS-+`: Right Shift (also `+⇧›+`)
-* `+M-+`: Left Meta, a.k.a. Windows, GUI, Command, Super (also `+‹⌘+` `+‹❖+` `+‹◆+`)
+* `+M-+`: Left Meta, a.k.a. Windows, GUI, Command, Super (also `+‹⌘+` `+‹❖+` `+‹◆+` or without the `+‹+` side indicator))
 * `+RM-+`: Right Meta (also `+⌘›+` `+❖›+` `+◆›+`)
 
 These modifiers may be combined together if desired.

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -627,7 +627,7 @@ You may want to remap a key to automatically be pressed in combination with
 modifiers such as Control or Shift. You can achieve this by prefixing the
 normal key name with one or more of:
 
-* `+C-+`: Left Control (also `+‹⎈+` )
+* `+C-+`: Left Control (also `+‹⎈+` `+‹⌃+`)
 * `+RC-+`: Right Control (also `+⎈›+` `+⌃›+`)
 * `+A-+`: Left Alt (also `+‹⎇+` `+‹⌥+`)
 * `+RA-+`: Right Alt, a.k.a. AltGr (also `+AG+` `+⎇›+` `+⌥›+`)

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1826,7 +1826,7 @@ fn parse_mods_held_for_submacro<'a>(
     Ok((mod_keys, unparsed_str))
 }
 
-static KEYMODI: [(&str, KeyCode); 25] = [
+static KEYMODI: [(&str, KeyCode); 31] = [
     ("S-", KeyCode::LShift),
     ("‹⇧", KeyCode::LShift),
     ("⇧›", KeyCode::RShift),
@@ -1852,6 +1852,12 @@ static KEYMODI: [(&str, KeyCode); 25] = [
     ("RA-", KeyCode::RAlt),
     ("⎇›", KeyCode::RAlt),
     ("⌥›", KeyCode::RAlt),
+    ("⎈", KeyCode::LCtrl), // Shorter indicators should be at the end to only get matched after indicators with sides have had a chance
+    ("⌥", KeyCode::LAlt),
+    ("⎇", KeyCode::LAlt),
+    ("◆", KeyCode::LGui),
+    ("⌘", KeyCode::LGui),
+    ("❖", KeyCode::LGui),
 ];
 
 /// Parses mod keys like `C-S-`. Returns the `KeyCode`s for the modifiers parsed and the unparsed


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Treat ⎈1 the same as ‹⎈1 (modifier symbols without a side indicator as left)

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - N/A
- Added tests, or did manual testing
  - [x] Yes manual, put the shorter no-side modifiers at the end of the array, and so iteration should always prioritize mods with sides, so ⎈› will match before ⎈
