### PR TITLE
rename nonexistent `expand-template` to `template-expand` in config.adoc

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -3197,7 +3197,7 @@ the second list-of-strings parameter
 ;; Below will expand to: `a c` because the string
 ;; $a itself is compared against the string hello
 ;; and they are not equal.
-(expand-template template1 $a)
+(template-expand template1 $a)
 
 (deftemplate template2 (var1)
   a (if-equal $a $var1 b) c
@@ -3207,7 +3207,7 @@ the second list-of-strings parameter
 ;; $a is compared against the string $a and they are equal.
 ;; But note that the variable $a is still not substituted
 ;; with its defvar value of: hello.
-(expand-template template2 $a)
+(template-expand template2 $a)
 ----
 
 [[concat-in-deftemplate]]


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
rename nonexistent `expand-template` to `template-expand` in config.adoc

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
