### PR TITLE
Fix setup-linux.md to adhere to systemd shell expansion

### DIFF
--- a/docs/setup-linux.md
+++ b/docs/setup-linux.md
@@ -56,12 +56,7 @@ Run this command first:
 mkdir -p ~/.config/systemd/user
 ```
 
-Then add this to: `~/.config/systemd/user/kanata.service`
-make sure to update the executable location for sh; you can check with
-```bash
-which sh
-```
-
+Then add this to: `~/.config/systemd/user/kanata.service`:
 ```bash
 [Unit]
 Description=Kanata keyboard remapper
@@ -70,14 +65,19 @@ Documentation=https://github.com/jtroo/kanata
 [Service]
 Environment=PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin
 Environment=DISPLAY=:0
-; Environment=HOME=/$HOME ; not needed
 Type=simple
 ExecStart=/usr/bin/sh -c 'exec $$(which kanata) --cfg $${HOME}/.config/kanata/config.kbd'
 Restart=no
 
 [Install]
 WantedBy=default.target
+```
 
+Make sure to update the executable location for sh in the snippet above.
+This would be the line starting with `ExecStart=/usr/bin/sh -c`.
+You can check the executable path with:
+```bash
+which sh
 ```
 
 Then run:

--- a/docs/setup-linux.md
+++ b/docs/setup-linux.md
@@ -57,6 +57,11 @@ mkdir -p ~/.config/systemd/user
 ```
 
 Then add this to: `~/.config/systemd/user/kanata.service`
+make sure to update the executable location for sh; you can check with
+```bash
+which sh
+```
+
 ```bash
 [Unit]
 Description=Kanata keyboard remapper
@@ -65,9 +70,9 @@ Documentation=https://github.com/jtroo/kanata
 [Service]
 Environment=PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin
 Environment=DISPLAY=:0
-Environment=HOME=/$HOME
+; Environment=HOME=/$HOME ; not needed
 Type=simple
-ExecStart=$(which kanata) --cfg $HOME/.config/kanata/config.kbd
+ExecStart=/usr/bin/sh -c 'exec $$(which kanata) --cfg $${HOME}/.config/kanata/config.kbd'
 Restart=no
 
 [Install]


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Update linux setup documentation to use systemd shell expansion syntax
Require the user to input their sh executable path, but not their home directory or the kanata exec path

documentation:
https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Command%20lines

Context added by jtroo from comments below:

There were unnecessary configurations missing from the instructions; the formatting for dynamically accessing the home directory and the kanata installation location was not functional with systemd because systemd cannot perform shell expansions like subshell, $(which kanata), or path variables, $HOME/.config/....

Instead, we call sh to achieve this dynamic functionality.

Note that the systemd syntax requires a double dollar sign $$ in order to represent the string literal $.

The discussion https://github.com/jtroo/kanata/discussions/130 gave a working configuration example, but required users to specify both their kanata executable path and their home directory. Typically, one prefers their dynamic expressions such as $HOME, so that way config flies can easily be shared or published.

Since the installation location of sh at /usr/bin/sh or /bin/sh is more standard than the location of kanata, the chance that a simple copy paste of the docs would result in a working config is greater than requiring users to specify both their home directory and kanata path.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A (is documentation change)
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
