### PR TITLE
feat: add LSP inactive config item hints

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -490,6 +490,12 @@ const DEFLOCALKEYS_VARIANTS: &[&str] = &[
     "deflocalkeys-macos",
 ];
 
+#[derive(Debug, Clone)]
+pub struct LspHintInactiveCode {
+    pub span: Span,
+    pub reason: String,
+}
+
 #[allow(clippy::type_complexity)] // return type is not pub
 pub fn parse_cfg_raw_string(
     text: &str,
@@ -499,9 +505,17 @@ pub fn parse_cfg_raw_string(
     def_local_keys_variant_to_apply: &str,
     env_vars: EnvVars,
 ) -> Result<IntermediateCfg> {
+    let mut lsp_hint_inactive_code: Vec<LspHintInactiveCode> = vec![];
+
     let spanned_root_exprs = sexpr::parse(text, &cfg_path.to_string_lossy())
         .and_then(|xs| expand_includes(xs, file_content_provider))
-        .and_then(|xs| filter_platform_specific_cfg(xs, def_local_keys_variant_to_apply))
+        .and_then(|xs| {
+            filter_platform_specific_cfg(
+                xs,
+                def_local_keys_variant_to_apply,
+                &mut lsp_hint_inactive_code,
+            )
+        })
         .and_then(expand_templates)?;
 
     if let Some(spanned) = spanned_root_exprs
@@ -518,10 +532,15 @@ pub fn parse_cfg_raw_string(
     let mut local_keys: Option<HashMap<String, OsCode>> = None;
     clear_custom_str_oscode_mapping();
     for def_local_keys_variant in DEFLOCALKEYS_VARIANTS {
-        if let Some(result) = root_exprs
+        if let Some((result, span)) = spanned_root_exprs
             .iter()
-            .find(gen_first_atom_filter(def_local_keys_variant))
-            .map(|custom_keys| parse_deflocalkeys(def_local_keys_variant, custom_keys))
+            .find(gen_first_atom_filter_spanned(def_local_keys_variant))
+            .map(|x| {
+                (
+                    parse_deflocalkeys(def_local_keys_variant, &x.t),
+                    x.span.clone(),
+                )
+            })
         {
             let mapping = result?;
             if def_local_keys_variant == &def_local_keys_variant_to_apply {
@@ -530,6 +549,13 @@ pub fn parse_cfg_raw_string(
                     ">1 mutually exclusive deflocalkeys variants were parsed"
                 );
                 local_keys = Some(mapping);
+            } else {
+                lsp_hint_inactive_code.push(LspHintInactiveCode {
+                    span,
+                    reason: format!(
+                        "Another localkeys variant is currently active: {def_local_keys_variant_to_apply}"
+                    ),
+                })
             }
         }
 
@@ -698,6 +724,7 @@ pub fn parse_cfg_raw_string(
         default_sequence_timeout: cfg.sequence_timeout,
         default_sequence_input_mode: cfg.sequence_input_mode,
         block_unmapped_keys: cfg.block_unmapped_keys,
+        lsp_hint_inactive_code,
         ..Default::default()
     };
 
@@ -731,9 +758,9 @@ pub fn parse_cfg_raw_string(
         .collect::<Vec<_>>();
     let sequences = parse_sequences(&sequence_exprs, s)?;
 
-    let alias_exprs = root_exprs
+    let alias_exprs = spanned_root_exprs
         .iter()
-        .filter(gen_first_atom_start_filter("defalias"))
+        .filter(gen_first_atom_start_filter_spanned("defalias"))
         .collect::<Vec<_>>();
     parse_aliases(&alias_exprs, s, &env_vars)?;
 
@@ -833,13 +860,13 @@ fn gen_first_atom_filter(a: &str) -> impl Fn(&&Vec<SExpr>) -> bool {
 /// Return a closure that filters a root expression by the content of the first element. The
 /// closure returns true if the first element is an atom that starts with the input `a` and false
 /// otherwise.
-fn gen_first_atom_start_filter(a: &str) -> impl Fn(&&Vec<SExpr>) -> bool {
+fn gen_first_atom_start_filter_spanned(a: &str) -> impl Fn(&&Spanned<Vec<SExpr>>) -> bool {
     let a = a.to_owned();
     move |expr| {
-        if expr.is_empty() {
+        if expr.t.is_empty() {
             return false;
         }
-        if let SExpr::Atom(atom) = &expr[0] {
+        if let SExpr::Atom(atom) = &expr.t[0] {
             atom.t.starts_with(&a)
         } else {
             false
@@ -1088,6 +1115,7 @@ pub struct ParsedState {
     default_sequence_input_mode: SequenceInputMode,
     block_unmapped_keys: bool,
     switch_max_key_timing: Cell<u16>,
+    pub lsp_hint_inactive_code: Vec<LspHintInactiveCode>,
     a: Arc<Allocations>,
 }
 
@@ -1115,6 +1143,7 @@ impl Default for ParsedState {
             default_sequence_input_mode: default_cfg.sequence_input_mode,
             block_unmapped_keys: default_cfg.block_unmapped_keys,
             switch_max_key_timing: Cell::new(0),
+            lsp_hint_inactive_code: Default::default(),
             a: unsafe { Allocations::new() },
         }
     }
@@ -1185,9 +1214,13 @@ fn push_all_atoms(exprs: &[SExpr], vars: &HashMap<String, SExpr>, pusheen: &mut 
 
 /// Parse alias->action mappings from multiple exprs starting with defalias.
 /// Mutates the input `s` by storing aliases inside.
-fn parse_aliases(exprs: &[&Vec<SExpr>], s: &mut ParsedState, env_vars: &EnvVars) -> Result<()> {
+fn parse_aliases(
+    exprs: &[&Spanned<Vec<SExpr>>],
+    s: &mut ParsedState,
+    env_vars: &EnvVars,
+) -> Result<()> {
     for expr in exprs {
-        handle_standard_defalias(expr, s)?;
+        handle_standard_defalias(&expr.t, s)?;
         handle_envcond_defalias(expr, s, env_vars)?;
     }
     Ok(())
@@ -1201,8 +1234,12 @@ fn handle_standard_defalias(expr: &[SExpr], s: &mut ParsedState) -> Result<()> {
     read_alias_name_action_pairs(subexprs, s)
 }
 
-fn handle_envcond_defalias(expr: &[SExpr], s: &mut ParsedState, env_vars: &EnvVars) -> Result<()> {
-    let mut subexprs = match check_first_expr(expr.iter(), "defaliasenvcond") {
+fn handle_envcond_defalias(
+    exprs: &Spanned<Vec<SExpr>>,
+    s: &mut ParsedState,
+    env_vars: &EnvVars,
+) -> Result<()> {
+    let mut subexprs = match check_first_expr(exprs.t.iter(), "defaliasenvcond") {
         Ok(exprs) => exprs,
         Err(_) => return Ok(()),
     };
@@ -1234,11 +1271,26 @@ fn handle_envcond_defalias(expr: &[SExpr], s: &mut ParsedState, env_vars: &EnvVa
             })?;
             match env_vars {
                 Ok(vars) => {
-                    if !vars
+                    let values_of_matching_vars: Vec<_> = vars
                         .iter()
-                        .any(|(name, value)| name == env_var_name && value == env_var_value)
-                    {
-                        log::info!("Did not find env var ({env_var_name} {env_var_value}), skipping associated aliases");
+                        .filter_map(|(k, v)| if k == env_var_name { Some(v) } else { None })
+                        .collect();
+                    if values_of_matching_vars.is_empty() {
+                        let msg = format!("Env var '{env_var_name}' is not set");
+                        s.lsp_hint_inactive_code.push(LspHintInactiveCode {
+                            span: exprs.span.clone(),
+                            reason: msg.clone(),
+                        });
+                        log::info!("{msg}, skipping associated aliases");
+                        return Ok(());
+                    } else if !values_of_matching_vars.iter().any(|&v| v == env_var_value) {
+                        let msg =
+                            format!("Env var '{env_var_name}' is set, but value doesn't match");
+                        s.lsp_hint_inactive_code.push(LspHintInactiveCode {
+                            span: exprs.span.clone(),
+                            reason: msg.clone(),
+                        });
+                        log::info!("{msg}, skipping associated aliases");
                         return Ok(());
                     }
                 }
@@ -1248,7 +1300,7 @@ fn handle_envcond_defalias(expr: &[SExpr], s: &mut ParsedState, env_vars: &EnvVa
             }
             log::info!("Found env var ({env_var_name} {env_var_value}), using associated aliases");
         }
-        None => bail_expr!(&expr[0], "Missing a list item.\n{conderr}"),
+        None => bail_expr!(&exprs.t[0], "Missing a list item.\n{conderr}"),
     };
     read_alias_name_action_pairs(subexprs, s)
 }

--- a/parser/src/cfg/os_dependent.rs
+++ b/parser/src/cfg/os_dependent.rs
@@ -6,6 +6,7 @@ use crate::err_expr;
 pub(crate) fn filter_platform_specific_cfg(
     top_levels: Vec<TopLevel>,
     deflocalkeys_variant_to_apply: &str,
+    lsp_hint_inactive_code: &mut Vec<LspHintInactiveCode>,
 ) -> Result<Vec<TopLevel>> {
     let valid_platform_names = DEFLOCALKEYS_VARIANTS
         .iter()
@@ -58,6 +59,14 @@ pub(crate) fn filter_platform_specific_cfg(
 
             if applicable_platforms.contains(&current_platform) {
                 tles.push(configuration.clone());
+            } else {
+                lsp_hint_inactive_code.push(LspHintInactiveCode {
+                    span: tle.span.clone(),
+                    reason: format!(
+                        "Current platform \"{current_platform}\" doesn't match any of: {}",
+                        applicable_platforms.join(" ")
+                    ),
+                })
             }
 
             Ok(tles)


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

I'm adding graying-out for inactive configuration items in vscode-kanata https://github.com/rszyma/vscode-kanata/pull/30, and I can't elegantly achieve that by just modifying vscode-kanata's code. Please merge :)

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] Yes 
- ~Added tests, or~ did manual testing
  - [x] Yes
