### PR TITLE
feat(parser): add a symbol for ScrollLock

### DIFF
--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -214,7 +214,7 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "ssrq" | "sys" => OsCode::KEY_SYSRQ,
         // Typically the Non-US backslash, near the left shift key
         "IntlBackslash" | "102d" | "lsgt" | "nubs" | "nonusbslash" | "﹨" => OsCode::KEY_102ND,
-        "ScrollLock" | "scrlck" | "slck" => OsCode::KEY_SCROLLLOCK,
+        "ScrollLock" | "scrlck" | "slck" | "⇳🔒" => OsCode::KEY_SCROLLLOCK,
         "Pause" | "pause" | "break" | "brk" => OsCode::KEY_PAUSE,
         "WakeUp" | "wkup" => OsCode::KEY_WAKEUP,
         "Escape" | "esc" | "⎋" => OsCode::KEY_ESC,


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Added one symbol ⇳🔒 for ScrollLock

Some physical keyboards use ⤓ for this, but currently this is taken by End, which to me is more intuitive, but could change to match the unintuitive reality and remove home/end ⤒⤓ symbols

## Checklist

- Add documentation to docs/config.adoc
  - [ ] no
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] N/A
- Update error messages
  - [ ]  N/A
- Added tests, or did manual testing
  - [ ] Yes, manual
