### PR TITLE
refactor: couple KanataLayers with allocations

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -268,18 +268,18 @@ pub fn new_from_str(cfg_text: &str) -> MResult<Cfg> {
         DEF_LOCAL_KEYS,
         Err("environment variables are not supported".into()),
     )?;
-        let (layers, allocations) = icfg.klayers.get();
-        let key_outputs = create_key_outputs(&layers, &icfg.overrides, &icfg.chords_v2);
-        let switch_max_key_timing = s.switch_max_key_timing.get();
-         let mut layout = KanataLayout::new(
-            Layout::new_with_trans_action_settings(
-                s.a.sref(s.defsrc_layer),
-                layers,
-                icfg.options.trans_resolution_behavior_v2,
-                icfg.options.delegate_to_first_layer,
-            ),
-            allocations,
-        );
+    let (layers, allocations) = icfg.klayers.get();
+    let key_outputs = create_key_outputs(&layers, &icfg.overrides, &icfg.chords_v2);
+    let switch_max_key_timing = s.switch_max_key_timing.get();
+    let mut layout = KanataLayout::new(
+        Layout::new_with_trans_action_settings(
+            s.a.sref(s.defsrc_layer),
+            layers,
+            icfg.options.trans_resolution_behavior_v2,
+            icfg.options.delegate_to_first_layer,
+        ),
+        allocations,
+    );
     layout.bm().chords_v2 = icfg.chords_v2;
     layout.bm().quick_tap_hold_timeout = icfg.options.concurrent_tap_hold;
     layout.bm().oneshot.on_press_release_delay = icfg.options.rapid_event_delay;
@@ -319,11 +319,10 @@ pub struct LayerInfo {
 fn parse_cfg(p: &Path) -> MResult<Cfg> {
     let mut s = ParserState::default();
     let icfg = parse_cfg_raw(p, &mut s)?;
-    let (layers, allocations) = icfg.klayers.get() ;
+    let (layers, allocations) = icfg.klayers.get();
     let key_outputs = create_key_outputs(&layers, &icfg.overrides, &icfg.chords_v2);
     let switch_max_key_timing = s.switch_max_key_timing.get();
-    let mut layout =
-        KanataLayout::new(
+    let mut layout = KanataLayout::new(
         Layout::new_with_trans_action_settings(
             s.a.sref(s.defsrc_layer),
             layers,
@@ -823,7 +822,7 @@ pub fn parse_cfg_raw_string(
         .into());
     }
     let layers = s.a.bref_slice(klayers);
-    let klayers = unsafe {KanataLayers::new(layers, s.a.clone())};
+    let klayers = unsafe { KanataLayers::new(layers, s.a.clone()) };
     Ok(IntermediateCfg {
         options: cfg,
         mapped_keys,

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -14,10 +14,10 @@ fn lock<T>(lk: &Mutex<T>) -> MutexGuard<T> {
     }
 }
 
-fn parse_cfg(cfg: &str) -> Result<(IntermediateCfg, ParserState)> {
+fn parse_cfg(cfg: &str) -> Result<IntermediateCfg> {
     let _lk = lock(&CFG_PARSE_LOCK);
     let mut s = ParserState::default();
-    Ok((
+    Ok(
         parse_cfg_raw_string(
             cfg,
             &mut s,
@@ -28,8 +28,7 @@ fn parse_cfg(cfg: &str) -> Result<(IntermediateCfg, ParserState)> {
             DEF_LOCAL_KEYS,
             Err("env vars not implemented".into()),
         )?,
-        s,
-    ))
+    )
 }
 
 #[test]
@@ -641,8 +640,9 @@ fn parse_switch() {
     let (op5, op6) = OpCode::new_historical_input((FAKE_KEY_ROW, 1), 0);
     let (op7, op8) =
         OpCode::new_historical_input((NORMAL_KEY_ROW, u16::from(OsCode::KEY_LEFTSHIFT)), 7);
+    let (klayers, _) = res.klayers.get();
     assert_eq!(
-        res.klayers[0][0][OsCode::KEY_A.as_u16() as usize],
+        klayers[0][0][OsCode::KEY_A.as_u16() as usize],
         Action::Switch(&Switch {
             cases: &[
                 (
@@ -820,8 +820,9 @@ fn parse_virtualkeys() {
         ""
     })
     .unwrap();
+    let (klayers, _) = res.klayers.get();
     assert_eq!(
-        res.klayers[0][0][OsCode::KEY_A.as_u16() as usize],
+        klayers[0][0][OsCode::KEY_A.as_u16() as usize],
         Action::Custom(
             &[&CustomAction::FakeKey {
                 coord: Coord { x: 1, y: 0 },
@@ -831,7 +832,7 @@ fn parse_virtualkeys() {
         ),
     );
     assert_eq!(
-        res.klayers[0][0][OsCode::KEY_F.as_u16() as usize],
+        klayers[0][0][OsCode::KEY_F.as_u16() as usize],
         Action::Custom(
             &[&CustomAction::FakeKey {
                 coord: Coord { x: 1, y: 1 },
@@ -841,7 +842,7 @@ fn parse_virtualkeys() {
         ),
     );
     assert_eq!(
-        res.klayers[0][0][OsCode::KEY_K.as_u16() as usize],
+        klayers[0][0][OsCode::KEY_K.as_u16() as usize],
         Action::Custom(
             &[&CustomAction::FakeKeyOnRelease {
                 coord: Coord { x: 1, y: 0 },
@@ -851,7 +852,7 @@ fn parse_virtualkeys() {
         ),
     );
     assert_eq!(
-        res.klayers[0][0][OsCode::KEY_P.as_u16() as usize],
+        klayers[0][0][OsCode::KEY_P.as_u16() as usize],
         Action::Custom(
             &[&CustomAction::FakeKeyOnRelease {
                 coord: Coord { x: 1, y: 1 },
@@ -884,8 +885,9 @@ fn parse_on_idle_fakekey() {
     let res = parse_cfg(source)
         .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
         .expect("parses");
+    let (klayers, _) = res.klayers.get();
     assert_eq!(
-        res.0.klayers[0][0][OsCode::KEY_A.as_u16() as usize],
+        klayers[0][0][OsCode::KEY_A.as_u16() as usize],
         Action::Custom(
             &[&CustomAction::FakeKeyOnIdle(FakeKeyOnIdle {
                 coord: Coord { x: 1, y: 0 },

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -17,18 +17,16 @@ fn lock<T>(lk: &Mutex<T>) -> MutexGuard<T> {
 fn parse_cfg(cfg: &str) -> Result<IntermediateCfg> {
     let _lk = lock(&CFG_PARSE_LOCK);
     let mut s = ParserState::default();
-    Ok(
-        parse_cfg_raw_string(
-            cfg,
-            &mut s,
-            &PathBuf::from("test"),
-            &mut FileContentProvider {
-                get_file_content_fn: &mut |_| unimplemented!(),
-            },
-            DEF_LOCAL_KEYS,
-            Err("env vars not implemented".into()),
-        )?,
-    )
+    Ok(parse_cfg_raw_string(
+        cfg,
+        &mut s,
+        &PathBuf::from("test"),
+        &mut FileContentProvider {
+            get_file_content_fn: &mut |_| unimplemented!(),
+        },
+        DEF_LOCAL_KEYS,
+        Err("env vars not implemented".into()),
+    )?)
 }
 
 #[test]

--- a/parser/src/layers.rs
+++ b/parser/src/layers.rs
@@ -1,8 +1,11 @@
 use kanata_keyberon::layout::*;
 
+use crate::cfg::alloc::*;
 use crate::cfg::KanataAction;
 use crate::custom_action::*;
 use crate::keys::OsCode;
+
+use std::sync::Arc;
 
 // OsCode::KEY_MAX is the biggest OsCode
 pub const KEYS_IN_ROW: usize = OsCode::KEY_MAX as usize;
@@ -10,8 +13,19 @@ pub const LAYER_ROWS: usize = 2;
 
 pub type IntermediateLayers = Box<[[Row; LAYER_ROWS]]>;
 
-pub type KanataLayers =
+pub type KLayers =
     Layers<'static, KEYS_IN_ROW, LAYER_ROWS, &'static &'static [&'static CustomAction]>;
+
+pub struct KanataLayers {
+    layers: Layers<'static, KEYS_IN_ROW, LAYER_ROWS, &'static &'static [&'static CustomAction]>,
+    _allocations: Arc<Allocations>,
+}
+
+impl std::fmt::Debug for KanataLayers {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KanataLayers").finish()
+    }
+}
 
 pub type Row = [kanata_keyberon::action::Action<'static, &'static &'static [&'static CustomAction]>;
     KEYS_IN_ROW];
@@ -29,4 +43,21 @@ pub fn new_layers(layers: usize) -> IntermediateLayers {
         ]);
     }
     layers.into_boxed_slice()
+}
+
+impl KanataLayers {
+    /// # Safety
+    ///
+    /// The allocations must hold all of the &'static pointers found in layers.
+    pub(crate) unsafe fn new(layers: KLayers, allocations: Arc<Allocations>) -> Self {
+        Self {
+            layers,
+            _allocations: allocations,
+        }
+    }
+
+    pub(crate) fn get(&self) -> (KLayers, Arc<Allocations>)
+    {
+        (self.layers, self._allocations.clone())
+    }
 }

--- a/parser/src/layers.rs
+++ b/parser/src/layers.rs
@@ -56,8 +56,7 @@ impl KanataLayers {
         }
     }
 
-    pub(crate) fn get(&self) -> (KLayers, Arc<Allocations>)
-    {
+    pub(crate) fn get(&self) -> (KLayers, Arc<Allocations>) {
         (self.layers, self._allocations.clone())
     }
 }


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Couple allocations to the layers that use them for better safety.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] existing test coverage is sufficient
