### PR TITLE
refactor: store sim output in Vec, fn to make Kanata from str

### DIFF
--- a/simulated_input/src/sim.rs
+++ b/simulated_input/src/sim.rs
@@ -203,6 +203,8 @@ fn main_impl() -> Result<()> {
             }
         }
         #[cfg(feature = "simulated_output")]
+        println!("{}", k.kbd_out.outputs.join("\n"));
+        #[cfg(feature = "simulated_output")]
         k.kbd_out.log.end(config_sim_file, sim_appendix.clone());
     }
 

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -359,7 +359,7 @@ impl Kanata {
 
         let kbd_out = match KbdOut::new(
             #[cfg(target_os = "linux")]
-            &args.symlink_path,
+            None,
         ) {
             Ok(kbd_out) => kbd_out,
             Err(err) => {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -359,7 +359,7 @@ impl Kanata {
 
         let kbd_out = match KbdOut::new(
             #[cfg(target_os = "linux")]
-            None,
+            &None,
         ) {
             Ok(kbd_out) => kbd_out,
             Err(err) => {

--- a/src/oskbd/simulated.rs
+++ b/src/oskbd/simulated.rs
@@ -329,16 +329,20 @@ pub struct KbdOut {
 }
 
 impl KbdOut {
-    #[cfg(not(target_os = "linux"))]
-    pub fn new() -> Result<Self, io::Error> {
+    fn new_actual() -> Result<Self, io::Error> {
         Ok(Self {
             log: LogFmt::new(),
             outputs: vec![],
         })
     }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn new() -> Result<Self, io::Error> {
+        Self::new_actual()
+    }
     #[cfg(target_os = "linux")]
-    pub fn new(_: &Option<String>) -> Result<Self, io::Error> {
-        Self::new()
+    pub fn new(_s: &Option<String>) -> Result<Self, io::Error> {
+        Self::new_actual()
     }
     #[cfg(target_os = "linux")]
     pub fn write_raw(&mut self, event: InputEvent) -> Result<(), io::Error> {

--- a/src/oskbd/simulated.rs
+++ b/src/oskbd/simulated.rs
@@ -343,7 +343,7 @@ impl KbdOut {
     #[cfg(target_os = "linux")]
     pub fn write_raw(&mut self, event: InputEvent) -> Result<(), io::Error> {
         self.log.write_raw(event);
-        self.output_events.push(format!("out-raw:{event:?}"));
+        self.outputs.push(format!("out-raw:{event:?}"));
         Ok(())
     }
     pub fn write(&mut self, event: InputEvent) -> Result<(), io::Error> {

--- a/src/oskbd/simulated.rs
+++ b/src/oskbd/simulated.rs
@@ -325,25 +325,29 @@ use std::fmt;
 /// Handle for writing keys to the OS.
 pub struct KbdOut {
     pub log: LogFmt,
+    pub outputs: Vec<String>,
 }
 
 impl KbdOut {
     #[cfg(not(target_os = "linux"))]
     pub fn new() -> Result<Self, io::Error> {
-        Ok(Self { log: LogFmt::new() })
+        Ok(Self {
+            log: LogFmt::new(),
+            outputs: vec![],
+        })
     }
     #[cfg(target_os = "linux")]
     pub fn new(_: &Option<String>) -> Result<Self, io::Error> {
-        Ok(Self { log: LogFmt::new() })
+        Self::new()
     }
     #[cfg(target_os = "linux")]
     pub fn write_raw(&mut self, event: InputEvent) -> Result<(), io::Error> {
         self.log.write_raw(event);
-        println!("out-raw:{event:?}");
+        self.output_events.push(format!("out-raw:{event:?}"));
         Ok(())
     }
     pub fn write(&mut self, event: InputEvent) -> Result<(), io::Error> {
-        println!("out:{event}");
+        self.outputs.push(format!("out:{event}"));
         Ok(())
     }
     pub fn write_key(&mut self, key: OsCode, value: KeyValue) -> Result<(), io::Error> {
@@ -362,7 +366,7 @@ impl KbdOut {
     }
     pub fn write_code(&mut self, code: u32, value: KeyValue) -> Result<(), io::Error> {
         self.log.write_code(code, value);
-        println!("out-code:{code};{value:?}");
+        self.outputs.push(format!("out-code:{code};{value:?}"));
         Ok(())
     }
     pub fn press_key(&mut self, key: OsCode) -> Result<(), io::Error> {
@@ -375,34 +379,37 @@ impl KbdOut {
     }
     pub fn send_unicode(&mut self, c: char) -> Result<(), io::Error> {
         self.log.send_unicode(c);
-        println!("outU:{c}");
+        self.outputs.push(format!("outU:{c}"));
         Ok(())
     }
     pub fn click_btn(&mut self, btn: Btn) -> Result<(), io::Error> {
         self.log.click_btn(btn);
-        println!("out🖰:↓{btn:?}");
+        self.outputs.push(format!("out🖰:↓{btn:?}"));
         Ok(())
     }
     pub fn release_btn(&mut self, btn: Btn) -> Result<(), io::Error> {
         self.log.release_btn(btn);
-        println!("out🖰:↑{btn:?}");
+        self.outputs.push(format!("out🖰:↑{btn:?}"));
         Ok(())
     }
     pub fn scroll(&mut self, direction: MWheelDirection, distance: u16) -> Result<(), io::Error> {
-        println!("scroll:{direction:?},{distance:?}");
+        self.outputs
+            .push(format!("scroll:{direction:?},{distance:?}"));
         Ok(())
     }
     pub fn move_mouse(&mut self, mv: CalculatedMouseMove) -> Result<(), io::Error> {
         let (direction, distance) = (mv.direction, mv.distance);
         self.log.move_mouse(direction, distance);
-        println!("out🖰:move {direction:?},{distance:?}");
+        self.outputs
+            .push(format!("out🖰:move {direction:?},{distance:?}"));
         Ok(())
     }
     pub fn move_mouse_many(&mut self, moves: &[CalculatedMouseMove]) -> Result<(), io::Error> {
         for mv in moves {
             let (direction, distance) = (&mv.direction, &mv.distance);
             self.log.move_mouse(*direction, *distance);
-            println!("out🖰:move {direction:?},{distance:?}");
+            self.outputs
+                .push(format!("out🖰:move {direction:?},{distance:?}"));
         }
         Ok(())
     }


### PR DESCRIPTION
Add `new_from_str` for `Kanata` and `Cfg`. The goal is to move towards being able to run a Kanata state machine on the web, which does not have access to files.

Store simulated output strings in a `Vec` instead of printing to stdout immediately. The goal is to give control to the consuming application for where to output the text, e.g. to a web text box instead of stdout.