### PR TITLE
do not duplicate items in `layer_info: Vec<LayerInfo>`

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -651,11 +651,6 @@ pub fn parse_cfg_raw_string(
     let layer_names = sorted_idxs
         .into_iter()
         .map(|(name, _)| (*name).clone())
-        .flat_map(|s| {
-            // Duplicate the same layer for `layer_strings` because the keyberon layout itself has
-            // two versions of each layer.
-            std::iter::repeat(s).take(2)
-        })
         .collect::<Vec<_>>();
 
     let deflayer_filter = |exprs: &&Vec<SExpr>| -> bool {
@@ -672,11 +667,6 @@ pub fn parse_cfg_raw_string(
         .iter()
         .filter(|expr| deflayer_filter(&&expr.t))
         .map(|expr| expr.span.file_content()[expr.span.clone()].to_string())
-        .flat_map(|s| {
-            // Duplicate the same layer for `layer_strings` because the keyberon layout itself has
-            // two versions of each layer.
-            std::iter::repeat(s).take(2)
-        })
         .collect::<Vec<_>>();
 
     let layer_info: Vec<LayerInfo> = layer_names

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -53,7 +53,7 @@ fn parse_jtroo() {
         Err(poisoned) => poisoned.into_inner(),
     };
     let cfg = new_from_file(&std::path::PathBuf::from("./cfg_samples/jtroo.kbd")).unwrap();
-    assert_eq!(cfg.layer_info.len(), 16);
+    assert_eq!(cfg.layer_info.len(), 8);
 }
 
 #[test]


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
do not duplicate items in `layer_info: Vec<LayerInfo>`  (at parse time)

fixes #945

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
    - manual testing