### PR TITLE
fix adoc rendering in config.adoc

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -178,17 +178,17 @@ An example complete configuration that maps Caps Lock to Escape is:
 )
 ----
 
-The input key takes the same role as `defsrc` keys.
-The output action takes the role that items in the normal `deflayer` have.
+The input key takes the same role as `+defsrc+` keys.
+The output action takes the role that items in the normal `+deflayer+` have.
 
 Instead of specifying an input key,
-you can use either `_`, `__`, or `___` to map all
+you can use either `+_+`, `+__+`, or `+___+` to map all
 the keys that are not explicitly mapped in the layer
-(`caps` in the example above). 
+(`+caps+` in the example above). 
 
-* `_` maps only keys that are in defsrc.
-* `__` excludes mapping keys that are in defsrc.
-* `___` maps all keys that are not explicitly mapped in the layer.
+* `+_+` maps only keys that are in defsrc.
+* `+__+` excludes mapping keys that are in defsrc.
+* `+___+` maps all keys that are not explicitly mapped in the layer.
 
 
 The map string can be any of the following strings, to your liking:


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
fix adoc rendering in config.adoc

before 
![image](https://github.com/jtroo/kanata/assets/9993663/e9833785-da4c-430d-bfcb-05511dfc15cb)
after
![image](https://github.com/jtroo/kanata/assets/9993663/8c243b66-43e9-48a0-b962-d202c4760563)


## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
