### PR TITLE
Use a shorter ↕ symbol for tap ↓↑ display 

### DIFF
--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -120,7 +120,7 @@ impl fmt::Display for InputEvent {
             KeyValue::Press => "↓",
             KeyValue::Release => "↑",
             KeyValue::Repeat => "⟳",
-            KeyValue::Tap => "↓↑",
+            KeyValue::Tap => "↕",
             KeyValue::WakeUp => "!",
         };
         let key_name = KeyCode::from(ke.code);


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Make key display output to always be a 1-char symbol:  ↕ instead of ↓↑

## Checklist

- Add documentation to docs/config.adoc
  - N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  - N/A
- Added tests, or did manual testing
  - n/a
