### PR TITLE
feat(seq): add special seq keys

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -1087,6 +1087,14 @@ If you need help, please feel welcome to ask in the GitHub discussions.
 (defalias dot-sequence (macro (sequence 250) 10 .))
 (defalias dot-sequence-inputmode (macro (sequence 250 hidden-delay-type) 10 .))
 
+;; There are special keys that you can assign in your actions which will
+;; never output events to your operating system, but which you can use
+;; in sequences. They are named: seq0-seq9.
+(defseq
+    dotcom (seq0 seq1)
+    dotorg (seq8 seq9)
+)
+
 ;; Input chording.
 ;;
 ;; Not to be confused with output chords (like C-S-a or the chords layer

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -1089,10 +1089,10 @@ If you need help, please feel welcome to ask in the GitHub discussions.
 
 ;; There are special keys that you can assign in your actions which will
 ;; never output events to your operating system, but which you can use
-;; in sequences. They are named: seq0-seq9.
+;; in sequences. They are named: nop0-nop9.
 (defseq
-    dotcom (seq0 seq1)
-    dotorg (seq8 seq9)
+    dotcom (nop0 nop1)
+    dotorg (nop8 nop9)
 )
 
 ;; Input chording.

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1441,6 +1441,9 @@ if any of the keys in the third parameter (right-trigger-keys) are currently act
 )
 ----
 
+TIP: the keys `nop0-nop9` can be used as no-op outputs that
+can still be checked within `fork`, unlike what `XX` does.
+
 [[caps-word]]
 === caps-word
 <<table-of-contents,Back to ToC>>
@@ -2627,7 +2630,7 @@ precisely, the action triggered is:
 )
 ----
 
-There are 10 special keys with names `seq0-seq9` which kanata treats specially.
+There are 10 special keys with names `nop0-nop9` which kanata treats specially.
 Kanata will never send OS events for these keys
 but they can still participate in sequences.
 
@@ -2639,36 +2642,36 @@ use of templates to conveniently define sequences below.
 ----
 (defsrc f7   f8   f9   f10)
 (deflayer base
-        sldr seq0 seq1 seq2)
+        sldr nop0 nop1 nop2)
 (deftemplate seq (vk-name input-keys output-action)
   (defvirtualkeys $vk-name $output-action)
   (defseq $vk-name $input-keys)
 )
-(template-expand seq dotcom (seq0 seq1) (macro . c o m))
-(template-expand seq dotorg (seq0 seq2) (macro . o r g))
+(template-expand seq dotcom (nop0 nop1) (macro . c o m))
+(template-expand seq dotorg (nop0 nop2) (macro . o r g))
 ----
 
 If 10 special sequence keys do not seem sufficient,
 you can get creative with your sequences and treat some as a prefix modifier.
-For example, you can get 28 "keys" by treating `seq0-seq6` as normal
-while treating `seq7-seq9` as prefixes:
+For example, you can get 28 "keys" by treating `nop0-nop6` as normal
+while treating `nop7-nop9` as prefixes:
 
 .Example:
 [source]
 ----
 (defalias
-  seq0 seq0
+  nop0 nop0
   ;; ...
-  seq6 seq6
-  seq7 (macro seq7 seq0)
+  nop6 nop6
+  nop7 (macro nop7 nop0)
   ;; ...
-  seq13 (macro seq7 seq6)
-  seq14 (macro seq8 seq0)
+  nop13 (macro nop7 nop6)
+  nop14 (macro nop8 nop0)
   ;; ...
-  seq20 (macro seq8 seq6)
-  seq21 (macro seq9 seq0)
+  nop20 (macro nop8 nop6)
+  nop21 (macro nop9 nop0)
   ;; ...
-  seq27 (macro seq9 seq6)
+  nop27 (macro nop9 nop6)
 )
 ----
 
@@ -2863,6 +2866,9 @@ The default use of keys check behaves similarly to fork.
 
 For example, the keys check `(a b c)` will activate the corresponding action
 if any of a, b, or c are currently pressed.
+
+TIP: the keys `nop0-nop9` can be used as no-op outputs that
+can still be checked within `switch`, unlike what `XX` does.
 
 The keys check also accepts the boolean operators `and|or|not` to allow more
 complex use cases.

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2634,8 +2634,8 @@ There are 10 special keys with names `nop0-nop9` which kanata treats specially.
 Kanata will never send OS events for these keys
 but they can still participate in sequences.
 
-See an example of using the special seq keys and
-use of templates to conveniently define sequences below.
+See an example of using the nop keys
+alongside templates to define sequences below.
 
 .Example:
 [source]
@@ -2651,7 +2651,7 @@ use of templates to conveniently define sequences below.
 (template-expand seq dotorg (nop0 nop2) (macro . o r g))
 ----
 
-If 10 special sequence keys do not seem sufficient,
+If 10 special nop keys do not seem sufficient,
 you can get creative with your sequences and treat some as a prefix modifier.
 For example, you can get 28 "keys" by treating `nop0-nop6` as normal
 while treating `nop7-nop9` as prefixes:

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2603,28 +2603,49 @@ but are saved until one of the following happens:
 * A key is typed that does not match any sequence
 * `+sequence-timeout+` milliseconds elapses since the most recent key press
 
-Sequences are configured similarly to `+deffakekeys+`. The first parameter of a
+Sequences are configured similarly to `+defvirtualkeys+`. The first parameter of a
 pair must be a defined virtual key name. The second parameter is a list of keys
 that will activate a virtual key tap when typed in the defined order. More
 precisely, the action triggered is:
 
-`+(on-press-fakekey <virtual key name> tap)+`
+`+(on-press tap-vkey <virtual key name>)+`
 
 .Example:
 [source]
 ----
 (defseq git-status (g s t))
-(deffakekeys git-status (macro g i t spc s t a t u s))
+(defvirtualkeys git-status (macro g i t spc s t a t u s))
 (defalias rcl (tap-hold-release 200 200 sldr rctl))
 
 (defseq
     dotcom (. S-3)
     dotorg (. S-4)
 )
-(deffakekeys
+(defvirtualkeys
     dotcom (macro . c o m)
     dotorg (macro . o r g)
 )
+----
+
+There are 10 special keys with names `seq0-seq9` which kanata treats specially.
+Kanata will never send OS events for these keys
+but they can still participate in sequences.
+
+See an example of using the special seq keys and
+use of templates to conveniently define sequences below.
+
+.Example:
+[source]
+----
+(defsrc f7   f8   f9   f10)
+(deflayer base
+        sldr seq0 seq1 seq2)
+(deftemplate seq (vk-name input-keys output-action)
+  (defvirtualkeys $vk-name $output-action)
+  (defseq $vk-name $input-keys)
+)
+(template-expand seq dotcom (seq0 seq1) (macro . c o m))
+(template-expand seq dotorg (seq0 seq2) (macro . o r g))
 ----
 
 For more context, you can read the

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2648,7 +2648,31 @@ use of templates to conveniently define sequences below.
 (template-expand seq dotorg (seq0 seq2) (macro . o r g))
 ----
 
-For more context, you can read the
+If 10 special sequence keys do not seem sufficient,
+you can get creative with your sequences and treat some as a prefix modifier.
+For example, you can get 28 "keys" by treating `seq0-seq6` as normal
+while treating `seq7-seq9` as prefixes:
+
+.Example:
+[source]
+----
+(defalias
+  seq0 seq0
+  ;; ...
+  seq6 seq6
+  seq7 (macro seq7 seq0)
+  ;; ...
+  seq13 (macro seq7 seq6)
+  seq14 (macro seq8 seq0)
+  ;; ...
+  seq20 (macro seq8 seq6)
+  seq21 (macro seq9 seq0)
+  ;; ...
+  seq27 (macro seq9 seq6)
+)
+----
+
+For more context about sequences, you can read the
 https://github.com/jtroo/kanata/issues/97[design and motivation of sequences].
 You may also be interested in
 https://github.com/jtroo/kanata/blob/main/docs/sequence-adding-chords-ideas.md[the document describing chords in sequences]

--- a/docs/platform-known-issues.adoc
+++ b/docs/platform-known-issues.adoc
@@ -73,6 +73,11 @@ without also having the shift keys in `defsrc` will break shift highlighting
 ** https://github.com/jtroo/kanata/discussions/733
 ** https://github.com/jtroo/kanata/issues/740
 ** adjusting https://github.com/jtroo/kanata/blob/main/docs/config.adoc#rapid-event-delay[rapid-event-delay] can potentially be a workaround
+* Macro keys on certain gaming keyboards might stop being processed
+** Context: search for `POTENTIAL PROBLEM - G-keys` in
+link:../src/kanata/mod.rs[the code].
+** Workaround: leave `process-unmapped-keys` disabled
+and explicitly map keys in `defsrc` instead
 
 == MacOS
 

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -994,9 +994,9 @@ pub enum OsCode {
     KEY_653 = 653,
     KEY_654 = 654,
     KEY_655 = 655,
-    KEY_656 = 656,
-    KEY_657 = 657,
-    KEY_658 = 658,
+    KEY_656 = 656, // 0x290 : KEY_MACRO1:
+    KEY_657 = 657, // https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
+    KEY_658 = 658, // ...
     KEY_659 = 659,
     KEY_660 = 660,
     KEY_661 = 661,
@@ -1022,8 +1022,8 @@ pub enum OsCode {
     KEY_681 = 681,
     KEY_682 = 682,
     KEY_683 = 683,
-    KEY_684 = 684,
-    KEY_685 = 685,
+    KEY_684 = 684, // ...
+    KEY_685 = 685, // 0x2ad: KEY_MACRO30
     KEY_686 = 686,
     KEY_687 = 687,
     KEY_688 = 688,

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -330,16 +330,16 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
 
         // Keys that behave as no-ops but can be used in sequences.
         // Also see: POTENTIAL PROBLEM - G-keys
-        "seq0" => OsCode::KEY_676,
-        "seq1" => OsCode::KEY_677,
-        "seq2" => OsCode::KEY_678,
-        "seq3" => OsCode::KEY_679,
-        "seq4" => OsCode::KEY_680,
-        "seq5" => OsCode::KEY_681,
-        "seq6" => OsCode::KEY_682,
-        "seq7" => OsCode::KEY_683,
-        "seq8" => OsCode::KEY_684,
-        "seq9" => OsCode::KEY_685,
+        "nop0" => OsCode::KEY_676,
+        "nop1" => OsCode::KEY_677,
+        "nop2" => OsCode::KEY_678,
+        "nop3" => OsCode::KEY_679,
+        "nop4" => OsCode::KEY_680,
+        "nop5" => OsCode::KEY_681,
+        "nop6" => OsCode::KEY_682,
+        "nop7" => OsCode::KEY_683,
+        "nop8" => OsCode::KEY_684,
+        "nop9" => OsCode::KEY_685,
 
         _ => return None,
     })

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -327,6 +327,20 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "powr" | "power" => OsCode::KEY_POWER,
         #[cfg(any(target_os = "linux", target_os = "unknown"))]
         "zzz" | "sleep" => OsCode::KEY_SLEEP,
+
+        // Keys that behave as no-ops but can be used in sequences.
+        // Also see: POTENTIAL PROBLEM - G-keys
+        "seq0" => OsCode::KEY_676,
+        "seq1" => OsCode::KEY_677,
+        "seq2" => OsCode::KEY_678,
+        "seq3" => OsCode::KEY_679,
+        "seq4" => OsCode::KEY_680,
+        "seq5" => OsCode::KEY_681,
+        "seq6" => OsCode::KEY_682,
+        "seq7" => OsCode::KEY_683,
+        "seq8" => OsCode::KEY_684,
+        "seq9" => OsCode::KEY_685,
+
         _ => return None,
     })
 }
@@ -995,7 +1009,7 @@ pub enum OsCode {
     KEY_654 = 654,
     KEY_655 = 655,
     KEY_656 = 656, // 0x290 : KEY_MACRO1:
-    KEY_657 = 657, // https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
+    KEY_657 = 657, // https://github.com/torvalds/linux/commit/b5625db9d23e58a573eb10a7f6d0c2ae060bc0e8
     KEY_658 = 658, // ...
     KEY_659 = 659,
     KEY_660 = 660,
@@ -1014,7 +1028,7 @@ pub enum OsCode {
     KEY_673 = 673,
     KEY_674 = 674,
     KEY_675 = 675,
-    KEY_676 = 676,
+    KEY_676 = 676, // 0x2a4: KEY_MACRO21
     KEY_677 = 677,
     KEY_678 = 678,
     KEY_679 = 679,

--- a/src/tests/sim_tests/mod.rs
+++ b/src/tests/sim_tests/mod.rs
@@ -6,6 +6,7 @@ use kanata_state_machine::{
 
 mod chord_sim_tests;
 mod layer_sim_tests;
+mod seq_sim_tests;
 
 fn simulate(cfg: &str, sim: &str) -> String {
     let _lk = match CFG_PARSE_LOCK.lock() {

--- a/src/tests/sim_tests/seq_sim_tests.rs
+++ b/src/tests/sim_tests/seq_sim_tests.rs
@@ -5,9 +5,9 @@ fn special_seq_keys() {
     let result = simulate(
         "(defcfg sequence-input-mode visible-backspaced)
          (defsrc a b c d e)
-         (deflayer base sldr seq0 c seq9 0)
+         (deflayer base sldr nop0 c nop9 0)
          (defvirtualkeys s1 (macro h i))
-         (defseq s1 (seq0 c seq9))
+         (defseq s1 (nop0 c nop9))
         ",
         "d:b d:d t:50 u:b u:d t:50
          d:a d:b d:c t:50 u:a u:b u:c t:50 d:d t:50",

--- a/src/tests/sim_tests/seq_sim_tests.rs
+++ b/src/tests/sim_tests/seq_sim_tests.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+#[test]
+fn special_seq_keys() {
+    let result = simulate(
+        "(defcfg sequence-input-mode visible-backspaced)
+         (defsrc a b c d e)
+         (deflayer base sldr seq0 c seq9 0)
+         (defvirtualkeys s1 (macro h i))
+         (defseq s1 (seq0 c seq9))
+        ",
+        "d:b d:d t:50 u:b u:d t:50
+         d:a d:b d:c t:50 u:a u:b u:c t:50 d:d t:50",
+    );
+    assert_eq!(
+        "t:102ms\nout:↓C\nt:50ms\nout:↑C\nt:48ms\n\
+        out:↓BSpace\nout:↑BSpace\n\
+        t:2ms\nout:↓H\nt:1ms\nout:↑H\nt:1ms\nout:↓I\nt:1ms\nout:↑I",
+        result
+    );
+}


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add seq keys that are never output as OS events but can participate in sequences.

The seq keys are mapped to a hopefully low-risk set of already-mapped codes (for Linux at least). The advantage of using already-mapped codes is that they won't change purpose in the future. The disadvantage is of course that there are already known uses of these keys. The known purpose is presumed to be low risk for negatively impacting users in practice, and a workaround is to not map keys from `defsrc`.

Maybe closes #950 

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
