### PR TITLE
feat: allow `<` as alias for `lsgt`

### DIFF
--- a/docs/fancy_symbols.md
+++ b/docs/fancy_symbols.md
@@ -16,7 +16,7 @@
   |⏎ ↩ ⌤ ␤       	|`return_or_enter`                         	|
   |︔ ⸴ ．⁄        	|`semicolon` / `comma` / `period` / `slash`	|
   |⧵ ＼           	|`backslash`                               	|
-  |﹨             	|`non_us_backslash`                        	|
+  |﹨ <           	|`non_us_backslash`                        	|
   |【 「 〔 ⎡       	|`open_bracket`                            	|
   |】 」 〕 ⎣       	|`close_bracket`                           	|
   |ˋ ˜           	|`grave_accent_and_tilde`                  	|

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -216,7 +216,7 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "NumpadComma" | "kp," | "🔢⸴" =>OsCode::KEY_KPCOMMA,
         "ssrq" | "sys" => OsCode::KEY_SYSRQ,
         // Typically the Non-US backslash, near the left shift key
-        "IntlBackslash" | "102d" | "lsgt" | "nubs" | "nonusbslash" | "﹨" => OsCode::KEY_102ND,
+        "IntlBackslash" | "102d" | "lsgt" | "nubs" | "nonusbslash" | "﹨" | "<" => OsCode::KEY_102ND,
         "ScrollLock" | "scrlck" | "slck" | "⇳🔒" => OsCode::KEY_SCROLLLOCK,
         "Pause" | "pause" | "break" | "brk" => OsCode::KEY_PAUSE,
         "WakeUp" | "wkup" => OsCode::KEY_WAKEUP,


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Allows `<` as alias for `lsgt` (non-US backslash). There is an existing `﹨` alias but it's non-ASCII, doesn't represent the actual symbol (on my keyboard, at least) and the character isn't present even in some "big" fonts.

If I can have a green light on this I will also update the docs accordingly.

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [x]
