### PR TITLE
fix!(transparent): forbid nested trans

### DIFF
--- a/parser/src/cfg/action_visitor.rs
+++ b/parser/src/cfg/action_visitor.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+pub(crate) fn visit_nested_actions(
+    action: &KanataAction,
+    visit: &mut dyn FnMut(&KanataAction) -> Result<()>,
+) -> Result<()> {
+    match action {
+        Action::HoldTap(HoldTapAction {
+            tap,
+            hold,
+            timeout_action,
+            ..
+        }) => {
+            visit(tap)?;
+            visit(hold)?;
+            visit(timeout_action)?;
+        }
+        Action::OneShot(OneShot { action: ac, .. }) => {
+            visit(ac)?;
+        }
+        Action::MultipleActions(actions) => {
+            for ac in actions.iter() {
+                visit(ac)?;
+            }
+        }
+        Action::TapDance(TapDance { actions, .. }) => {
+            for ac in actions.iter() {
+                visit(ac)?;
+            }
+        }
+        Action::Fork(ForkConfig { left, right, .. }) => {
+            visit(left)?;
+            visit(right)?;
+        }
+        Action::Chords(ChordsGroup { chords, .. }) => {
+            for (_, ac) in chords.iter() {
+                visit(ac)?;
+            }
+        }
+        Action::Switch(Switch { cases }) => {
+            for case in cases.iter() {
+                visit(case.1)?;
+            }
+        }
+        ac @ Action::KeyCode(_)
+        | ac @ Action::NoOp
+        | ac @ Action::Custom(_)
+        | ac @ Action::Trans
+        | ac @ Action::MultipleKeyCodes(_)
+        | ac @ Action::Repeat
+        | ac @ Action::Layer(_)
+        | ac @ Action::DefaultLayer(_)
+        | ac @ Action::Sequence { .. }
+        | ac @ Action::RepeatableSequence { .. }
+        | ac @ Action::CancelSequences
+        | ac @ Action::ReleaseState(_) => {
+            visit(ac)?;
+        }
+    };
+    Ok(())
+}

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -2819,11 +2819,9 @@ fn parse_layers(
     mapped_keys: &mut MappedKeys,
     defcfg: &CfgOptions,
 ) -> Result<IntermediateLayers> {
-    // There are two copies/versions of each layer. One is used as the target of "layer-switch" and
-    // the other is the target of "layer-while-held".
     let mut layers_cfg = new_layers(s.layer_exprs.len());
-    if s.layer_exprs.len() > MAX_LAYERS / 2 {
-        bail!("Maximum number of layers ({}) exceeded.", MAX_LAYERS / 2);
+    if s.layer_exprs.len() > MAX_LAYERS {
+        bail!("Maximum number of layers ({}) exceeded.", MAX_LAYERS);
     }
     let mut defsrc_layer = s.defsrc_layer;
     let mut error_on_nested_trans = s.delegate_to_first_layer;

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -42,6 +42,8 @@ pub mod sexpr;
 mod alloc;
 use alloc::*;
 
+mod action_visitor;
+
 mod key_override;
 use kanata_keyberon::chord::ChordsV2;
 pub use key_override::*;
@@ -2824,14 +2826,25 @@ fn parse_layers(
         bail!("Maximum number of layers ({}) exceeded.", MAX_LAYERS / 2);
     }
     let mut defsrc_layer = s.defsrc_layer;
+    let mut error_on_nested_trans = s.delegate_to_first_layer;
+    let nested_trans_errmsg = "This nested transparent action is forbidden on the first\n\
+                               defined layer when delegate-to-first-layer is enabled";
     for (layer_level, layer) in s.layer_exprs.iter().enumerate() {
         match layer {
             // The skip is done to skip the the `deflayer` and layer name tokens.
             LayerExprs::DefsrcMapping(layer) => {
                 // Parse actions in the layer and place them appropriately according
                 // to defsrc mapping order.
-                for (i, ac) in layer.iter().skip(2).enumerate() {
-                    let ac = parse_action(ac, s)?;
+                for (i, ac_expr) in layer.iter().skip(2).enumerate() {
+                    let ac = parse_action(ac_expr, s)?;
+                    if error_on_nested_trans && !matches!(ac, Action::Trans) {
+                        action_visitor::visit_nested_actions(ac, &mut |ac| {
+                            if matches!(ac, Action::Trans) {
+                                bail_expr!(ac_expr, "{nested_trans_errmsg}");
+                            }
+                            Ok(())
+                        })?;
+                    }
                     layers_cfg[layer_level][0][s.mapping_order[i]] = *ac;
                 }
             }
@@ -2844,7 +2857,7 @@ fn parse_layers(
                 let mut both_anykey_used = false;
                 for triplet in pairs.by_ref() {
                     let input = &triplet[0];
-                    let action = &triplet[1];
+                    let action_expr = &triplet[1];
 
                     // TODO: remove me some time after April 2024 to reduce code bloat somewhat.
                     const MAPSTRS: &[&str] = &[":", "->", ">>", "maps-to", "→", "🞂"];
@@ -2854,11 +2867,22 @@ fn parse_layers(
                     if input.atom(s.vars()).is_some_and(|x| MAPSTRS.contains(&x)) {
                         bail_expr!(input, "{MAPSTR_ERR}");
                     }
-                    if action.atom(s.vars()).is_some_and(|x| MAPSTRS.contains(&x)) {
-                        bail_expr!(action, "{MAPSTR_ERR}");
+                    if action_expr
+                        .atom(s.vars())
+                        .is_some_and(|x| MAPSTRS.contains(&x))
+                    {
+                        bail_expr!(action_expr, "{MAPSTR_ERR}");
                     }
 
-                    let action = parse_action(action, s)?;
+                    let action = parse_action(action_expr, s)?;
+                    if error_on_nested_trans && !matches!(action, Action::Trans) {
+                        action_visitor::visit_nested_actions(action, &mut |ac| {
+                            if matches!(ac, Action::Trans) {
+                                bail_expr!(action_expr, "{nested_trans_errmsg}");
+                            }
+                            Ok(())
+                        })?;
+                    }
                     if input.atom(s.vars()).is_some_and(|x| x == "_") {
                         if defsrc_anykey_used {
                             bail_expr!(input, "must have only one use of _ within a layer")
@@ -2965,6 +2989,7 @@ fn parse_layers(
                 }
             }
         }
+        error_on_nested_trans = false;
     }
     s.defsrc_layer = defsrc_layer;
     Ok(layers_cfg)
@@ -3413,6 +3438,8 @@ fn add_chordsv2_output_for_key_pos(
     }
 }
 
+// TODO: refactor - define in terms of action_visitor::visit.
+// But need to generate a test that they add all the same outputs
 fn add_key_output_from_action_to_key_pos(
     osc_slot: OsCode,
     action: &KanataAction,

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -2116,6 +2116,24 @@ fn parse_nested_trans_delegate_to_base_layer_fails() {
         DEF_LOCAL_KEYS,
         Err("env vars not implemented".into()),
     )
-    .map(||())
+    .map(|_| ())
+    .unwrap_err();
+    let mut s = ParserState::default();
+    let source = r#"
+(defcfg delegate-to-first-layer true)
+(defsrc)
+(deflayermap (base) a (multi _))
+"#;
+    parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+        DEF_LOCAL_KEYS,
+        Err("env vars not implemented".into()),
+    )
+    .map(|_| ())
     .unwrap_err();
 }

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -2093,3 +2093,29 @@ fn parse_platform_specific() {
     .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
     .unwrap();
 }
+
+#[test]
+fn parse_nested_trans_delegate_to_base_layer_fails() {
+    let _lk = match CFG_PARSE_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let mut s = ParserState::default();
+    let source = r#"
+(defcfg delegate-to-first-layer true)
+(defsrc q)
+(deflayer base (multi _))
+"#;
+    parse_cfg_raw_string(
+        source,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+        DEF_LOCAL_KEYS,
+        Err("env vars not implemented".into()),
+    )
+    .map(||())
+    .unwrap_err();
+}


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

This commit forbids nested transparent actions on the first layer when `delegate-to-first-layer` is enabled.

This change is done because, with the way the current code works, this configuration causes an infinite recursion leading to stack overflow. The behaviour was introduced in commit 089853a which improves the runtime memory consumption of kanata by having only one keyberon layer for each configured layer, instead of having two variants (base + while-held). One of the changes necessary to remove the two layer variants was to modify the `defsrc_layer` with the content of the first defined layer, and it is this change that causes the infinite recursion. It seems undesirable to revert the improvement to enable this niche, and in my opinion, nonsensical use case. This same use case also already behaves incorrectly v1.5.0, so there is no loss in functionality from a non-prerelease version.

Some considerations was made to fix the behaviour by adding to the transparency resolution code, rather than reverting commit 089853a. For example, introduce a second, deeper `src_layer` to the keyberon `Layout` which would be the original `defsrc` layer, with no modification from `delegate-to-first-layer`. However, this code and memory bloat does not seem worthwhile to enable the niche+nonsensical use case.

Closes #939.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes