### PR TITLE
ci: adjust how jobs run

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,23 +33,51 @@ jobs:
     - name: Check fmt
       run: cargo fmt --all --check
 
-  build-test-clippy:
+  build-test-clippy-linux:
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
 
         include:
           - build: linux
             os: ubuntu-latest
             target: x86_64-unknown-linux-musl
 
+    steps:
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: "persist-cross-job"
+        workspaces: ./
+    - run: rustup component add clippy
+
+    - name: Run tests no features
+      run: cargo test --all --no-default-features
+    - name: Run clippy no features
+      run: cargo clippy --all --no-default-features -- -D warnings
+
+    - name: Run tests default features
+      run: cargo test --all
+    - name: Run clippy default features
+      run: cargo clippy --all -- -D warnings
+
+    - name: Run tests cmd
+      run: cargo test --all --features=cmd
+    - name: Run clippy cmd
+      run: cargo clippy --all --features=cmd -- -D warnings
+
+    - name: Run tests simulated output
+      run: cargo test --features=simulated_output -- sim_tests
+    - name: Run clippy simulated output
+      run: cargo clippy --all --features=simulated_output,cmd -- -D warnings
+
+  build-test-clippy-windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
           - build: windows
             os: windows-latest
             target: x86_64-pc-windows-msvc
-
-          - build: macos
-            os: macos-latest
-            target: x86_64-apple-darwin
 
     steps:
     - uses: actions/checkout@v3
@@ -79,5 +107,34 @@ jobs:
     - name: Run clippy all features
       run: cargo clippy --all --features=cmd,interception_driver,win_sendinput_send_scancodes -- -D warnings
 
+    - name: Run tests simulated output
+      run: cargo test --features=simulated_output -- sim_tests
     - name: Run clippy simulated output
       run: cargo clippy --all --features=simulated_output,cmd -- -D warnings
+
+  build-test-clippy-macos:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - build: macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: "persist-cross-job"
+        workspaces: ./
+    - run: rustup component add clippy
+
+    - name: Run tests default features
+      run: cargo test --all
+    - name: Run clippy default features
+      run: cargo clippy --all -- -D warnings
+
+    - name: Run tests cmd
+      run: cargo test --all --features=cmd
+    - name: Run clippy all features
+      run: cargo clippy --all --features=cmd -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
   build-test-clippy-linux:
     runs-on: ${{ matrix.os }}
     strategy:
-
+      matrix:
         include:
           - build: linux
             os: ubuntu-latest

--- a/src/tests/sim_tests/chord_sim_tests.rs
+++ b/src/tests/sim_tests/chord_sim_tests.rs
@@ -3,10 +3,12 @@ use super::*;
 static SIMPLE_NONOVERLAPPING_CHORD_CFG: &str = "\
 (defcfg process-unmapped-keys yes concurrent-tap-hold yes) \
 (defsrc) \
+(defalias c c)
+(defvar d d)
 (deflayer base) \
 (defchordsv2-experimental \
-  (a b) c 200 all-released () \
-  (b z) d 200 first-release () \
+  (a b) @c 200 all-released () \
+  (b z) $d 200 first-release () \
 )";
 
 #[test]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "kanata"
-version = "1.6.0-prerelease-4"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "kanata-keyberon"
-version = "0.160.4"
+version = "0.160.5"
 dependencies = [
  "arraydeque",
  "heapless",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "kanata-parser"
-version = "0.160.4"
+version = "0.160.5"
 dependencies = [
  "anyhow",
  "itertools",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "kanata-tcp-protocol"
-version = "0.160.4"
+version = "0.160.5"
 dependencies = [
  "serde",
  "serde_derive",


### PR DESCRIPTION
Split up pipeline jobs by operating system.

The macOS pipeline has been inconsistently failing for some reason, with an incomprehensible SIGABRT of all things. The main goal of this PR is a shot-in-the-dark that reducing the stuff that runs in the macOS pipeline will help with the consistency.

It's also a generally good improvement anyway because Linux and macOS don't use a bunch of the feature flags that Windows uses.

Some other miscellaneous test+lock changes made it in too, not worth undoing that.