### PR TITLE
use `127.0.0.1` instead of `0.0.0.0` to prevent TCP connections from outside the machine

### DIFF
--- a/simulated_input/src/sim.rs
+++ b/simulated_input/src/sim.rs
@@ -4,6 +4,8 @@ use clap::Parser;
 use kanata_state_machine::{oskbd::*, *};
 use simplelog::*;
 
+use crate::SocketAddrWrapper;
+
 use std::path::PathBuf;
 
 pub fn default_sim() -> Vec<PathBuf> {
@@ -132,7 +134,7 @@ fn cli_init_fsim() -> Result<(ValidatedArgs, Vec<PathBuf>, Option<String>)> {
         ValidatedArgs {
             paths: cfg_paths,
             #[cfg(feature = "tcp_server")]
-            tcp_server_address: None,
+            tcp_server_address: None::<SocketAddrWrapper>,
             #[cfg(target_os = "linux")]
             symlink_path: None,
             nodelay: true,

--- a/simulated_input/src/sim.rs
+++ b/simulated_input/src/sim.rs
@@ -4,8 +4,6 @@ use clap::Parser;
 use kanata_state_machine::{oskbd::*, *};
 use simplelog::*;
 
-use crate::SocketAddrWrapper;
-
 use std::path::PathBuf;
 
 pub fn default_sim() -> Vec<PathBuf> {

--- a/simulated_input/src/sim.rs
+++ b/simulated_input/src/sim.rs
@@ -132,7 +132,7 @@ fn cli_init_fsim() -> Result<(ValidatedArgs, Vec<PathBuf>, Option<String>)> {
         ValidatedArgs {
             paths: cfg_paths,
             #[cfg(feature = "tcp_server")]
-            port: None,
+            tcp_server_address: None,
             #[cfg(target_os = "linux")]
             symlink_path: None,
             nodelay: true,

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -16,6 +16,8 @@ use std::time;
 use crate::oskbd::{KeyEvent, *};
 #[cfg(feature = "tcp_server")]
 use crate::tcp_server::simple_sexpr_to_json_array;
+#[cfg(feature = "tcp_server")]
+use crate::PortArg;
 use crate::ValidatedArgs;
 use kanata_parser::cfg;
 use kanata_parser::cfg::*;
@@ -176,7 +178,7 @@ pub struct Kanata {
     /// The maximum value of switch's key-timing item in the configuration.
     pub switch_max_key_timing: u16,
     #[cfg(feature = "tcp_server")]
-    tcp_server_port: Option<i32>,
+    tcp_server_port: Option<PortArg>,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -342,7 +344,7 @@ impl Kanata {
             virtual_keys: cfg.fake_keys,
             switch_max_key_timing: cfg.switch_max_key_timing,
             #[cfg(feature = "tcp_server")]
-            tcp_server_port: args.port,
+            tcp_server_port: args.port.clone(),
         })
     }
 

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -17,7 +17,7 @@ use crate::oskbd::{KeyEvent, *};
 #[cfg(feature = "tcp_server")]
 use crate::tcp_server::simple_sexpr_to_json_array;
 #[cfg(feature = "tcp_server")]
-use crate::PortArg;
+use crate::SocketAddrWrapper;
 use crate::ValidatedArgs;
 use kanata_parser::cfg;
 use kanata_parser::cfg::*;
@@ -178,7 +178,7 @@ pub struct Kanata {
     /// The maximum value of switch's key-timing item in the configuration.
     pub switch_max_key_timing: u16,
     #[cfg(feature = "tcp_server")]
-    tcp_server_port: Option<PortArg>,
+    tcp_server_address: Option<SocketAddrWrapper>,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -344,7 +344,7 @@ impl Kanata {
             virtual_keys: cfg.fake_keys,
             switch_max_key_timing: cfg.switch_max_key_timing,
             #[cfg(feature = "tcp_server")]
-            tcp_server_port: args.port.clone(),
+            tcp_server_address: args.tcp_server_address.clone(),
         })
     }
 
@@ -434,7 +434,7 @@ impl Kanata {
             virtual_keys: cfg.fake_keys,
             switch_max_key_timing: cfg.switch_max_key_timing,
             #[cfg(feature = "tcp_server")]
-            tcp_server_port: None,
+            tcp_server_address: None,
         })
     }
 
@@ -1297,7 +1297,7 @@ impl Kanata {
                                 }
                             }
                             #[cfg(feature = "tcp_server")]
-                            match self.tcp_server_port {
+                            match self.tcp_server_address {
                                 None => {
                                     log::warn!("{} was used, but TCP server is not running. did you specify a port?", PUSH_MESSAGE);
                                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-use anyhow::Error;
-use anyhow::Result;
+use anyhow::{anyhow, Error, Result};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -50,15 +49,11 @@ impl FromStr for SocketAddrWrapper {
         let mut address = s.to_string();
         if let Ok(port) = s.parse::<u16>() {
             address = format!("127.0.0.1:{}", port);
-        } else if !is_address_format(s) {
-            return Err(anyhow::Error::msg(
-                "please specify either a port number, e.g. 8081 or an address, e.g. 127.0.0.1:8081",
-            ));
         }
         address
             .parse::<SocketAddr>()
             .map(SocketAddrWrapper)
-            .map_err(|e| e.into())
+            .map_err(|e| anyhow!("Please specify either a port number, e.g. 8081 or an address, e.g. 127.0.0.1:8081.\n{e}"))
     }
 }
 
@@ -69,16 +64,4 @@ impl SocketAddrWrapper {
     pub fn get_ref(&self) -> &SocketAddr {
         &self.0
     }
-}
-
-fn is_address_format(addr: &str) -> bool {
-    if let Some((host, port)) = addr.split_once(':') {
-        if host.is_empty() {
-            return false;
-        }
-        if let Ok(port_num) = port.parse::<u16>() {
-            return port_num > 0;
-        }
-    }
-    false
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
+use anyhow::Error;
+use anyhow::Result;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 pub mod kanata;
 pub mod oskbd;
@@ -12,7 +15,7 @@ type CfgPath = PathBuf;
 pub struct ValidatedArgs {
     pub paths: Vec<CfgPath>,
     #[cfg(feature = "tcp_server")]
-    pub port: Option<i32>,
+    pub port: Option<PortArg>,
     #[cfg(target_os = "linux")]
     pub symlink_path: Option<String>,
     pub nodelay: bool,
@@ -34,4 +37,39 @@ pub fn default_cfg() -> Vec<PathBuf> {
     }
 
     cfgs
+}
+
+#[derive(Clone, Debug)]
+pub enum PortArg {
+    Number(u16),
+    Address(String),
+}
+
+impl FromStr for PortArg {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(num) = s.parse::<u16>() {
+            Ok(PortArg::Number(num))
+        } else if is_address_format(s) {
+            Ok(PortArg::Address(s.to_string()))
+        } else {
+            Err(anyhow::Error::msg(
+                "specify either a port number, e.g. 8081 or an address, e.g. 127.0.0.1:8081",
+            ))
+        }
+    }
+}
+
+fn is_address_format(addr: &str) -> bool {
+    if let Some((host, port)) = addr.split_once(':') {
+        if host.is_empty() {
+            return false;
+        }
+
+        if let Ok(port_num) = port.parse::<u16>() {
+            return port_num > 0;
+        }
+    }
+    false
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,7 @@ fn main_impl() -> Result<()> {
         }
         #[cfg(not(feature = "tcp_server"))]
         {
-            None
+            None::<SocketAddrWrapper>
         }
     } {
         let mut server = TcpServer::new(address.into_inner(), tx.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,12 +47,16 @@ kanata.kbd in the current working directory and
     #[arg(short, long, verbatim_doc_comment)]
     cfg: Option<Vec<PathBuf>>,
 
-    /// Port to run the optional TCP server on. If blank, no TCP port will be
+    /// Port or full address (IP:PORT) to run the optional TCP server on. If blank, no TCP port will be
     /// listened on.
     #[cfg(feature = "tcp_server")]
-    #[arg(short, long, verbatim_doc_comment)]
-    port: Option<PortArg>,
-
+    #[arg(
+        short = 'p',
+        long = "port",
+        value_name = "PORT or IP:PORT",
+        verbatim_doc_comment
+    )]
+    tcp_server_address: Option<SocketAddrWrapper>,
     /// Path for the symlink pointing to the newly-created device. If blank, no
     /// symlink will be created.
     #[cfg(target_os = "linux")]
@@ -160,7 +164,7 @@ fn cli_init() -> Result<ValidatedArgs> {
     Ok(ValidatedArgs {
         paths: cfg_paths,
         #[cfg(feature = "tcp_server")]
-        port: args.port,
+        tcp_server_address: args.tcp_server_address,
         #[cfg(target_os = "linux")]
         symlink_path: args.symlink_path,
         nodelay: args.nodelay,
@@ -184,23 +188,17 @@ fn main_impl() -> Result<()> {
 
     let (tx, rx) = std::sync::mpsc::sync_channel(100);
 
-    let (server, ntx, nrx) = if let Some(port) = {
+    let (server, ntx, nrx) = if let Some(address) = {
         #[cfg(feature = "tcp_server")]
         {
-            args.port
+            args.tcp_server_address
         }
         #[cfg(not(feature = "tcp_server"))]
         {
             None
         }
     } {
-        let address = match port {
-            PortArg::Number(port) => {
-                format!("127.0.0.1:{}", port)
-            }
-            PortArg::Address(address) => address,
-        };
-        let mut server = TcpServer::new(address, tx.clone());
+        let mut server = TcpServer::new(address.into_inner(), tx.clone());
         server.start(kanata_arc.clone());
         let (ntx, nrx) = std::sync::mpsc::sync_channel(100);
         (Some(server), Some(ntx), Some(nrx))

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ kanata.kbd in the current working directory and
     /// listened on.
     #[cfg(feature = "tcp_server")]
     #[arg(short, long, verbatim_doc_comment)]
-    port: Option<i32>,
+    port: Option<PortArg>,
 
     /// Path for the symlink pointing to the newly-created device. If blank, no
     /// symlink will be created.
@@ -194,7 +194,13 @@ fn main_impl() -> Result<()> {
             None
         }
     } {
-        let mut server = TcpServer::new(port, tx.clone());
+        let address = match port {
+            PortArg::Number(port) => {
+                format!("127.0.0.1:{}", port)
+            }
+            PortArg::Address(address) => address,
+        };
+        let mut server = TcpServer::new(address, tx.clone());
         server.start(kanata_arc.clone());
         let (ntx, nrx) = std::sync::mpsc::sync_channel(100);
         (Some(server), Some(ntx), Some(nrx))

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -69,7 +69,7 @@ impl TcpServer {
     }
 
     #[cfg(not(feature = "tcp_server"))]
-    pub fn new(_port: u16, _wakeup_channel: Sender<KeyEvent>) -> Self {
+    pub fn new(address: String, _wakeup_channel: Sender<KeyEvent>) -> Self {
         Self { connections: () }
     }
 

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -4,6 +4,7 @@ use crate::Kanata;
 #[cfg(feature = "tcp_server")]
 use kanata_tcp_protocol::*;
 use parking_lot::Mutex;
+use std::net::SocketAddr;
 use std::sync::mpsc::SyncSender as Sender;
 use std::sync::Arc;
 
@@ -37,7 +38,7 @@ fn to_action(val: FakeKeyActionMessage) -> FakeKeyAction {
 
 #[cfg(feature = "tcp_server")]
 pub struct TcpServer {
-    pub address: std::net::SocketAddr,
+    pub address: SocketAddr,
     pub connections: Connections,
     pub wakeup_channel: Sender<KeyEvent>,
 }
@@ -49,27 +50,16 @@ pub struct TcpServer {
 
 impl TcpServer {
     #[cfg(feature = "tcp_server")]
-    pub fn new(address: String, wakeup_channel: Sender<KeyEvent>) -> Self {
-        use std::net::ToSocketAddrs;
-
+    pub fn new(address: SocketAddr, wakeup_channel: Sender<KeyEvent>) -> Self {
         Self {
-            address: address
-                .to_socket_addrs()
-                .unwrap_or_else(|_| panic!("Failed to resolve the specified address: {}", address))
-                .next()
-                .unwrap_or_else(|| {
-                    panic!(
-                        "Specified address {} resolved to no valid endpoints",
-                        address
-                    )
-                }),
+            address,
             connections: Arc::new(Mutex::new(HashMap::default())),
             wakeup_channel,
         }
     }
 
     #[cfg(not(feature = "tcp_server"))]
-    pub fn new(_address: String, _wakeup_channel: Sender<KeyEvent>) -> Self {
+    pub fn new(_address: SocketAddr, _wakeup_channel: Sender<KeyEvent>) -> Self {
         Self { connections: () }
     }
 

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -69,7 +69,7 @@ impl TcpServer {
     }
 
     #[cfg(not(feature = "tcp_server"))]
-    pub fn new(address: String, _wakeup_channel: Sender<KeyEvent>) -> Self {
+    pub fn new(_address: String, _wakeup_channel: Sender<KeyEvent>) -> Self {
         Self { connections: () }
     }
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
I read that using `127.0.0.1` as opposed to `0.0.0.0` (or any other IP address) prevents TCP connections to the server from outside the machine, using `127.0.0.1` (the loopback interface IP address) limits the connections to connections from the local machine, even if the machine's firewall was misconfigured or for some reason is not working.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
