### PR TITLE
Fix config.adoc deflayermap underscore character display

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -182,13 +182,13 @@ The input key takes the same role as `defsrc` keys.
 The output action takes the role that items in the normal `deflayer` have.
 
 Instead of specifying an input key,
-you can use either `_`, `__`, or `___` to map all
+you can use either `&#95;`, `&#95;&#95;`, or `&#95;&#95;&#95;` to map all
 the keys that are not explicitly mapped in the layer
 (`caps` in the example above). 
 
-* `_` maps only keys that are in defsrc.
-* `__` excludes mapping keys that are in defsrc.
-* `___` maps all keys that are not explicitly mapped in the layer.
+`&#95;` maps only keys that are in defsrc.
+`&#95;&#95;` excludes mapping keys that are in defsrc.
+`&#95;&#95;&#95;` maps all keys that are not explicitly mapped in the layer.
 
 
 The map string can be any of the following strings, to your liking:

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -187,7 +187,9 @@ the keys that are not explicitly mapped in the layer
 (`caps` in the example above). 
 
 `&#95;` maps only keys that are in defsrc.
+
 `&#95;&#95;` excludes mapping keys that are in defsrc.
+
 `&#95;&#95;&#95;` maps all keys that are not explicitly mapped in the layer.
 
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Before:
![image](https://github.com/jtroo/kanata/assets/650565/9488169f-ad63-45e4-8aa5-4f47290f46b2)
After:
![image](https://github.com/jtroo/kanata/assets/650565/5b619353-cc03-4a61-905c-6ba6ef6cfda5)

Solution found at https://github.com/asciidoctor/asciidoctor/issues/3528

## Checklist

- Add documentation to docs/config.adoc
  - [X ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [X ] Yes or N/A
- Update error messages
  - [X ] Yes or N/A
- Added tests, or did manual testing
  - [X ] Yes
