### PR TITLE
feat: chords v2 experimental

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "arraydeque",
  "heapless",
  "kanata-keyberon-macros",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -223,7 +223,7 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;; in time expire their timeout quicker. Without this, the timeout for the 2nd
   ;; tap-hold onwards will start from 0ms after the previous tap-hold expires.
   ;;
-  ;; concurrent-tap-hold yes
+  concurrent-tap-hold yes
 
   ;; This configuration makes the release of one-shot-press and of the tap in a tap-hold
   ;; by the defined number of milliseconds (approximate).
@@ -1229,4 +1229,24 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   (defoverrides
     (template-expand common-overrides)
   )
+)
+
+#|
+
+Global input chords.
+
+Syntax (5-tuples):
+
+    (defchordsv2-experimental
+      (participating-keys1) action1 timeout1 release-behaviour1 (disabled-layers1)
+        ...
+      (participating-keysN) actionN timeoutN release-behaviourN (disabled-layersN)
+    )
+
+|#
+
+(defchordsv2-experimental
+  (a b)      c                200 all-released  (arrows)
+  (a b z)   (macro h e l l o) 250 first-release (arrows)
+  (a b z y) (macro b y e)     400 first-release (arrows)
 )

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1708,13 +1708,15 @@ The valid values for applicable platforms are:
 ----
 
 [[input-chords-v2]]
-== Input chords / combos
+== Input chords / combos (v2)
 <<table-of-contents,Back to ToC>>
 
 You may define a single `+defchordsv2-experimental+` configuration item.
 This enables you to define global input chord behaviour.
-This functionality is may also be known by another name of "combos"
+One might also find this functionality called another name of "combos"
 in other projects.
+
+Input chords enables you to press
 
 WARNING: As the name suggests, this is a new feature.
 Using this feature puts you at higher risk
@@ -1737,15 +1739,21 @@ The configuration is made up of 5-tuples of:
 [cols="1,2"]
 |===
 | 1. A list of participating keys
-| These are key names you would use in `defsrc`
+| These are key names you would use in `defsrc`.
+A minimum of two keys must be defined per chord.
+The list must be unique per chord.
 
 | 2. Associated action
-| These are actions as you would configure in `deflayer` or `defalias`
+| These are actions as you would configure in `deflayer` or `defalias`.
+The action activates if all participating keys are activated
+within the timeout.
 
 | 3. Timeout to fulfill the chord
-| If the configured timeout (unit: milliseconds) has elapsed
-since the first press of a participating chord key,
-all pressed keys will be handled by active layer.
+| The time (unit: milliseconds) within which,
+if all participating keys are pressed,
+the chord action will activate;
+otherwise the key presses are handled by the active layer.
+The time begins when the first participant is pressed.
 
 | 4. Release behaviour
 | This must be either `first-release` or `all-released`;
@@ -1755,7 +1763,7 @@ while `all-released` means the chord action will be released
 only when all of the participants have been released.
 
 |5. Disabled layers
-| A list of layers on which this chord is disabled.
+| A list of layer names on which this chord is disabled.
 |===
 
 Input chords have a related `defcfg` item: <<chords-v2-min-idle-experimental>>.
@@ -1765,19 +1773,19 @@ a timeout begins with duration configured by
 Until this timeout expires, all inputs will immediately skip
 chords processing and be processed by the active layer.
 
-IMPORTANT: when opting into input chords v2,
+IMPORTANT: When opting into input chords v2,
 you must enable `concurrent-tap-hold`.
 This is enforced for a more responsive `tap-hold` experience when
 activated by a chord.
 
-.Syntax example
+.Example
 [source]
 ----
 (defcfg concurrent-tap-hold yes)
 (defchordsv2-experimental
-  (a b)      c                200 last-release  (non-chord-layer)
-  (a b z)   (macro h e l l o) 250 first-release (non-chord-layer)
-  (a b z y) (macro b y e)     400 first-release (non-chord-layer)
+  (a s)    c                200 last-release  (non-chord-layer)
+  (a s d) (macro h e l l o) 250 first-release (non-chord-layer)
+  (s d f) (macro b y e)     400 first-release (non-chord-layer)
 )
 ----
 

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2069,6 +2069,16 @@ you can set reduce the value to a number 0 to 4.
 This configuration affects the timer during which chords processing is disabled.
 NOTE: For more info, see <<input-chords-v2>>.
 
+The default (and minimum) value is `5` and the unit is milliseconds.
+
+.Example:
+[source]
+----
+(defcfg
+  chords-v2-min-idle-experimental 200
+)
+----
+
 [[linux-only-linux-dev]]
 === Linux only: linux-dev
 <<table-of-contents,Back to ToC>>

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1707,6 +1707,83 @@ The valid values for applicable platforms are:
 )
 ----
 
+[[input-chords-v2]]
+== Input chords / combos
+<<table-of-contents,Back to ToC>>
+
+You may define a single `+defchordsv2-experimental+` configuration item.
+This enables you to define global input chord behaviour.
+This functionality is may also be known by another name of "combos"
+in other projects.
+
+WARNING: As the name suggests, this is a new feature.
+Using this feature puts you at higher risk
+of encountering bugs or future breaking changes.
+
+The `+defchordsv2-experimental+` feature is configured as shown below:
+
+.Syntax example
+[source]
+----
+(defchordsv2-experimental
+  (participating-keys1) action1 timeout1 release-behaviour1 (disabled-layers1)
+    ...
+  (participating-keysN) actionN timeoutN release-behaviourN (disabled-layersN)
+)
+----
+
+The configuration is made up of 5-tuples of:
+
+[cols="1,2"]
+|===
+| 1. A list of participating keys
+| These are key names you would use in `defsrc`
+
+| 2. Associated action
+| These are actions as you would configure in `deflayer` or `defalias`
+
+| 3. Timeout to fulfill the chord
+| If the configured timeout (unit: milliseconds) has elapsed
+since the first press of a participating chord key,
+all pressed keys will be handled by active layer.
+
+| 4. Release behaviour
+| This must be either `first-release` or `all-released`;
+`first-release` means the chord action will be released
+when the first participant is released,
+while `all-released` means the chord action will be released
+only when all of the participants have been released.
+
+|5. Disabled layers
+| A list of layers on which this chord is disabled.
+|===
+
+Input chords have a related `defcfg` item: <<chords-v2-min-idle-experimental>>.
+When any non-chord activation happens,
+a timeout begins with duration configured by
+`chords-v2-min-idle-experimental` (unit: milliseconds).
+Until this timeout expires, all inputs will immediately skip
+chords processing and be processed by the active layer.
+
+IMPORTANT: when opting into input chords v2,
+you must enable `concurrent-tap-hold`.
+This is enforced for a more responsive `tap-hold` experience when
+activated by a chord.
+
+.Syntax example
+[source]
+----
+(defcfg concurrent-tap-hold yes)
+(defchordsv2-experimental
+  (a b)      c                200 last-release  (non-chord-layer)
+  (a b z)   (macro h e l l o) 250 first-release (non-chord-layer)
+  (a b z y) (macro b y e)     400 first-release (non-chord-layer)
+)
+----
+
+
+NOTE: Also see <<input-chords,v1 chords>>,
+which are configured differently and can be defined per-layer.
 
 [[optional-defcfg-options]]
 == defcfg options
@@ -1976,6 +2053,13 @@ you can set reduce the value to a number 0 to 4.
   rapid-event-delay 20
 )
 ----
+
+[[chords-v2-min-idle-experimental]]
+=== chords-v2-min-idle-experimental
+<<table-of-contents,Back to ToC>>
+
+This configuration affects the timer during which chords processing is disabled.
+NOTE: For more info, see <<input-chords-v2>>.
 
 [[linux-only-linux-dev]]
 === Linux only: linux-dev

--- a/keyberon/Cargo.toml
+++ b/keyberon/Cargo.toml
@@ -14,4 +14,5 @@ readme = "README.md"
 [dependencies]
 kanata-keyberon-macros = { version = "0.2.0" }
 heapless = "0.7.16"
+rustc-hash = "1.1.0"
 arraydeque = { version = "0.5.1", default-features = false }

--- a/keyberon/src/chord.rs
+++ b/keyberon/src/chord.rs
@@ -1,0 +1,544 @@
+//! Module for chords v2 implementation.
+
+use std::cell::Cell;
+
+use arraydeque::ArrayDeque;
+use heapless::Vec as HVec;
+use rustc_hash::FxHashMap;
+
+use crate::{
+    action::Action,
+    key_code::KEY_MAX,
+    layout::{Event, Queue, Queued, QueuedAction},
+};
+
+// Macro to help with this boilerplate.
+// $v should probably be `self` at points of use.
+// Ownership rules make this difficult to do as a regular fn,
+// because impl function calls don't understand split borrowing.
+macro_rules! no_chord_activations {
+    ($v:expr, $l:expr) => {{
+        $v.ticks_to_ignore_chord = $v.configured_ticks_to_ignore_chord;
+        eprintln!($l);
+    }};
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ReleaseBehaviour {
+    OnFirstRelease,
+    OnLastRelease,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChordV2<'a, T> {
+    /// The action associated with this chord.
+    pub action: &'a Action<'a, T>,
+    /// The full set of keys that need to be pressed to activate this chord.
+    pub participating_keys: &'a [u16],
+    /// The number of ticks during which, after the first press of a participant,
+    /// this chord can be activated if all participants get pressed.
+    /// In other words, after the number of ticks defined by `pending_duration`
+    /// elapses, this chord can no longer be completed.
+    pub pending_duration: u16,
+    /// The layers on which this chord is disabled.
+    pub disabled_layers: &'a [u16],
+    /// When should the action for this chord be released.
+    pub release_behaviour: ReleaseBehaviour,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChordsForKey<'a, T> {
+    /// Chords that this key participates in.
+    pub chords: Vec<&'a ChordV2<'a, T>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChordsForKeys<'a, T> {
+    pub mapping: FxHashMap<u16, ChordsForKey<'a, T>>,
+}
+
+const SMOL_Q_LEN: usize = 16;
+
+struct ActiveChord<'a, T> {
+    /// Chords uses a virtual coordinate in the keyberon state for an activated chord.
+    /// This field tracks which coordinate to release when the chord itself is released.
+    coordinate: u16,
+    /// Keys left to release.
+    /// For OnFirstRelease, this should have length 0.
+    remaining_keys_to_release: HVec<u16, SMOL_Q_LEN>,
+    /// Necessary to include here make sure that, for OnFirstRelease,
+    /// random other releases that are not part of this chord,
+    /// do not release this chord.
+    participating_keys: &'a [u16],
+    /// Action associated with the active chord.
+    /// This needs to be stored here
+    action: &'a Action<'a, T>,
+    /// In the case of Unread, this chord has not yet been consumed by the layout code.
+    /// This might happen for a while because of tap-hold-related delays.
+    /// In the Releasable status, the active chord has been consumed and can be released.
+    status: ActiveChordStatus,
+    /// Tracks how old an action is.
+    delay: u16,
+}
+
+fn tick_ach<T>(acc: &mut ActiveChord<T>) {
+    acc.delay = acc.delay.saturating_add(1);
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ActiveChordStatus {
+    /// -> UnreadPendingRelease if chord released before being consumed
+    /// -> Releasable if consumed
+    Unread,
+    /// -> Released once consumed
+    UnreadReleased,
+    /// Can remove at any time.
+    /// -> Released once released
+    Releasable,
+    /// Remove on next tick_chv2
+    Released,
+}
+use ActiveChordStatus::*;
+
+/// Like the layout Queue but smaller.
+pub(crate) type SmolQueue = ArrayDeque<Queued, SMOL_Q_LEN, arraydeque::behavior::Wrapping>;
+
+/// Global input chords configuration.
+pub struct ChordsV2<'a, T> {
+    // Note: Interior fields do not need to be pub or mutable via impl pub fn.
+    // Like a layout, this should be destroyed and recreated on a live reload.
+    //
+    /// Queued inputs that can potentially activate a chord but have not yet.
+    /// Inputs will leave if they are determined that they will not activate a chord,
+    /// or if a chord activates.
+    queue: Queue,
+    /// Information about what chords are possible and what keys they are associated with.
+    chords: ChordsForKeys<'a, T>,
+    /// Chords that are active, i.e. ones that have not yet been released.
+    active_chords: HVec<ActiveChord<'a, T>, 10>,
+    /// When a key leaves the combo queue without activating a chord,
+    /// this activates a timer during which keys cannot activate chords
+    /// and are always forwarded directly to the standard input queue.
+    ///
+    /// This keeps track of the timer.
+    ticks_to_ignore_chord: u16,
+    /// Initial value for the above when the appropriate event happens.
+    /// This must have a minimum value even if not configured by the user,
+    /// or if configured by the user to be zero. (maybe forbid that config)
+    configured_ticks_to_ignore_chord: u16,
+    /// Optimization: if there are no new inputs, the code can skip some processing work.
+    /// This tracks the next time that a change will happen, so that the processing work
+    /// is **not** skipped when something needs to be checked.
+    ticks_until_next_state_change: u16,
+    /// Optimization: the below is part of skipping processing work - if this is has changed,
+    /// then processing work cannot be skipped.
+    prev_active_layer: u16,
+    /// Optimization: the below is part of skipping processing work - if this is has changed,
+    /// then processing work cannot be skipped.
+    prev_queue_len: u8,
+    /// Virtual coordinate for use in the layout state.
+    next_coord: Cell<u16>,
+}
+
+impl<'a, T> std::fmt::Debug for ChordsV2<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ChordsV2")
+    }
+}
+
+impl<'a, T> ChordsV2<'a, T> {
+    pub fn new(chords: ChordsForKeys<'a, T>, ticks_ignore_chord: u16) -> Self {
+        assert!(ticks_ignore_chord >= 5);
+        Self {
+            queue: Queue::new(),
+            chords,
+            active_chords: HVec::new(),
+            ticks_to_ignore_chord: 0,
+            configured_ticks_to_ignore_chord: ticks_ignore_chord,
+            ticks_until_next_state_change: 0,
+            prev_active_layer: u16::MAX,
+            prev_queue_len: u8::MAX,
+            next_coord: Cell::new(KEY_MAX + 1),
+        }
+    }
+
+    pub fn is_idle_chv2(&self) -> bool {
+        self.queue.is_empty() && self.active_chords.is_empty()
+    }
+
+    pub fn push_back_chv2(&mut self, item: Queued) -> Option<Queued> {
+        self.queue.push_back(item)
+    }
+
+    pub(crate) fn get_action_chv2(&mut self) -> (QueuedAction<'a, T>, bool) {
+        match self
+            .active_chords
+            .iter_mut()
+            .find_map(|ach| match ach.status {
+                Unread => {
+                    ach.status = Releasable;
+                    Some((Some(((0, ach.coordinate), ach.delay, ach.action)), false))
+                }
+                UnreadReleased => {
+                    ach.status = Released;
+                    Some((Some(((0, ach.coordinate), ach.delay, ach.action)), true))
+                }
+                Releasable | Released => None,
+            }) {
+            Some(v) => v,
+            None => (None, false),
+        }
+    }
+
+    /// Update the times in the queue without activating any chords yet.
+    /// Returns queued events that are no longer usable in chords.
+    pub(crate) fn tick_chv2(&mut self, active_layer: u16) -> SmolQueue {
+        let mut q = SmolQueue::new();
+        self.queue.iter_mut().for_each(Queued::tick_qd);
+        self.active_chords.iter_mut().for_each(tick_ach);
+        self.drain_inputs(&mut q, active_layer);
+        self.clear_released_chords(&mut q);
+        self.ticks_to_ignore_chord = self.ticks_to_ignore_chord.saturating_sub(1);
+        q
+    }
+
+    fn next_coord(&self) -> u16 {
+        let ret = self.next_coord.get();
+        let mut new = ret + 1;
+        if new > KEY_MAX + 50 {
+            new = KEY_MAX + 1;
+        }
+        self.next_coord.set(new);
+        ret
+    }
+
+    fn drain_inputs(&mut self, drainq: &mut SmolQueue, active_layer: u16) {
+        if self.ticks_to_ignore_chord > 0 {
+            drainq.extend(self.queue.drain(0..));
+            if !drainq.is_empty() {
+                eprintln!("drained keys {drainq:?}");
+            }
+            return;
+        }
+        if self.ticks_until_next_state_change > 0
+            && self.prev_active_layer == active_layer
+            && usize::from(self.prev_queue_len) == self.queue.len()
+        {
+            self.ticks_until_next_state_change =
+                self.ticks_until_next_state_change.saturating_sub(1);
+            return;
+        }
+        self.ticks_until_next_state_change = 0;
+        self.prev_active_layer = active_layer;
+        debug_assert!(self.queue.capacity() < 255);
+        self.prev_queue_len = self.queue.len() as u8;
+
+        self.drain_virtual_keys(drainq);
+        self.drain_releases(drainq);
+        self.process_presses(active_layer);
+    }
+
+    fn drain_virtual_keys(&mut self, drainq: &mut SmolQueue) {
+        self.queue.retain(|qd| {
+            match qd.event {
+                // Only row 0 is real inputs.
+                // Drain other rows (at the time of writing should only be index 1).
+                Event::Press(0, _) | Event::Release(0, _) => true,
+                _ => {
+                    let overflow = drainq.push_back(*qd);
+                    assert!(overflow.is_none(), "oops overflowed drain queue");
+                    false
+                }
+            }
+        });
+    }
+
+    fn drain_releases(&mut self, drainq: &mut SmolQueue) {
+        let achs = &mut self.active_chords;
+        let mut presses = HVec::<_, SMOL_Q_LEN>::new();
+        self.queue.retain(|qd| match qd.event {
+            Event::Press(_, j) => {
+                let overflow = presses.push(j);
+                debug_assert!(overflow.is_ok());
+                true
+            }
+            Event::Release(_, j) => {
+                if presses.contains(&j) {
+                    return true;
+                }
+                achs.iter_mut().for_each(|ach| {
+                    if !ach.participating_keys.contains(&j) {
+                        return;
+                    }
+                    ach.remaining_keys_to_release.retain(|pk| *pk != j);
+                    if ach.remaining_keys_to_release.is_empty() {
+                        ach.status = match ach.status {
+                            Unread | UnreadReleased => UnreadReleased,
+                            Releasable | Released => Released,
+                        }
+                    }
+                });
+                drainq.push_back(*qd);
+                false
+            }
+        })
+    }
+
+    fn process_presses(&mut self, active_layer: u16) {
+        let mut presses = HVec::<u16, SMOL_Q_LEN>::new();
+        let mut relevant_release_found = false;
+        for qd in self.queue.iter() {
+            match qd.event {
+                Event::Press(_, j) => {
+                    let overflowed = presses.push(j);
+                    debug_assert!(overflowed.is_ok(), "too many presses in queue");
+                }
+                Event::Release(_, j) => {
+                    if presses.contains(&j) {
+                        relevant_release_found = true;
+                        break;
+                    }
+                }
+            }
+        }
+        let prev_active_chords_len = self.active_chords.len();
+        let Some(starting_press) = presses.first() else {
+            return;
+        };
+        let Some(possible_chords) = self.chords.mapping.get(starting_press) else {
+            dbg!("no chord activations");
+            no_chord_activations!(self, "no chords for key");
+            return;
+        };
+
+        // For subsequent keypresses,
+        // all must fit into a single chord for chord state to remain pending
+        // instead of activating a chord,
+        // and there must also be a longer chord that can still potentially be activated.
+        //
+        // Prioritization of chord activation:
+        // 1. Timed out chord
+        // 2. Longer chord
+        let mut accumulated_presses = HVec::<u16, SMOL_Q_LEN>::new();
+        let mut chord_candidates = HVec::<&ChordV2<'a, T>, SMOL_Q_LEN>::new();
+        let mut timed_out_chord = Option::<(&ChordV2<'a, T>, u8)>::default();
+        let mut prev_count = usize::MAX;
+        let mut min_timeout;
+
+        assert!(!presses.is_empty());
+        let since = self.queue.iter().next().unwrap().since;
+
+        for press in presses.iter().copied() {
+            min_timeout = u16::MAX;
+            accumulated_presses
+                .push(press)
+                .expect("accpresses same len as presses");
+
+            let count_possible = if prev_count == chord_candidates.len() {
+                // optimization: no longer need to check the whole list.
+                // chord_candidates will keep getting shrunk.
+                chord_candidates.retain(|chc| chc.participating_keys.contains(&press));
+                for chc in chord_candidates.iter() {
+                    min_timeout = std::cmp::min(min_timeout, chc.pending_duration);
+                    if chc.pending_duration <= since
+                        && chc
+                            .participating_keys
+                            .iter()
+                            .all(|pk| accumulated_presses.contains(pk))
+                    {
+                        // Invariant:
+                        // This should only happen at most once per iteration
+                        // due to needing an exact match with accumulated presses.
+                        // Later iterations are "better" choices
+                        // if more than one timed_out_chord is found,
+                        // because they consume more presses.
+                        timed_out_chord = Some((chc, accumulated_presses.len() as u8));
+                    }
+                }
+                chord_candidates.len()
+            } else {
+                chord_candidates.clear();
+                possible_chords
+                    .chords
+                    .iter()
+                    .filter(|pch| !pch.disabled_layers.contains(&active_layer))
+                    .filter(|pch| {
+                        if accumulated_presses
+                            .iter()
+                            .all(|acp| pch.participating_keys.contains(acp))
+                        {
+                            if pch.pending_duration <= since
+                                && pch
+                                    .participating_keys
+                                    .iter()
+                                    .all(|pk| accumulated_presses.contains(pk))
+                            {
+                                // this should only happen at most once per iteration due to needing an exact match.
+                                timed_out_chord = Some((pch, accumulated_presses.len() as u8));
+                            }
+                            // If full, can't run the optimization above, but not fatal.
+                            // Can ignore the overflow.
+                            let _overflow = chord_candidates.push(pch);
+                            min_timeout = std::cmp::min(min_timeout, pch.pending_duration);
+                            true
+                        } else {
+                            false
+                        }
+                    })
+                    .count()
+            };
+
+            match count_possible {
+                1 => {
+                    // Found a chord that is not fully overlapped by another.
+                    // Activate the chord if it is completed
+                    let coord = self.next_coord();
+                    let cch = chord_candidates[0];
+                    if cch
+                        .participating_keys
+                        .iter()
+                        .all(|pk| accumulated_presses.contains(pk))
+                    {
+                        dbg!("got exact chord match");
+                        let ach = get_active_chord(cch, since, coord);
+                        let overflow = self.active_chords.push(ach);
+                        assert!(overflow.is_ok(), "active chords has room");
+                        break;
+                    }
+                }
+                0 => {
+                    // If reached this, it means we went from 2+ -> 0,
+                    // or we got to zero at the first iteration.
+                    // Backtrack one accumulated press then:
+                    // - activate a chord if one completed
+                    // - clear the input queue otherwise
+                    let _ = accumulated_presses.pop();
+                    eprintln!("zero chord candidates left");
+                    chord_candidates.clear();
+                    let completed_chord = possible_chords
+                        .chords
+                        .iter()
+                        .filter(|pch| !pch.disabled_layers.contains(&active_layer))
+                        .find(
+                            // Ensure the two lists have the same set of keys
+                            |pch| {
+                                accumulated_presses
+                                    .iter()
+                                    .all(|acp| pch.participating_keys.contains(acp))
+                                    && pch
+                                        .participating_keys
+                                        .iter()
+                                        .all(|pk| accumulated_presses.contains(pk))
+                            },
+                        );
+                    match completed_chord {
+                        Some(cch) => {
+                            let coord = self.next_coord();
+                            let ach = get_active_chord(cch, since, coord);
+                            let overflow = self.active_chords.push(ach);
+                            assert!(overflow.is_ok(), "active chords has room");
+                        }
+                        None => no_chord_activations!(self, "0 possible chords remaining"),
+                    }
+                    break;
+                }
+                _ => {}
+            }
+            self.ticks_until_next_state_change = dbg!(min_timeout.saturating_sub(since));
+            prev_count = count_possible;
+        }
+        if self.ticks_until_next_state_change == 0 || relevant_release_found {
+            // Find a chord that matches exactly and activate that,
+            // otherwise clear the input queue.
+            let completed_chord = if chord_candidates.is_full() {
+                possible_chords
+                    .chords
+                    .iter()
+                    .filter(|pch| !pch.disabled_layers.contains(&active_layer))
+                    .find(
+                        // Ensure the two lists have the same set of keys
+                        |pch| {
+                            accumulated_presses
+                                .iter()
+                                .all(|acp| pch.participating_keys.contains(acp))
+                                && pch
+                                    .participating_keys
+                                    .iter()
+                                    .all(|pk| accumulated_presses.contains(pk))
+                        },
+                    )
+            } else {
+                chord_candidates
+                    .iter()
+                    .filter(|pch| !pch.disabled_layers.contains(&active_layer))
+                    .find(
+                        // Ensure the two lists have the same set of keys
+                        |pch| {
+                            accumulated_presses
+                                .iter()
+                                .all(|acp| pch.participating_keys.contains(acp))
+                                && pch
+                                    .participating_keys
+                                    .iter()
+                                    .all(|pk| accumulated_presses.contains(pk))
+                        },
+                    )
+            };
+            match completed_chord {
+                Some(cch) => {
+                    let ach = get_active_chord(cch, since, self.next_coord());
+                    let overflow = self.active_chords.push(ach);
+                    assert!(overflow.is_ok(), "active chords has room");
+                }
+                None => {
+                    no_chord_activations!(self, "no completed chord found in no ticks state change")
+                }
+            }
+        }
+
+        if let Some((chord, consumed_presses)) = timed_out_chord {
+            self.queue.drain(0..usize::from(consumed_presses));
+            let ach = get_active_chord(chord, since, self.next_coord());
+            let overflow = self.active_chords.push(ach);
+            assert!(overflow.is_ok(), "active chords has room");
+        }
+
+        // Clear presses from the queue if they were consumed by a chord.
+        if self.active_chords.len() > prev_active_chords_len {
+            self.queue.retain(|qd| match qd.event {
+                Event::Press(_, j) => !accumulated_presses.contains(&j),
+                _ => true,
+            });
+        }
+    }
+
+    fn clear_released_chords(&mut self, drainq: &mut SmolQueue) {
+        self.active_chords.retain(|ach| {
+            if ach.status == Released {
+                let overflow = drainq.push_back(Queued {
+                    event: Event::Release(0, ach.coordinate),
+                    since: 0,
+                });
+                assert!(overflow.is_none(), "oops overflowed drain queue");
+                false
+            } else {
+                true
+            }
+        });
+    }
+}
+
+fn get_active_chord<'a, T>(cch: &ChordV2<'a, T>, since: u16, coord: u16) -> ActiveChord<'a, T> {
+    let mut remaining_keys_to_release = HVec::new();
+    if cch.release_behaviour == ReleaseBehaviour::OnLastRelease {
+        remaining_keys_to_release.extend(cch.participating_keys.iter().copied());
+    };
+    ActiveChord {
+        coordinate: coord,
+        remaining_keys_to_release,
+        participating_keys: cch.participating_keys,
+        action: cch.action,
+        status: ActiveChordStatus::Unread,
+        delay: since,
+    }
+}

--- a/keyberon/src/chord.rs
+++ b/keyberon/src/chord.rs
@@ -170,6 +170,10 @@ impl<'a, T> ChordsV2<'a, T> {
         self.queue.push_back(item)
     }
 
+    pub fn chords(&self) -> &ChordsForKeys<'a, T> {
+        &self.chords
+    }
+
     pub(crate) fn get_action_chv2(&mut self) -> (QueuedAction<'a, T>, bool) {
         match self
             .active_chords

--- a/keyberon/src/chord.rs
+++ b/keyberon/src/chord.rs
@@ -486,7 +486,8 @@ impl<'a, T> ChordsV2<'a, T> {
             };
             match completed_chord {
                 Some(cch) => {
-                    let ach = get_active_chord(cch, since, self.next_coord(), relevant_release_found);
+                    let ach =
+                        get_active_chord(cch, since, self.next_coord(), relevant_release_found);
                     let overflow = self.active_chords.push(ach);
                     assert!(overflow.is_ok(), "active chords has room");
                 }
@@ -528,7 +529,12 @@ impl<'a, T> ChordsV2<'a, T> {
     }
 }
 
-fn get_active_chord<'a, T>(cch: &ChordV2<'a, T>, since: u16, coord: u16, release_found: bool) -> ActiveChord<'a, T> {
+fn get_active_chord<'a, T>(
+    cch: &ChordV2<'a, T>,
+    since: u16,
+    coord: u16,
+    release_found: bool,
+) -> ActiveChord<'a, T> {
     let mut remaining_keys_to_release = HVec::new();
     if cch.release_behaviour == ReleaseBehaviour::OnLastRelease {
         remaining_keys_to_release.extend(cch.participating_keys.iter().copied());

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -22,6 +22,7 @@
 /// to do when not using a macro.
 pub use kanata_keyberon_macros::*;
 
+use crate::chord::*;
 use crate::key_code::KeyCode;
 use crate::{action::*, multikey_buffer::MultiKeyBuffer};
 use arraydeque::ArrayDeque;
@@ -56,7 +57,7 @@ fn check_queue_size() {
 /// The current event queue.
 ///
 /// Events can be retrieved by iterating over this struct and calling [Queued::event].
-type Queue = ArrayDeque<Queued, QUEUE_SIZE, arraydeque::behavior::Wrapping>;
+pub(crate) type Queue = ArrayDeque<Queued, QUEUE_SIZE, arraydeque::behavior::Wrapping>;
 
 /// A list of queued press events. Used for special handling of potentially multiple press events
 /// that occur during a Waiting event.
@@ -73,7 +74,7 @@ pub const ACTION_QUEUE_LEN: usize = 8;
 type ActionQueue<'a, T> =
     ArrayDeque<QueuedAction<'a, T>, ACTION_QUEUE_LEN, arraydeque::behavior::Wrapping>;
 type Delay = u16;
-type QueuedAction<'a, T> = Option<(KCoord, Delay, &'a Action<'a, T>)>;
+pub(crate) type QueuedAction<'a, T> = Option<(KCoord, Delay, &'a Action<'a, T>)>;
 
 const HISTORICAL_EVENT_LEN: usize = 8;
 const EXTRA_WAITING_LEN: usize = 8;
@@ -107,6 +108,8 @@ where
     pub historical_keys: History<KeyCode>,
     pub historical_inputs: History<KCoord>,
     pub quick_tap_hold_timeout: bool,
+    // TODO: if below is Some(), quick_tap_hold_timeout should be true
+    pub chords_v2: Option<ChordsV2<'a, T>>,
     rpt_multikey_key_buffer: MultiKeyBuffer<'a, T>,
     trans_resolution_behavior_v2: bool,
 }
@@ -155,7 +158,7 @@ where
         }
     }
 
-    fn tick(&mut self) {
+    fn tick_hist(&mut self) {
         let ticks = self.ticks_since_occurrences.as_uninit_slice_mut();
         for tick_count in ticks {
             unsafe {
@@ -338,9 +341,6 @@ impl<'a, T: 'a> State<'a, T> {
             _ => None,
         }
     }
-    fn tick(&self) -> Option<Self> {
-        Some(*self)
-    }
     /// Returns None if the key has been released and Some otherwise.
     pub fn release(&self, c: KCoord, custom: &mut CustomEvent<'a, T>) -> Option<Self> {
         match *self {
@@ -408,7 +408,7 @@ pub struct TapDanceEagerState<'a, T: 'a> {
 }
 
 impl<'a, T> TapDanceEagerState<'a, T> {
-    fn tick(&mut self) {
+    fn tick_tde(&mut self) {
         self.timeout = self.timeout.saturating_sub(1);
     }
 
@@ -461,7 +461,7 @@ pub enum WaitingAction {
 }
 
 impl<'a, T: std::fmt::Debug> WaitingState<'a, T> {
-    fn tick(
+    fn tick_wt(
         &mut self,
         queued: &mut Queue,
         action_queue: &mut ActionQueue<'a, T>,
@@ -914,7 +914,7 @@ enum OneShotHandlePressKey {
 }
 
 impl OneShotState {
-    fn tick(&mut self) -> Option<ReleasedOneShotKeys> {
+    fn tick_osh(&mut self) -> Option<ReleasedOneShotKeys> {
         if self.keys.is_empty() {
             return None;
         }
@@ -1007,8 +1007,8 @@ impl<'a> Iterator for QueuedIter<'a> {
 /// An event, waiting in a queue to be processed.
 #[derive(Debug, Copy, Clone)]
 pub struct Queued {
-    event: Event,
-    since: u16,
+    pub(crate) event: Event,
+    pub(crate) since: u16,
 }
 impl From<Event> for Queued {
     fn from(event: Event) -> Self {
@@ -1016,7 +1016,7 @@ impl From<Event> for Queued {
     }
 }
 impl Queued {
-    fn tick(&mut self) {
+    pub(crate) fn tick_qd(&mut self) {
         self.since = self.since.saturating_add(1);
     }
 
@@ -1033,7 +1033,7 @@ pub struct LastPressTracker {
 }
 
 impl LastPressTracker {
-    fn tick(&mut self) {
+    fn tick_lpt(&mut self) {
         self.tap_hold_timeout = self.tap_hold_timeout.saturating_sub(1);
     }
 }
@@ -1070,6 +1070,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
             rpt_multikey_key_buffer: unsafe { MultiKeyBuffer::new() },
             quick_tap_hold_timeout: false,
             trans_resolution_behavior_v2: true,
+            chords_v2: None,
         }
     }
     pub fn new_with_trans_action_settings(
@@ -1239,6 +1240,14 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
     /// Returns the corresponding `CustomEvent`, allowing to manage
     /// custom actions thanks to the `Action::Custom` variant.
     pub fn tick(&mut self) -> CustomEvent<'a, T> {
+        let active_layer = self
+            .trans_resolution_layer_order()
+            .into_iter()
+            .next()
+            .expect("there must always be an active layer");
+        if let Some(chv2) = self.chords_v2.as_mut() {
+            self.queue.extend(chv2.tick_chv2(active_layer).drain(0..));
+        }
         if let Some(Some((coord, delay, action))) = self.action_queue.pop_front() {
             // If there's anything in the action queue, don't process anything else yet - execute
             // everything. Otherwise an action may never be released.
@@ -1250,22 +1259,21 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
                 &mut self.trans_resolution_layer_order().into_iter().skip(1),
             );
         }
-        self.states = self.states.iter().filter_map(State::tick).collect();
-        self.queue.iter_mut().for_each(Queued::tick);
-        self.last_press_tracker.tick();
+        self.queue.iter_mut().for_each(Queued::tick_qd);
+        self.last_press_tracker.tick_lpt();
         if let Some(ref mut tde) = self.tap_dance_eager {
-            tde.tick();
+            tde.tick_tde();
             if tde.is_expired() {
                 self.tap_dance_eager = None;
             }
         }
         self.process_sequences();
 
-        self.historical_keys.tick();
-        self.historical_inputs.tick();
+        self.historical_keys.tick_hist();
+        self.historical_inputs.tick_hist();
 
         let mut custom = CustomEvent::NoEvent;
-        if let Some(released_keys) = self.oneshot.tick() {
+        if let Some(released_keys) = self.oneshot.tick_osh() {
             for key in released_keys.iter() {
                 custom.update(self.dequeue(Queued {
                     event: Event::Release(key.0, key.1),
@@ -1275,7 +1283,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
         }
 
         custom.update(match &mut self.waiting {
-            Some(w) => match w.tick(&mut self.queue, &mut self.action_queue) {
+            Some(w) => match w.tick_wt(&mut self.queue, &mut self.action_queue) {
                 Some((WaitingAction::Hold, _)) => self.waiting_into_hold(-1),
                 Some((WaitingAction::Tap, pq)) => self.waiting_into_tap(pq, -1),
                 Some((WaitingAction::Timeout, _)) => self.waiting_into_timeout(-1),
@@ -1284,6 +1292,18 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
             },
             None => {
                 if self.extra_waiting.is_empty() {
+                    // If no tap-holds, v2 chords, tap-dance waiting,
+                    // then can run chord actions.
+                    if let Some(ch) = self.chords_v2.as_mut() {
+                        if let (qac @ Some(_), pause_input_processing) = ch.get_action_chv2() {
+                            self.action_queue.push_back(qac);
+                            if pause_input_processing {
+                                self.oneshot.pause_input_processing_ticks =
+                                    self.oneshot.on_press_release_delay;
+                            }
+                        }
+                    }
+
                     // Due to the possible delay in the key release for EndOnFirstPress
                     // because some apps/DEs do not handle it properly if done too quickly,
                     // undesirable behaviour of extra presses making it in before
@@ -1406,17 +1426,17 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
         }
         let mut waiting_action = (0, None);
         for (i, w) in self.extra_waiting.iter_mut().enumerate() {
-            match w.tick(&mut self.queue, &mut self.action_queue) {
+            match w.tick_wt(&mut self.queue, &mut self.action_queue) {
                 None => {}
                 wa => {
                     waiting_action = (i as isize, wa);
                     // break - only complete one at a time even if potentially multiple have
                     // completed, so that only one custom event is returned.
                     //
-                    // Theoretically if we could call the waiting_into_* function, we could do that
+                    // Theoretically if we could call the waiting_into_* functions, we could do that
                     // here and break only if custom is None, but that runs into mutability
-                    // problems. I don't expect any measurable improvements from being able to do
-                    // that too.
+                    // problems. I don't expect any perceptible degradation between from not doing
+                    // the above.
                     break;
                 }
             }
@@ -1507,11 +1527,15 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
         if let Event::Press(x, y) = event {
             self.historical_inputs.push_front((x, y));
         }
-        if let Some(queued) = self.queue.push_back(event.into()) {
+        if let Some(overflow) = if let Some(ch) = self.chords_v2.as_mut() {
+            ch.push_back_chv2(event.into())
+        } else {
+            self.queue.push_back(event.into())
+        } {
             for i in -1..(EXTRA_WAITING_LEN as i8) {
                 self.waiting_into_hold(i);
             }
-            self.dequeue(queued);
+            self.dequeue(overflow);
         }
     }
     /// Resolve coordinate to first non-Trans actions.

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -1245,8 +1245,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
             if let (qac @ Some(_), pause_input_processing) = chv2.get_action_chv2() {
                 self.action_queue.push_back(qac);
                 if pause_input_processing {
-                    self.oneshot.pause_input_processing_ticks =
-                        self.oneshot.on_press_release_delay;
+                    self.oneshot.pause_input_processing_ticks = self.oneshot.on_press_release_delay;
                 }
             }
         }

--- a/keyberon/src/lib.rs
+++ b/keyberon/src/lib.rs
@@ -2,6 +2,7 @@
 //! Please make contributions to the original project.
 
 pub mod action;
+pub mod chord;
 pub mod key_code;
 pub mod layout;
 mod multikey_buffer;

--- a/parser/src/cfg/chord.rs
+++ b/parser/src/cfg/chord.rs
@@ -1,0 +1,115 @@
+use kanata_keyberon::chord::{ChordV2, ChordsForKey, ChordsForKeys, ReleaseBehaviour};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{anyhow_expr, bail_expr};
+
+use super::*;
+
+pub(crate) fn parse_defchordv2(
+    exprs: &[SExpr],
+    s: &ParserState,
+) -> Result<ChordsForKeys<'static, KanataCustom>> {
+    let mut chunks = exprs[1..].chunks_exact(5);
+    let mut all_chords = FxHashSet::default();
+    let mut chords_container = ChordsForKeys::<'static, KanataCustom> {
+        mapping: FxHashMap::default(),
+    };
+    for chunk in chunks.by_ref() {
+        let keys = &chunk[0];
+
+        let mut participants = keys
+            .list(s.vars())
+            .map(|l| {
+                l.iter()
+                    .try_fold(vec![], |mut keys, key| -> Result<Vec<u16>> {
+                        let k = key.atom(s.vars()).and_then(str_to_oscode).ok_or_else(|| {
+                            anyhow_expr!(
+                                key,
+                                "The first chord item must be a list of keys.\nInvalid key name."
+                            )
+                        })?;
+                        keys.push(k.into());
+                        Ok(keys)
+                    })
+            })
+            .ok_or_else(|| anyhow_expr!(keys, "The first chord item must be a list of keys."))??;
+        if participants.len() < 2 {
+            bail_expr!(keys, "The minimum number of participating chord keys is 2");
+        }
+        participants.sort();
+        if !all_chords.insert(participants.clone()) {
+            bail_expr!(
+                keys,
+                "This chord has previously been defined.\n\
+                Only one set of chords must exist."
+            );
+        }
+
+        let action = parse_action(&chunk[1], s)?;
+        let timeout = parse_non_zero_u16(&chunk[2], s, "chord timeout")?;
+        let release_behaviour = chunk[3]
+            .atom(s.vars())
+            .and_then(|r| {
+                Some(match r {
+                    "first-release" => ReleaseBehaviour::OnFirstRelease,
+                    "last-release" => ReleaseBehaviour::OnLastRelease,
+                    _ => return None,
+                })
+            })
+            .ok_or_else(|| {
+                anyhow_expr!(
+                    &chunk[3],
+                    "Chord release behaviour must be one of:\n\
+                first-release | last-release"
+                )
+            })?;
+
+        let disabled_layers = &chunk[4];
+        let disabled_layers = disabled_layers
+            .list(s.vars())
+            .map(|dl| {
+                dl.iter()
+                    .try_fold(vec![], |mut layers, layer| -> Result<Vec<u16>> {
+                        let l_idx = layer
+                            .atom(s.vars())
+                            .and_then(|l| s.layer_idxs.get(l))
+                            .ok_or_else(|| anyhow_expr!(layer, "Not a known layer name."))?;
+                        layers.push((*l_idx * 2) as u16);
+                        layers.push((*l_idx * 2 + 1) as u16);
+                        Ok(layers)
+                    })
+            })
+            .ok_or_else(|| {
+                anyhow_expr!(
+                    disabled_layers,
+                    "Disabled layers must be a list of layer names"
+                )
+            })??;
+        let chord = ChordV2 {
+            action,
+            participating_keys: s.a.sref_vec(participants.clone()),
+            pending_duration: timeout,
+            disabled_layers: s.a.sref_vec(disabled_layers),
+            release_behaviour,
+        };
+        let chord = s.a.sref(chord);
+        for pkey in participants.iter().copied() {
+            log::trace!("chord for key:{pkey:?} > {chord:?}");
+            chords_container
+                .mapping
+                .entry(pkey)
+                .or_insert(ChordsForKey { chords: vec![] })
+                .chords
+                .push(chord);
+        }
+    }
+    let rem = chunks.remainder();
+    if !rem.is_empty() {
+        bail_expr!(
+            rem.last().unwrap(),
+            "Incomplete chord entry. Each chord entry must have 5 items:\n\
+        particpating-keys, action, timeout, release-type, disabled-layers"
+        );
+    }
+    Ok(chords_container)
+}

--- a/parser/src/cfg/chord.rs
+++ b/parser/src/cfg/chord.rs
@@ -41,7 +41,7 @@ pub(crate) fn parse_defchordv2(
             bail_expr!(
                 keys,
                 "This chord has previously been defined.\n\
-                Only one set of chords must exist."
+                Only one set of chords must exist for one key combination."
             );
         }
 

--- a/parser/src/cfg/chord.rs
+++ b/parser/src/cfg/chord.rs
@@ -52,7 +52,7 @@ pub(crate) fn parse_defchordv2(
             .and_then(|r| {
                 Some(match r {
                     "first-release" => ReleaseBehaviour::OnFirstRelease,
-                    "last-release" => ReleaseBehaviour::OnLastRelease,
+                    "all-released" => ReleaseBehaviour::OnLastRelease,
                     _ => return None,
                 })
             })
@@ -60,7 +60,7 @@ pub(crate) fn parse_defchordv2(
                 anyhow_expr!(
                     &chunk[3],
                     "Chord release behaviour must be one of:\n\
-                first-release | last-release"
+                first-release | all-released"
                 )
             })?;
 

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -23,6 +23,7 @@ pub struct CfgOptions {
     pub concurrent_tap_hold: bool,
     pub rapid_event_delay: u16,
     pub trans_resolution_behavior_v2: bool,
+    pub chords_v2_min_idle: u16,
     #[cfg(any(target_os = "linux", target_os = "unknown"))]
     pub linux_dev: Vec<String>,
     #[cfg(any(target_os = "linux", target_os = "unknown"))]
@@ -71,6 +72,7 @@ impl Default for CfgOptions {
             concurrent_tap_hold: false,
             rapid_event_delay: 5,
             trans_resolution_behavior_v2: true,
+            chords_v2_min_idle: 5,
             #[cfg(any(target_os = "linux", target_os = "unknown"))]
             linux_dev: vec![],
             #[cfg(any(target_os = "linux", target_os = "unknown"))]
@@ -431,6 +433,13 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                                 v
                             ),
                         };
+                    }
+                    "chords-v2-min-idle-experimental" => {
+                        let min_idle = parse_cfg_val_u16(val, label, true)?;
+                        if min_idle < 5 {
+                            bail_expr!(val, "{label} must be 5-65535");
+                        }
+                        cfg.chords_v2_min_idle = min_idle;
                     }
                     _ => bail_expr!(key, "Unknown defcfg option {}", label),
                 };

--- a/parser/src/cfg/fake_key.rs
+++ b/parser/src/cfg/fake_key.rs
@@ -4,7 +4,7 @@ use crate::{anyhow_expr, bail, bail_expr};
 
 pub(crate) fn parse_on_press_fake_key_op(
     ac_params: &[SExpr],
-    s: &ParsedState,
+    s: &ParserState,
 ) -> Result<&'static KanataAction> {
     let (coord, action) = parse_fake_key_op_coord_action(ac_params, s, ON_PRESS_FAKEKEY)?;
     Ok(s.a.sref(Action::Custom(
@@ -14,7 +14,7 @@ pub(crate) fn parse_on_press_fake_key_op(
 
 pub(crate) fn parse_on_release_fake_key_op(
     ac_params: &[SExpr],
-    s: &ParsedState,
+    s: &ParserState,
 ) -> Result<&'static KanataAction> {
     let (coord, action) = parse_fake_key_op_coord_action(ac_params, s, ON_RELEASE_FAKEKEY)?;
     Ok(s.a.sref(Action::Custom(s.a.sref(
@@ -24,7 +24,7 @@ pub(crate) fn parse_on_release_fake_key_op(
 
 pub(crate) fn parse_on_idle_fakekey(
     ac_params: &[SExpr],
-    s: &ParsedState,
+    s: &ParserState,
 ) -> Result<&'static KanataAction> {
     const ERR_MSG: &str =
         "on-idle-fakekey expects three parameters:\n<fake key name> <(tap|press|release)> <idle time>\n";
@@ -77,7 +77,7 @@ pub(crate) fn parse_on_idle_fakekey(
 
 fn parse_fake_key_op_coord_action(
     ac_params: &[SExpr],
-    s: &ParsedState,
+    s: &ParserState,
     ac_name: &str,
 ) -> Result<(Coord, FakeKeyAction)> {
     const ERR_MSG: &str = "expects two parameters: <fake key name> <(tap|press|release|toggle)>";
@@ -128,14 +128,14 @@ pub(crate) fn get_fake_key_coords<T: Into<usize>>(y: T) -> (u8, u16) {
 
 pub(crate) fn parse_fake_key_delay(
     ac_params: &[SExpr],
-    s: &ParsedState,
+    s: &ParserState,
 ) -> Result<&'static KanataAction> {
     parse_delay(ac_params, false, s)
 }
 
 pub(crate) fn parse_on_release_fake_key_delay(
     ac_params: &[SExpr],
-    s: &ParsedState,
+    s: &ParserState,
 ) -> Result<&'static KanataAction> {
     parse_delay(ac_params, true, s)
 }
@@ -143,7 +143,7 @@ pub(crate) fn parse_on_release_fake_key_delay(
 fn parse_delay(
     ac_params: &[SExpr],
     is_release: bool,
-    s: &ParsedState,
+    s: &ParserState,
 ) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "fakekey-delay expects a single number (ms, 0-65535)";
     log::warn!("The configuration contains a fakekey-delay action. This is broken for many use cases. It is recommended to use macro instead.");
@@ -159,7 +159,7 @@ fn parse_delay(
         })))))
 }
 
-fn parse_vkey_coord(param: &SExpr, s: &ParsedState) -> Result<Coord> {
+fn parse_vkey_coord(param: &SExpr, s: &ParserState) -> Result<Coord> {
     let name = param
         .atom(s.vars())
         .ok_or_else(|| anyhow_expr!(param, "key-name must not be a list",))?;
@@ -171,7 +171,7 @@ fn parse_vkey_coord(param: &SExpr, s: &ParsedState) -> Result<Coord> {
     Ok(coord)
 }
 
-fn parse_vkey_action(param: &SExpr, s: &ParsedState) -> Result<FakeKeyAction> {
+fn parse_vkey_action(param: &SExpr, s: &ParserState) -> Result<FakeKeyAction> {
     let action = param
         .atom(s.vars())
         .and_then(|ac| {
@@ -195,7 +195,7 @@ fn parse_vkey_action(param: &SExpr, s: &ParsedState) -> Result<FakeKeyAction> {
 
 pub(crate) fn parse_on_press(
     ac_params: &[SExpr],
-    s: &ParsedState,
+    s: &ParserState,
 ) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "on-press expects two parameters: <action> <key-name>";
     if ac_params.len() != 2 {
@@ -211,7 +211,7 @@ pub(crate) fn parse_on_press(
 
 pub(crate) fn parse_on_release(
     ac_params: &[SExpr],
-    s: &ParsedState,
+    s: &ParserState,
 ) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "on-press expects two parameters: <action> <key-name>";
     if ac_params.len() != 2 {
@@ -225,7 +225,7 @@ pub(crate) fn parse_on_release(
     ))))
 }
 
-pub(crate) fn parse_on_idle(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
+pub(crate) fn parse_on_idle(ac_params: &[SExpr], s: &ParserState) -> Result<&'static KanataAction> {
     const ERR_MSG: &str = "on-idle expects three parameters: <timeout> <action> <key-name>";
     if ac_params.len() != 3 {
         bail!("{ERR_MSG}");

--- a/parser/src/cfg/switch.rs
+++ b/parser/src/cfg/switch.rs
@@ -2,7 +2,7 @@ use super::sexpr::*;
 use super::*;
 use crate::{anyhow_expr, bail, bail_expr};
 
-pub fn parse_switch(ac_params: &[SExpr], s: &ParsedState) -> Result<&'static KanataAction> {
+pub fn parse_switch(ac_params: &[SExpr], s: &ParserState) -> Result<&'static KanataAction> {
     const ERR_STR: &str =
         "switch expects triples of params: <key match> <action> <break|fallthrough>";
 
@@ -55,7 +55,7 @@ pub fn parse_switch_case_bool(
     depth: u8,
     op_expr: &SExpr,
     ops: &mut Vec<OpCode>,
-    s: &ParsedState,
+    s: &ParserState,
 ) -> Result<()> {
     if ops.len() > MAX_OPCODE_LEN as usize {
         bail_expr!(

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -2175,7 +2175,7 @@ fn parse_platform_specific() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (platform () (invalid config but is not used anywhere))
 (defsrc)

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -35,7 +35,7 @@ fn span_works_with_unicode_characters() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"(defsrc a) ;; 😊
 (deflayer base @😊)
 "#;
@@ -70,7 +70,7 @@ fn test_multiline_error_span() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"(defsrc a)
 (
   🍍
@@ -107,7 +107,7 @@ fn test_span_of_an_unterminated_block_comment_error() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"(defsrc a) |# I'm an unterminated block comment..."#;
     let span = parse_cfg_raw_string(
         source,
@@ -138,7 +138,7 @@ fn parse_action_vars() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defvar
   one 1
@@ -221,7 +221,7 @@ fn parse_delegate_to_default_layer_yes() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defcfg delegate-to-first-layer yes)
 (defsrc a)
@@ -251,7 +251,7 @@ fn parse_delegate_to_default_layer_yes_but_base_transparent() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defcfg delegate-to-first-layer yes)
 (defsrc a)
@@ -281,7 +281,7 @@ fn parse_delegate_to_default_layer_no() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defcfg delegate-to-first-layer no)
 (defsrc a)
@@ -311,7 +311,7 @@ fn parse_transparent_default() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let icfg = parse_cfg_raw(
         &std::path::PathBuf::from("./test_cfgs/transparent_default.kbd"),
         &mut s,
@@ -479,7 +479,7 @@ fn recursive_multi_is_flattened() {
             list!([atom!("multi"), atom!("c"), atom!("mrtp"),])
         ]),
     ];
-    let s = ParsedState::default();
+    let s = ParserState::default();
     if let KanataAction::MultipleActions(parsed_multi) = parse_multi(&params, &s).unwrap() {
         assert_eq!(parsed_multi.len(), 4);
         assert_eq!(parsed_multi[0], Action::KeyCode(KeyCode::A));
@@ -504,7 +504,7 @@ fn recursive_multi_is_flattened() {
 fn test_parse_sequence_a_b() {
     let seq = parse_sequence_keys(
         &parse("(a b)", "test").expect("parses")[0].t,
-        &ParsedState::default(),
+        &ParserState::default(),
     )
     .expect("parses");
     assert_eq!(seq.len(), 2);
@@ -516,7 +516,7 @@ fn test_parse_sequence_a_b() {
 fn test_parse_sequence_sa_b() {
     let seq = parse_sequence_keys(
         &parse("(S-a b)", "test").expect("parses")[0].t,
-        &ParsedState::default(),
+        &ParserState::default(),
     )
     .expect("parses");
     assert_eq!(seq.len(), 3);
@@ -529,7 +529,7 @@ fn test_parse_sequence_sa_b() {
 fn test_parse_sequence_sab() {
     let seq = parse_sequence_keys(
         &parse("(S-(a b))", "test").expect("parses")[0].t,
-        &ParsedState::default(),
+        &ParserState::default(),
     )
     .expect("parses");
     assert_eq!(seq.len(), 3);
@@ -542,7 +542,7 @@ fn test_parse_sequence_sab() {
 fn test_parse_sequence_bigchord() {
     let seq = parse_sequence_keys(
         &parse("(AG-A-M-C-S-(a b) c)", "test").expect("parses")[0].t,
-        &ParsedState::default(),
+        &ParserState::default(),
     )
     .expect("parses");
     assert_eq!(seq.len(), 8);
@@ -560,7 +560,7 @@ fn test_parse_sequence_bigchord() {
 fn test_parse_sequence_inner_chord() {
     let seq = parse_sequence_keys(
         &parse("(S-(a b C-c) d)", "test").expect("parses")[0].t,
-        &ParsedState::default(),
+        &ParserState::default(),
     )
     .expect("parses");
     assert_eq!(seq.len(), 6);
@@ -576,7 +576,7 @@ fn test_parse_sequence_inner_chord() {
 fn test_parse_sequence_earlier_inner_chord() {
     let seq = parse_sequence_keys(
         &parse("(S-(a C-b c) d)", "test").expect("parses")[0].t,
-        &ParsedState::default(),
+        &ParserState::default(),
     )
     .expect("parses");
     assert_eq!(seq.len(), 6);
@@ -592,7 +592,7 @@ fn test_parse_sequence_earlier_inner_chord() {
 fn test_parse_sequence_numbers() {
     let seq = parse_sequence_keys(
         &parse("(0 1 2 3 4 5 6 7 8 9)", "test").expect("parses")[0].t,
-        &ParsedState::default(),
+        &ParserState::default(),
     )
     .expect("parses");
     assert_eq!(seq.len(), 10);
@@ -618,7 +618,7 @@ fn test_parse_macro_numbers() {
     let mut i = 1;
     while !expr_rem.is_empty() {
         let (macro_events, expr_rem_tmp) =
-            parse_macro_item(expr_rem, &ParsedState::default()).expect("parses");
+            parse_macro_item(expr_rem, &ParserState::default()).expect("parses");
         expr_rem = expr_rem_tmp;
         assert_eq!(macro_events.len(), 1);
         match &macro_events[0] {
@@ -629,7 +629,7 @@ fn test_parse_macro_numbers() {
     }
 
     let exprs = parse("(0)", "test").expect("parses")[0].t.clone();
-    parse_macro_item(exprs.as_slice(), &ParsedState::default()).expect_err("errors");
+    parse_macro_item(exprs.as_slice(), &ParserState::default()).expect_err("errors");
 }
 
 #[test]
@@ -697,7 +697,7 @@ fn parse_bad_submacro() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defsrc a)
 (deflayer base
@@ -729,7 +729,7 @@ fn parse_bad_submacro_2() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defsrc a)
 (deflayer base
@@ -761,7 +761,7 @@ fn parse_nested_macro() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defvar m1 (a b c))
 (defsrc a b)
@@ -793,7 +793,7 @@ fn parse_switch() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defvar var1 a)
 (defsrc a)
@@ -948,7 +948,7 @@ fn parse_switch_exceed_depth() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defsrc a)
 (deflayer base
@@ -981,7 +981,7 @@ fn parse_virtualkeys() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defvar var1 a)
 (defsrc a b c d e f g h i j k l m n o p)
@@ -1069,7 +1069,7 @@ fn parse_on_idle_fakekey() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defvar var1 a)
 (defsrc a b c d e f g h i)
@@ -1121,7 +1121,7 @@ fn parse_on_idle_fakekey_errors() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defvar var1 a)
 (defsrc a)
@@ -1225,7 +1225,7 @@ fn parse_on_idle_fakekey_errors() {
 
 #[test]
 fn parse_fake_keys_errors_on_too_many() {
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let mut checked_for_err = false;
     for n in 0..1000 {
         let exprs = [&vec![
@@ -1362,7 +1362,7 @@ new 316
 (defsrc + [  ]  {  }  /  ;  `  =  -  '  ,  .  \  yen ¥ new)
 (deflayer base + [  ]  {  }  /  ;  `  =  -  '  ,  .  \  yen ¥ new)
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -1386,7 +1386,7 @@ fn use_default_overridable_mappings() {
 (defsrc + [  ]  a  b  /  ;  `  =  -  '  ,  .  9  yen ¥  )
 (deflayer base + [  ]  {  }  /  ;  `  =  -  '  ,  .  \  yen ¥  )
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -1406,7 +1406,7 @@ fn list_action_not_in_list_error_message_is_good() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defsrc a)
 (defalias hello
@@ -1547,7 +1547,7 @@ fn parse_all_defcfg() {
 (defsrc a)
 (deflayer base a)
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -1577,7 +1577,7 @@ fn parse_unmod() {
   (unshift a b)
 )
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -1597,7 +1597,7 @@ fn using_parentheses_in_deflayer_directly_fails_with_custom_message() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defsrc a b)
 (deflayer base ( ))
@@ -1624,7 +1624,7 @@ fn using_escaped_parentheses_in_deflayer_fails_with_custom_message() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let source = r#"
 (defsrc a b)
 (deflayer base \( \))
@@ -1668,7 +1668,7 @@ fn parse_cmd() {
     3 (cmd $x $y ($z))
 )
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -1707,7 +1707,7 @@ fn parse_defvar_concat() {
     otherpath (concat $rootpath "/helloworld")
 )
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -1785,7 +1785,7 @@ fn parse_template_1() {
   lctl lmet lalt           spc            ralt rmet rctl
 )
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -1840,7 +1840,7 @@ fn parse_template_2() {
 (deflayer dvorak @dva @dvo @dve @dvu)
 (deflayer qwerty @qwa @qws @qwd @qwf)
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -1888,7 +1888,7 @@ fn parse_template_3() {
   lctl lmet lalt           spc            ralt rmet rctl
 )
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -1928,7 +1928,7 @@ fn parse_template_4() {
   (template-expand home-row v2)
 )
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -1968,7 +1968,7 @@ fn parse_template_5() {
   (template-expand home-row v2)
 )
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -2008,7 +2008,7 @@ fn parse_template_6() {
   (template-expand home-row v2)
 )
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -2048,7 +2048,7 @@ fn parse_template_7() {
   (template-expand home-row v2)
 )
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -2084,7 +2084,7 @@ fn test_deflayermap() {
   m      >>  4
 )
 "#;
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -2114,7 +2114,7 @@ fn test_defaliasenvcond() {
 "#;
 
     let env_var_err = "env vars not implemented";
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     let parse_err = parse_cfg_raw_string(
         source,
         &mut s,
@@ -2130,7 +2130,7 @@ fn test_defaliasenvcond() {
 
     // now test with env vars implemented
 
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,
@@ -2150,7 +2150,7 @@ fn test_defaliasenvcond() {
 
     // test env var set but to a different value
 
-    let mut s = ParsedState::default();
+    let mut s = ParserState::default();
     parse_cfg_raw_string(
         source,
         &mut s,

--- a/simulated_input/src/sim.rs
+++ b/simulated_input/src/sim.rs
@@ -89,7 +89,7 @@ fn log_init() {
     };
     log_cfg.set_time_format_rfc3339();
     CombinedLogger::init(vec![TermLogger::new(
-        LevelFilter::Debug,
+        LevelFilter::Info,
         log_cfg.build(),
         TerminalMode::Stderr,
         ColorChoice::AlwaysAnsi,

--- a/src/oskbd/simulated.rs
+++ b/src/oskbd/simulated.rs
@@ -246,7 +246,7 @@ impl LogFmt {
     }
 
     pub fn end(&self, in_path: &PathBuf, appendix: Option<String>) {
-        let pad = self.combo.len() - 3;
+        let pad = self.combo.len().saturating_sub(3);
         let table_out = formatdoc!(
             "🕐Δms│{}
           In───┼{:─<pad$}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,9 @@
 use kanata_parser::cfg::*;
 use std::sync::Mutex;
 
+#[cfg(all(feature = "simulated_output", not(target_os = "macos")))]
+mod sim_tests;
+
 static CFG_PARSE_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,11 @@
 use kanata_parser::cfg::*;
 use std::sync::Mutex;
 
-#[cfg(all(feature = "simulated_output", not(target_os = "macos")))]
+#[cfg(all(
+    feature = "simulated_output",
+    not(target_os = "macos"),
+    not(feature = "interception_driver")
+))]
 mod sim_tests;
 
 static CFG_PARSE_LOCK: Mutex<()> = Mutex::new(());

--- a/src/tests/sim_tests.rs
+++ b/src/tests/sim_tests.rs
@@ -55,7 +55,7 @@ static SIMPLE_NONOVERLAPPING_CHORD_CFG: &str = "\
 (defsrc) \
 (deflayer base) \
 (defchordsv2-experimental \
-  (a b) c 200 last-release () \
+  (a b) c 200 all-released () \
   (b z) d 200 first-release () \
 )";
 
@@ -121,7 +121,7 @@ static SIMPLE_OVERLAPPING_CHORD_CFG: &str = "\
 (defsrc)
 (deflayer base)
 (defchordsv2-experimental
-  (a b) c 200 last-release ()
+  (a b) c 200 all-released ()
   (a b z) d 250 first-release ()
   (a b z y) e 400 first-release ()
 )";
@@ -178,9 +178,9 @@ static SIMPLE_DISABLED_LAYER_CHORD_CFG: &str = "\
 (deflayermap (3) 2 : (layer-while-held 2)
                  1 : (layer-while-held 1))
 (defchordsv2-experimental
-  (a b) x 200 last-release (1)
-  (c d) y 200 last-release (2)
-  (e f) z 200 last-release (3)
+  (a b) x 200 all-released (1)
+  (c d) y 200 all-released (2)
+  (e f) z 200 all-released (3)
 )";
 
 #[test]
@@ -274,7 +274,7 @@ static CHORD_INTO_TAP_HOLD_CFG: &str = "\
 (defsrc)
 (deflayer base)
 (defchordsv2-experimental
-  (a b) (tap-hold 200 200 x y) 200 last-release ()
+  (a b) (tap-hold 200 200 x y) 200 all-released ()
 )";
 
 #[test]
@@ -295,7 +295,7 @@ static CHORD_WITH_PENDING_UNDERLYING_TAP_HOLD: &str = "\
 (defsrc)
 (deflayermap (base) a : (tap-hold 200 200 a b))
 (defchordsv2-experimental
-  (b c) d 100 last-release ()
+  (b c) d 100 all-released ()
 )";
 
 #[test]
@@ -314,7 +314,7 @@ static CHORD_WITH_TRANSPARENCY: &str = "\
 (defsrc)
 (deflayer base)
 (defchordsv2-experimental
-  (a b) _ 100 last-release ()
+  (a b) _ 100 all-released ()
 )";
 
 #[test]

--- a/src/tests/sim_tests.rs
+++ b/src/tests/sim_tests.rs
@@ -1,9 +1,15 @@
+use super::*;
+
 use kanata_state_machine::{
     oskbd::{KeyEvent, KeyValue},
     str_to_oscode, Kanata,
 };
 
 fn simulate(cfg: &str, sim: &str) -> String {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
     let mut k = Kanata::new_from_str(cfg).expect("failed to parse cfg");
     for pair in sim.split_whitespace() {
         match pair.split_once(':') {
@@ -58,7 +64,7 @@ fn sim_chord_basic_repeated_last_release() {
     let result = simulate(
         SIMPLE_NONOVERLAPPING_CHORD_CFG,
         "d:a t:50 d:b t:50 u:a t:50 u:b t:50 \
-        d:a t:50 d:b t:50 u:a t:50 u:b t:50 ",
+         d:b t:50 d:a t:50 u:b t:50 u:a t:50 ",
     );
     assert_eq!(
         "t:50ms\nout:↓C\nt:101ms\nout:↑C\nt:99ms\nout:↓C\nt:101ms\nout:↑C",

--- a/src/tests/sim_tests.rs
+++ b/src/tests/sim_tests.rs
@@ -288,3 +288,18 @@ fn sim_chord_pending_tap_hold() {
     // are intentionally not delayed by waiting actions like tap-hold.
     assert_eq!("t:20ms\nout:↓D\nt:179ms\nout:↓B", result);
 }
+
+static CHORD_WITH_TRANSPARENCY: &str = "\
+(defcfg process-unmapped-keys yes concurrent-tap-hold yes)
+(defsrc)
+(deflayer base)
+(defchordsv2-experimental
+  (a b) _ 100 last-release ()
+)";
+
+#[test]
+fn sim_denies_transparent() {
+    Kanata::new_from_str(CHORD_WITH_TRANSPARENCY)
+        .map(|_| ())
+        .expect_err("trans in defchordsv2 should error");
+}

--- a/src/tests/sim_tests.rs
+++ b/src/tests/sim_tests.rs
@@ -255,6 +255,20 @@ fn sim_chord_layer_3_held_disabled() {
     );
 }
 
+#[test]
+fn sim_chord_layer_3_repeat() {
+    let result = simulate(
+        SIMPLE_DISABLED_LAYER_CHORD_CFG,
+        "d:3 t:50 d:a t:50 d:b t:50 r:b t:50 r:b t:50\n\
+         d:d t:50 d:c t:50 r:c t:50 r:d t:50",
+    );
+    assert_eq!(
+        "t:100ms\nout:↓X\nt:50ms\nout:↓X\nt:50ms\nout:↓X\n\
+         t:100ms\nout:↓Y\nt:50ms\nout:↓Y\nt:50ms\nout:↓Y",
+        result
+    );
+}
+
 static CHORD_INTO_TAP_HOLD_CFG: &str = "\
 (defcfg process-unmapped-keys yes concurrent-tap-hold yes)
 (defsrc)

--- a/src/tests/sim_tests.rs
+++ b/src/tests/sim_tests.rs
@@ -138,10 +138,7 @@ fn sim_chord_overlapping_release() {
         SIMPLE_OVERLAPPING_CHORD_CFG,
         "d:a d:b t:100 u:a d:z t:300 u:b t:300",
     );
-    assert_eq!(
-        "t:100ms\nout:↓C\nt:251ms\nout:↓Z\nt:50ms\nout:↑C",
-        result
-    );
+    assert_eq!("t:100ms\nout:↓C\nt:251ms\nout:↓Z\nt:50ms\nout:↑C", result);
 }
 
 #[test]

--- a/src/tests/sim_tests.rs
+++ b/src/tests/sim_tests.rs
@@ -182,10 +182,7 @@ fn sim_chord_activate_largest_overlapping() {
         SIMPLE_OVERLAPPING_CHORD_CFG,
         "d:a t:50 d:b t:50 d:z t:50 d:y t:50 u:b t:50",
     );
-    assert_eq!(
-        "t:151ms\nout:↓E\nt:50ms\nout:↑E",
-        result
-    );
+    assert_eq!("t:151ms\nout:↓E\nt:50ms\nout:↑E", result);
 }
 
 static SIMPLE_DISABLED_LAYER_CHORD_CFG: &str = "\

--- a/src/tests/sim_tests.rs
+++ b/src/tests/sim_tests.rs
@@ -269,3 +269,22 @@ fn sim_chord_into_tap_hold() {
         result
     );
 }
+
+static CHORD_WITH_PENDING_UNDERLYING_TAP_HOLD: &str = "\
+(defcfg process-unmapped-keys yes concurrent-tap-hold yes)
+(defsrc)
+(deflayermap (base) a : (tap-hold 200 200 a b))
+(defchordsv2-experimental
+  (b c) d 100 last-release ()
+)";
+
+#[test]
+fn sim_chord_pending_tap_hold() {
+    let result = simulate(
+        CHORD_WITH_PENDING_UNDERLYING_TAP_HOLD,
+        "d:a t:10 d:b t:10 d:c t:300",
+    );
+    // unlike other actions, chordv2 activations
+    // are intentionally not delayed by waiting actions like tap-hold.
+    assert_eq!("t:20ms\nout:↓D\nt:179ms\nout:↓B", result);
+}

--- a/src/tests/sim_tests.rs
+++ b/src/tests/sim_tests.rs
@@ -1,0 +1,176 @@
+use kanata_state_machine::{
+    oskbd::{KeyEvent, KeyValue},
+    str_to_oscode, Kanata,
+};
+
+fn simulate(cfg: &str, sim: &str) -> String {
+    let mut k = Kanata::new_from_str(cfg).expect("failed to parse cfg");
+    for pair in sim.split_whitespace() {
+        match pair.split_once(':') {
+            Some((kind, val)) => match kind {
+                "t" => {
+                    let tick = str::parse::<u128>(val).expect("valid num for tick");
+                    k.tick_ms(tick, &None).unwrap();
+                }
+                "d" => {
+                    let key_code = str_to_oscode(val).expect("valid keycode");
+                    k.handle_input_event(&KeyEvent {
+                        code: key_code,
+                        value: KeyValue::Press,
+                    })
+                    .expect("input handles fine");
+                }
+                "u" => {
+                    let key_code = str_to_oscode(val).expect("valid keycode");
+                    k.handle_input_event(&KeyEvent {
+                        code: key_code,
+                        value: KeyValue::Release,
+                    })
+                    .expect("input handles fine");
+                }
+                "r" => {
+                    let key_code = str_to_oscode(val).expect("valid keycode");
+                    k.handle_input_event(&KeyEvent {
+                        code: key_code,
+                        value: KeyValue::Repeat,
+                    })
+                    .expect("input handles fine");
+                }
+                _ => panic!("invalid item {pair}"),
+            },
+            None => panic!("invalid item {pair}"),
+        }
+    }
+    k.kbd_out.outputs.events.join("\n")
+}
+
+static SIMPLE_NONOVERLAPPING_CHORD_CFG: &str = "\
+(defcfg process-unmapped-keys yes concurrent-tap-hold yes) \
+(defsrc) \
+(deflayer base) \
+(defchordsv2-experimental \
+  (a b) c 200 last-release () \
+  (b z) d 200 first-release () \
+)";
+
+#[test]
+fn sim_chord_basic_repeated_last_release() {
+    let result = simulate(
+        SIMPLE_NONOVERLAPPING_CHORD_CFG,
+        "d:a t:50 d:b t:50 u:a t:50 u:b t:50 \
+        d:a t:50 d:b t:50 u:a t:50 u:b t:50 ",
+    );
+    assert_eq!(
+        "t:51ms
+out:↓C
+t:100ms
+out:↑C
+t:100ms
+out:↓C
+t:100ms
+out:↑C",
+        result
+    );
+}
+
+#[test]
+fn sim_chord_min_idle_takes_effect() {
+    let result = simulate(
+        SIMPLE_NONOVERLAPPING_CHORD_CFG,
+        "d:z t:20 d:a t:20 d:b t:20 d:d t:20",
+    );
+    assert_eq!(
+        "t:21ms
+out:↓Z
+t:1ms
+out:↓A
+t:39ms
+out:↓B
+t:1ms
+out:↓D",
+        result
+    );
+}
+
+#[test]
+fn sim_timeout_hold_key() {
+    let result = simulate(SIMPLE_NONOVERLAPPING_CHORD_CFG, "d:z t:201 d:b t:200");
+    assert_eq!(
+        "t:201ms
+out:↓Z
+t:1ms
+out:↓B",
+        result
+    );
+}
+
+#[test]
+fn sim_chord_basic_repeated_first_release() {
+    let result = simulate(
+        SIMPLE_NONOVERLAPPING_CHORD_CFG,
+        "d:z t:50 d:b t:50 u:z t:50 u:b t:50 \
+        d:z t:50 d:b t:50 u:z t:50 u:b t:50 ",
+    );
+    assert_eq!(
+        "t:51ms
+out:↓D
+t:50ms
+out:↑D
+t:150ms
+out:↓D
+t:50ms
+out:↑D",
+        result
+    );
+}
+
+static SIMPLE_OVERLAPPING_CHORD_CFG: &str = "\
+(defcfg process-unmapped-keys yes concurrent-tap-hold yes) \
+(defsrc) \
+(deflayer base) \
+(defchordsv2-experimental \
+  (a b) c 200 last-release () \
+  (a b z) d 250 first-release () \
+)";
+
+#[test]
+fn sim_overlapping_timeout() {
+    let result = simulate(SIMPLE_OVERLAPPING_CHORD_CFG, "d:a d:b t:201 d:z t:300");
+    assert_eq!(
+        "t:201ms
+out:↓C
+t:251ms
+out:↓Z",
+        result
+    );
+}
+
+#[test]
+fn sim_overlapping_release() {
+    let result = simulate(
+        SIMPLE_OVERLAPPING_CHORD_CFG,
+        "d:a d:b t:100 u:a d:z t:300 u:b t:300",
+    );
+    assert_eq!(
+        "t:101ms
+out:↓C
+t:250ms
+out:↓Z
+t:50ms
+out:↑C",
+        result
+    );
+}
+
+#[test]
+fn sim_presses_for_old_chord_repress_into_new_chord() {
+    let result = simulate(
+        SIMPLE_OVERLAPPING_CHORD_CFG,
+        "d:a d:b t:50 u:a t:50 d:z t:50 u:b t:50 d:a d:b t:50 u:a t:50",
+    );
+    assert_eq!(
+        "t:51ms\nout:↓C\nt:100ms\nout:↑C\nt:50ms\nout:↓D\nt:50ms\n\
+        out:↑D",
+        result
+    );
+}

--- a/src/tests/sim_tests.rs
+++ b/src/tests/sim_tests.rs
@@ -61,14 +61,7 @@ fn sim_chord_basic_repeated_last_release() {
         d:a t:50 d:b t:50 u:a t:50 u:b t:50 ",
     );
     assert_eq!(
-        "t:51ms
-out:↓C
-t:100ms
-out:↑C
-t:100ms
-out:↓C
-t:100ms
-out:↑C",
+        "t:50ms\nout:↓C\nt:101ms\nout:↑C\nt:99ms\nout:↓C\nt:101ms\nout:↑C",
         result
     );
 }
@@ -112,14 +105,7 @@ fn sim_chord_basic_repeated_first_release() {
         d:z t:50 d:b t:50 u:z t:50 u:b t:50 ",
     );
     assert_eq!(
-        "t:51ms
-out:↓D
-t:50ms
-out:↑D
-t:150ms
-out:↓D
-t:50ms
-out:↑D",
+        "t:50ms\nout:↓D\nt:51ms\nout:↑D\nt:149ms\nout:↓D\nt:51ms\nout:↑D",
         result
     );
 }
@@ -138,9 +124,9 @@ static SIMPLE_OVERLAPPING_CHORD_CFG: &str = "\
 fn sim_chord_overlapping_timeout() {
     let result = simulate(SIMPLE_OVERLAPPING_CHORD_CFG, "d:a d:b t:201 d:z t:300");
     assert_eq!(
-        "t:201ms
+        "t:200ms
 out:↓C
-t:251ms
+t:252ms
 out:↓Z",
         result
     );
@@ -153,12 +139,7 @@ fn sim_chord_overlapping_release() {
         "d:a d:b t:100 u:a d:z t:300 u:b t:300",
     );
     assert_eq!(
-        "t:101ms
-out:↓C
-t:250ms
-out:↓Z
-t:50ms
-out:↑C",
+        "t:100ms\nout:↓C\nt:251ms\nout:↓Z\nt:50ms\nout:↑C",
         result
     );
 }
@@ -170,8 +151,7 @@ fn sim_presses_for_old_chord_repress_into_new_chord() {
         "d:a d:b t:50 u:a t:50 d:z t:50 u:b t:50 d:a d:b t:50 u:a t:50",
     );
     assert_eq!(
-        "t:51ms\nout:↓C\nt:100ms\nout:↑C\nt:100ms\nout:↓D\nt:2ms\n\
-        out:↑D",
+        "t:50ms\nout:↓C\nt:101ms\nout:↑C\nt:99ms\nout:↓D\nt:7ms\nout:↑D",
         result
     );
 }
@@ -182,7 +162,7 @@ fn sim_chord_activate_largest_overlapping() {
         SIMPLE_OVERLAPPING_CHORD_CFG,
         "d:a t:50 d:b t:50 d:z t:50 d:y t:50 u:b t:50",
     );
-    assert_eq!("t:151ms\nout:↓E\nt:50ms\nout:↑E", result);
+    assert_eq!("t:150ms\nout:↓E\nt:51ms\nout:↑E", result);
 }
 
 static SIMPLE_DISABLED_LAYER_CHORD_CFG: &str = "\
@@ -207,7 +187,7 @@ fn sim_chord_layer_1_switch_disabled() {
         "d:a t:50 d:b t:50 d:c t:50 d:d t:50 d:e t:50 d:f t:50",
     );
     assert_eq!(
-        "t:1ms\nout:↓A\nt:50ms\nout:↓B\nt:100ms\nout:↓Y\nt:100ms\nout:↓Z",
+        "t:1ms\nout:↓A\nt:50ms\nout:↓B\nt:99ms\nout:↓Y\nt:100ms\nout:↓Z",
         result
     );
 }
@@ -219,7 +199,7 @@ fn sim_chord_layer_2_switch_disabled() {
         "d:2 t:50 d:a t:50 d:b t:50 d:c t:50 d:d t:50 d:e t:50 d:f t:50",
     );
     assert_eq!(
-        "t:101ms\nout:↓X\nt:50ms\nout:↓C\nt:50ms\nout:↓D\nt:100ms\nout:↓Z",
+        "t:100ms\nout:↓X\nt:51ms\nout:↓C\nt:50ms\nout:↓D\nt:99ms\nout:↓Z",
         result
     );
 }
@@ -231,7 +211,7 @@ fn sim_chord_layer_3_switch_disabled() {
         "d:3 t:50 d:a t:50 d:b t:50 d:c t:50 d:d t:50 d:e t:50 d:f t:50",
     );
     assert_eq!(
-        "t:101ms\nout:↓X\nt:100ms\nout:↓Y\nt:50ms\nout:↓E\nt:50ms\nout:↓F",
+        "t:100ms\nout:↓X\nt:100ms\nout:↓Y\nt:51ms\nout:↓E\nt:50ms\nout:↓F",
         result
     );
 }
@@ -243,7 +223,7 @@ fn sim_chord_layer_1_held_disabled() {
         "d:3 t:50 d:1 t:50 d:a t:50 d:b t:50 d:c t:50 d:d t:50 d:e t:50 d:f t:50",
     );
     assert_eq!(
-        "t:101ms\nout:↓A\nt:50ms\nout:↓B\nt:100ms\nout:↓Y\nt:100ms\nout:↓Z",
+        "t:101ms\nout:↓A\nt:50ms\nout:↓B\nt:99ms\nout:↓Y\nt:100ms\nout:↓Z",
         result
     );
 }
@@ -255,7 +235,7 @@ fn sim_chord_layer_2_held_disabled() {
         "d:3 t:50 d:2 t:50 d:a t:50 d:b t:50 d:c t:50 d:d t:50 d:e t:50 d:f t:50",
     );
     assert_eq!(
-        "t:151ms\nout:↓X\nt:50ms\nout:↓C\nt:50ms\nout:↓D\nt:100ms\nout:↓Z",
+        "t:150ms\nout:↓X\nt:51ms\nout:↓C\nt:50ms\nout:↓D\nt:99ms\nout:↓Z",
         result
     );
 }
@@ -267,7 +247,28 @@ fn sim_chord_layer_3_held_disabled() {
         "d:2 t:50 d:3 t:50 d:a t:50 d:b t:50 d:c t:50 d:d t:50 d:e t:50 d:f t:50",
     );
     assert_eq!(
-        "t:151ms\nout:↓X\nt:100ms\nout:↓Y\nt:50ms\nout:↓E\nt:50ms\nout:↓F",
+        "t:150ms\nout:↓X\nt:100ms\nout:↓Y\nt:51ms\nout:↓E\nt:50ms\nout:↓F",
+        result
+    );
+}
+
+static CHORD_INTO_TAP_HOLD_CFG: &str = "\
+(defcfg process-unmapped-keys yes concurrent-tap-hold yes)
+(defsrc)
+(deflayer base)
+(defchordsv2-experimental
+  (a b) (tap-hold 200 200 x y) 200 last-release ()
+)";
+
+#[test]
+fn sim_chord_into_tap_hold() {
+    let result = simulate(
+        CHORD_INTO_TAP_HOLD_CFG,
+        "d:a t:50 d:b t:149 u:a u:b t:5 \
+         d:a t:50 d:b t:148 u:a u:b t:1000",
+    );
+    assert_eq!(
+        "t:199ms\nout:↓Y\nt:3ms\nout:↑Y\nt:200ms\nout:↓X\nt:8ms\nout:↑X",
         result
     );
 }


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Chords v2 implements global chords with an option to disable chords on specific layers. In the implementation, inputs first go into a separate queue for chords v2 processing. This is in contrast to the existing chords implementation, which uses the same Layout queue as the rest of the keyberon actions.

An advantage of this system is that this enables using the same chord definition on multiple layers without manually changing/defining the key actions of individual keypresses. To contrast the original implementation, actions for an individual key press must also be defined within the chord group.

A notable addition that is adjacent to the chords implementation is the use of simulated tests which work similarly to the existing keyberon tests, but which I find easier to read and write.

- [x] TODO: make these run in GitHub actions

It is not yet fully tested, but the implementation does work for some scenarios. Seems like it's in an acceptable state for feedback, e.g.
- comments on syntax
- contribute to the tests
- test it manually

Known limitations
- [x] Fixed: key repeat does not work; doesn't affect Desktop Linux where DEs ignore kanata's key repeat anyway
- [x] Choosing not to do: reusing the same chord keys with mutually exclusive active layers is not possible

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes
  - [x] known missing test: disabled layers
  - [x] known missing test: combining with other complex keyberon actions in the underlying layers (e.g. tap-dance, tap-hold)
  - [x] transparent action should be forbidden
