### PR TITLE
feat(sequences): add `O-(...)` for any-order overlapping keys

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -1095,6 +1095,12 @@ If you need help, please feel welcome to ask in the GitHub discussions.
     dotorg (nop8 nop9)
 )
 
+;; A key list within O-(...) signifies simultaneous presses.
+(defseq
+    dotcom (O-(. c m))
+    dotorg (O-(. r g))
+)
+
 ;; Input chording.
 ;;
 ;; Not to be confused with output chords (like C-S-a or the chords layer

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2625,11 +2625,11 @@ precisely, the action triggered is:
     dotcom (. S-3)
     dotorg (. S-4)
 
-             ;; The shifted letters in parentheses means a single press of lsft
-             ;; must remain held while both h and then s are pressed.
-             ;; This is not the same as S-h S-s, which means that the lsft key
-             ;; must be released and repressed between the h and s presses.
-    https (. S-(h s))
+    ;;     The shifted letters in parentheses means a single press of lsft
+    ;;     must remain held while both h and then s are pressed.
+    ;;     This is not the same as S-h S-s, which means that the lsft key
+    ;;     must be released and repressed between the h and s presses.
+    https (S-(h s))
 )
 (defvirtualkeys
     dotcom (macro . c o m)
@@ -2652,11 +2652,12 @@ alongside templates to define sequences below.
 (deflayer base
         sldr nop0 nop1 nop2)
 (deftemplate seq (vk-name input-keys output-action)
-  (defvirtualkeys $vk-name $output-action)
-  (defseq $vk-name $input-keys)
+        sldr(defvirtualkeys $vk-name $output-action)
+        sldr(defseq $vk-name $input-keys)
 )
-(template-expand seq dotcom (nop0 nop1) (macro . c o m))
-(template-expand seq dotorg (nop0 nop2) (macro . o r g))
+;; template-expand has a shortened form: t!
+(t! seq dotcom (nop0 nop1) (macro . c o m))
+(t! seq dotorg (nop0 nop2) (macro . o r g))
 ----
 
 If 10 special nop keys do not seem sufficient,
@@ -2683,11 +2684,20 @@ while treating `nop7-nop9` as prefixes:
 )
 ----
 
-For more context about sequences, you can read the
-https://github.com/jtroo/kanata/issues/97[design and motivation of sequences].
-You may also be interested in
-https://github.com/jtroo/kanata/blob/main/docs/sequence-adding-chords-ideas.md[the document describing chords in sequences]
-to read about how chords in sequences behave.
+==== Overlapping keys in any order
+
+Within the key list of `defseq` configuration items,
+the special `O-` list prefix can be used to denote a set of keys that must
+all be pressed before any are released in order to match the sequence.
+
+For an example, `O-(a b c)` is equivalent to `O-(c b a)`.
+
+.Example:
+[source]
+----
+(defvirtualkey hello (macro h (unshift e l) 5 (unshift l o)))
+(defseq hello (O-(h l o)))
+----
 
 ==== Override the global timeout and input mode
 
@@ -2713,6 +2723,14 @@ The second parameter is an override for `sequence-input-mode`:
 ;; Enter sequence mode and input . with a timeout of 250 and using hidden-delay-type
 (defalias dot-sequence (macro (sequence 250 hidden-delay-type) 10 .))
 ----
+
+==== More about sequences
+
+For more context about sequences, you can read the
+https://github.com/jtroo/kanata/issues/97[design and motivation of sequences].
+You may also be interested in
+https://github.com/jtroo/kanata/blob/main/docs/sequence-adding-chords-ideas.md[the document describing chords in sequences]
+to read about how chords in sequences behave.
 
 [[input-chords]]
 === Input chords
@@ -3089,6 +3107,7 @@ because the current input is in the recency `1` slot.
 The top-level configuration item `deftemplate`
 declares a template that can be expanded multiple times
 via the list item `template-expand`.
+The short form of `template-expand` is `t!`.
 
 The parameters to `deftemplate` in order are:
 
@@ -3161,7 +3180,8 @@ you wouldn't want this. Rather than retyping the code with `fork` and
 )
 
 (template-expand left-hand-chords qwerty a s d f qwa qws qwd qwf)
-(template-expand left-hand-chords dvorak a o e u dva dvo dve dvu)
+;; t! is short for template-expand
+(t! left-hand-chords dvorak a o e u dva dvo dve dvu)
 
 (defsrc a s d f)
 (deflayer dvorak @dva @dvo @dve @dvu)
@@ -3180,7 +3200,7 @@ you wouldn't want this. Rather than retyping the code with `fork` and
   grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
   tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
        ;; usable even inside defsrc
-  caps (template-expand home-row j)                            ret
+  caps (t! home-row j)                            ret
   lsft z    x    c    v    b    n    m    ,    .    /    rsft
   lctl lmet lalt           spc            ralt rmet rctl
 )
@@ -3189,7 +3209,7 @@ you wouldn't want this. Rather than retyping the code with `fork` and
   grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
   tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
                                  ;; lists can be passed in too!
-  caps (template-expand home-row (tap-hold 200 200 j lctl))    ret
+  caps (t! home-row (tap-hold 200 200 j lctl))    ret
   lsft z    x    c    v    b    n    m    ,    .    /    rsft
   lctl lmet lalt           spc            ralt rmet rctl
 )

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2699,6 +2699,57 @@ For an example, `O-(a b c)` is equivalent to `O-(c b a)`.
 (defseq hello (O-(h l o)))
 ----
 
+.Sample of more advanced usage
+[%collapsible]
+====
+
+The configuration below showcases context-dependent chording
+with auto-space and auto-deleted spaces from typing punctuation.
+
+For example, chording `(d a y)` and then `(t u e)` will output
+`Tuesday`, while chording `(t u e)` by itself does nothing.
+
+.Example configuration:
+[source]
+----
+(defsrc f1)
+(deflayer base lrld)
+(defcfg process-unmapped-keys yes
+	sequence-input-mode visible-backspaced
+	concurrent-tap-hold true)
+(deftemplate seq (vk-name in out)
+	(defvirtualkeys $vk-name $out)
+	(defseq $vk-name $in))
+
+(defvirtualkeys rls-sft (multi (release-key lsft)(release-key rsft)))
+(defvar rls-sft (on-press tap-vkey rls-sft))
+(deftemplate rls-sft () $rls-sft 5)
+
+(defchordsv2-experimental
+	(d a y) (macro sldr d (t! rls-sft) a y spc nop0) 200 first-release ()
+	(h l o) (macro h (t! rls-sft) e l l o sldr spc nop0) 200 first-release ()
+)
+(t! seq Monday (d a y spc nop0 O-(m o n)) (macro S-m $rls-sft o n d a y nop9 sldr spc nop0))
+(t! seq Tuesday (d a y spc nop0 O-(t u e)) (macro S-t $rls-sft u e s d a y nop9 sldr spc nop0))
+(t! seq DelSpace_. (spc nop0 .) (macro .))
+(t! seq DelSpace_; (spc nop0 ;) (macro ;))
+----
+
+.Try using the above configuration to type the text:
+[source]
+----
+day;
+Day;
+Tuesday.
+day hello
+hello day
+Hello day.
+hello Tuesday
+Hello Monday;
+----
+
+====
+
 ==== Override the global timeout and input mode
 
 An alternative to using `sldr` is the `sequence` action.

--- a/parser/src/cfg/permutations.rs
+++ b/parser/src/cfg/permutations.rs
@@ -44,7 +44,7 @@ fn heaps_alg<T: Clone>(k: usize, a: &mut [T], outs: &mut Vec<Vec<T>>) {
             } else {
                 a.swap(0, k - 1);
             }
-            heaps_alg(k-1, a, outs);
+            heaps_alg(k - 1, a, outs);
         }
     }
 }

--- a/parser/src/cfg/permutations.rs
+++ b/parser/src/cfg/permutations.rs
@@ -1,0 +1,50 @@
+//! Implements Heap's algorithm.
+
+/*
+From Wikipedia:
+
+procedure generate(k: integer, A : array of any):
+    if k = 1 then
+        output(A)
+    else
+        // Generate permutations with k-th unaltered
+        // Initially k = length(A)
+        generate(k - 1, A)
+
+        // Generate permutations for k-th swapped with each k-1 initial
+        for i := 0; i < k-1; i += 1 do
+            // Swap choice dependent on parity of k (even or odd)
+            if k is even then
+                swap(A[i], A[k-1]) // zero-indexed, the k-th is at k-1
+            else
+                swap(A[0], A[k-1])
+            end if
+            generate(k - 1, A)
+        end for
+    end if
+*/
+
+/// Heap's algorithm
+pub fn gen_permutations<T: Clone + Default>(a: &[T]) -> Vec<Vec<T>> {
+    let mut a2 = vec![Default::default(); a.len()];
+    a2.clone_from_slice(a);
+    let mut outs = vec![];
+    heaps_alg(a.len(), &mut a2, &mut outs);
+    outs
+}
+
+fn heaps_alg<T: Clone>(k: usize, a: &mut [T], outs: &mut Vec<Vec<T>>) {
+    if k == 1 {
+        outs.push(a.to_vec());
+    } else {
+        heaps_alg(k - 1, a, outs);
+        for i in 0..k - 1 {
+            if (k % 2) == 0 {
+                a.swap(i, k - 1);
+            } else {
+                a.swap(0, k - 1);
+            }
+            heaps_alg(k-1, a, outs);
+        }
+    }
+}

--- a/parser/src/sequences.rs
+++ b/parser/src/sequences.rs
@@ -2,6 +2,8 @@ use kanata_keyberon::key_code::KeyCode;
 
 pub const MASK_KEYCODES: u16 = 0x03FF;
 pub const MASK_MODDED: u16 = 0xFC00;
+pub const KEY_OVERLAP: KeyCode = KeyCode::ErrorRollOver;
+pub const KEY_OVERLAP_MARKER: u16 = 0x0400;
 
 pub fn mod_mask_for_keycode(kc: KeyCode) -> u16 {
     use KeyCode::*;
@@ -11,6 +13,11 @@ pub fn mod_mask_for_keycode(kc: KeyCode) -> u16 {
         LAlt => 0x2000,
         RAlt => 0x1000,
         LGui | RGui => 0x0800,
+        // This is not real... this is a marker to help signify that key presses should be
+        // overlapping. The way this will look in the chord sequence is as such:
+        //
+        //   [ (0x0400 | X), (0x0400 | Y), (0x0400) ]
+        ErrorRollOver => KEY_OVERLAP_MARKER,
         _ => 0,
     }
 }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -930,7 +930,14 @@ impl Kanata {
                     .get_or_descendant_exists(&state.overlapped_sequence)
                 {
                     HasValue((i, j)) => {
-                        do_successful_sequence_termination(&mut self.kbd_out, state, layout, i, j, EndSequenceType::Overlap)?;
+                        do_successful_sequence_termination(
+                            &mut self.kbd_out,
+                            state,
+                            layout,
+                            i,
+                            j,
+                            EndSequenceType::Overlap,
+                        )?;
                         self.sequence_state = None;
                     }
                     NotInTrie => {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -930,7 +930,7 @@ impl Kanata {
                     .get_or_descendant_exists(&state.overlapped_sequence)
                 {
                     HasValue((i, j)) => {
-                        do_successful_sequence_termination(&mut self.kbd_out, state, layout, i, j)?;
+                        do_successful_sequence_termination(&mut self.kbd_out, state, layout, i, j, EndSequenceType::Overlap)?;
                         self.sequence_state = None;
                     }
                     NotInTrie => {

--- a/src/kanata/sequences.rs
+++ b/src/kanata/sequences.rs
@@ -1,0 +1,276 @@
+use super::*;
+
+pub struct SequenceState {
+    /// Keeps track of standard sequence state.
+    /// This includes regular keys, e.g. `a b c`
+    /// and chorded keys, e.g. `S-(d e f)`.
+    pub sequence: Vec<u16>,
+    /// Keeps track of overlapping sequence state.
+    /// E.g. able to detect `O-(g h i)`
+    pub overlapped_sequence: Vec<u16>,
+    /// Determines the handling of keys while sequence state is in progress.
+    pub sequence_input_mode: SequenceInputMode,
+    /// Starts from `sequence_timeout` and ticks down
+    /// approximately every millisecond.
+    /// At 0 the sequence state terminates.
+    pub ticks_until_timeout: u16,
+    /// User-configured sequence timeout setting.
+    pub sequence_timeout: u16,
+}
+
+pub(super) fn get_mod_mask_for_cur_keys(cur_keys: &[KeyCode]) -> u16 {
+    cur_keys
+        .iter()
+        .copied()
+        .fold(0, |a, v| a | mod_mask_for_keycode(v))
+}
+
+pub(super) fn do_sequence_press_logic(
+    state: &mut SequenceState,
+    k: &KeyCode,
+    mod_mask: u16,
+    kbd_out: &mut KbdOut,
+    sequences: &kanata_parser::trie::Trie,
+    sequence_backtrack_modcancel: bool,
+    layout: &mut BorrowedKLayout,
+) -> Result<bool, anyhow::Error> {
+    let mut clear_sequence_state = false;
+    state.ticks_until_timeout = state.sequence_timeout;
+    let osc = OsCode::from(*k);
+    use kanata_parser::trie::GetOrDescendentExistsResult::*;
+    let pushed_into_seq = {
+        // Transform to OsCode and convert modifiers other than altgr/ralt
+        // (same key different names) to the left version, since that's
+        // how chords get transformed when building up sequences.
+        let base = u16::from(match osc {
+            OsCode::KEY_RIGHTSHIFT => OsCode::KEY_LEFTSHIFT,
+            OsCode::KEY_RIGHTMETA => OsCode::KEY_LEFTMETA,
+            OsCode::KEY_RIGHTCTRL => OsCode::KEY_LEFTCTRL,
+            osc => osc,
+        });
+        base | mod_mask
+    };
+    match state.sequence_input_mode {
+        SequenceInputMode::VisibleBackspaced => {
+            press_key(kbd_out, osc)?;
+        }
+        SequenceInputMode::HiddenSuppressed | SequenceInputMode::HiddenDelayType => {}
+    }
+    log::debug!("sequence got {k:?}");
+    state.sequence.push(pushed_into_seq);
+    let pushed_into_overlap_seq = (pushed_into_seq & MASK_KEYCODES) | KEY_OVERLAP_MARKER;
+    state.overlapped_sequence.push(pushed_into_overlap_seq);
+    let mut res = sequences.get_or_descendant_exists(&state.sequence);
+
+    // Check for invalid termination of standard variant of sequence state.
+    // Can potentially backtrack and overwrite modded keystates as well as overlap keystates, which
+    // might exist in the sequence because of an earlier invalid termination where the standard
+    // sequence got filled in with overlap sequence data.
+    let mut is_invalid_termination_standard = false;
+    if res == NotInTrie {
+        is_invalid_termination_standard = {
+            let mut no_valid_seqs = true;
+            // If applicable, check again with modifier bits unset.
+            for i in (0..state.sequence.len()).rev() {
+                // Note: proper bounds are immediately above.
+                // Can't use iter_mut due to borrowing issues.
+                if state.sequence[i] == KEY_OVERLAP_MARKER {
+                    state.sequence.remove(i);
+                } else if sequence_backtrack_modcancel {
+                    state.sequence[i] &= MASK_KEYCODES;
+                } else {
+                    state.sequence[i] &= !KEY_OVERLAP_MARKER;
+                }
+                res = sequences.get_or_descendant_exists(&state.sequence);
+                if res != NotInTrie {
+                    no_valid_seqs = false;
+                    break;
+                }
+            }
+            no_valid_seqs
+        };
+    }
+
+    // Check for invalid termination of overlap variant of sequence state.
+    // This variant does not backtrack today because I haven't figured out how to do that easily.
+    // It does do some attempts to stay valid by modifying the tail of the sequence though.
+    let mut res_overlapped = sequences.get_or_descendant_exists(&state.overlapped_sequence);
+    let is_invalid_termination_overlapped = if res_overlapped == NotInTrie {
+        // Try ending the overlapping and push overlapping seq again.
+        let index_of_last = state.overlapped_sequence.len() - 1;
+        state.overlapped_sequence[index_of_last] = KEY_OVERLAP_MARKER;
+        state.overlapped_sequence.push(pushed_into_overlap_seq);
+        res_overlapped = sequences.get_or_descendant_exists(&state.overlapped_sequence);
+        let index_of_last = index_of_last + 1;
+        if res_overlapped == NotInTrie {
+            // Try checking the trie after setting the latest key to not have the overlapping
+            // marker.
+            state.overlapped_sequence[index_of_last] = pushed_into_seq;
+            res_overlapped = sequences.get_or_descendant_exists(&state.overlapped_sequence);
+            if res_overlapped == NotInTrie {
+                if pushed_into_seq & MASK_KEYCODES == pushed_into_seq {
+                    // Avoid calling get_or_descendant_exists if there is no difference, to save on
+                    // doing work checking in the trie.
+                    true
+                } else {
+                    // Try unmodded `pushed_into_seq`.
+                    state.overlapped_sequence[index_of_last] = pushed_into_seq & MASK_KEYCODES;
+                    res_overlapped = sequences.get_or_descendant_exists(&state.overlapped_sequence);
+                    res_overlapped == NotInTrie
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    match (
+        is_invalid_termination_standard,
+        is_invalid_termination_overlapped,
+    ) {
+        (false, false) => {}
+        (false, true) => {
+            log::debug!("overlap seq is invalid; filling with standard seq");
+            // Overwrite overlapped with non-overlapped tracking
+            state.overlapped_sequence.clear();
+            state
+                .overlapped_sequence
+                .extend(state.sequence.iter().copied());
+            res_overlapped = sequences.get_or_descendant_exists(&state.overlapped_sequence);
+        }
+        (true, false) => {
+            log::debug!("standard seq is invalid; filling with overlap seq");
+            state.sequence.clear();
+            state
+                .sequence
+                .extend(state.overlapped_sequence.iter().copied());
+            if state.sequence.last().copied().unwrap_or(0) != KEY_OVERLAP_MARKER
+                && state.overlapped_sequence.last().copied().unwrap_or(0) >= KEY_OVERLAP_MARKER
+            {
+                // Always treat non-overlapping sequence as if overlap state has
+                // ended; if overlapped_sequence itself has an overlap state.
+                state.sequence.push(KEY_OVERLAP_MARKER);
+            }
+            res = sequences.get_or_descendant_exists(&state.sequence);
+        }
+        (true, true) => {
+            log::debug!("got invalid seq; exiting seq mode");
+            cancel_sequence(state, kbd_out)?;
+            clear_sequence_state = true;
+        }
+    }
+
+    // Check for successful sequence termination.
+    if let HasValue((i, j)) = res_overlapped {
+        // First, check for a valid simultaneous completion.
+        // Simultaneous completion should take priority.
+        clear_sequence_state = true;
+        do_successful_sequence_termination(kbd_out, state, layout, i, j)?;
+    } else if let HasValue((i, j)) = res {
+        clear_sequence_state = true;
+        // Try terminating the overlapping and check if simultaneous termination worked.
+        // Simultaneous completion should take priority.
+        state.overlapped_sequence.push(KEY_OVERLAP_MARKER);
+        if let HasValue((oi, oj)) = sequences.get_or_descendant_exists(&state.overlapped_sequence) {
+            do_successful_sequence_termination(kbd_out, state, layout, oi, oj)?;
+        } else {
+            do_successful_sequence_termination(kbd_out, state, layout, i, j)?;
+        }
+    }
+    Ok(clear_sequence_state)
+}
+
+pub(super) fn do_successful_sequence_termination(
+    kbd_out: &mut KbdOut,
+    state: &mut SequenceState,
+    layout: &mut Layout<'_, 767, 2, &&[&CustomAction]>,
+    i: u8,
+    j: u16,
+) -> Result<(), anyhow::Error> {
+    log::debug!("sequence complete; tapping fake key");
+    match state.sequence_input_mode {
+        SequenceInputMode::HiddenSuppressed | SequenceInputMode::HiddenDelayType => {}
+        SequenceInputMode::VisibleBackspaced => {
+            // Release all keys since they might modify the behaviour of
+            // backspace into an undesirable behaviour, for example deleting
+            // more characters than it should.
+            layout.states.retain(|s| match s {
+                State::NormalKey { keycode, .. } => {
+                    // Ignore the error, ugly to return it from retain, and
+                    // this is very unlikely to happen anyway.
+                    let _ = release_key(kbd_out, keycode.into());
+                    false
+                }
+                _ => true,
+            });
+            for k in state.sequence.iter().copied() {
+                // Check for pressed modifiers and don't input backspaces for
+                // those since they don't output characters that can be
+                // backspaced.
+                if k == KEY_OVERLAP_MARKER {
+                    continue;
+                };
+                let osc = OsCode::from(k & MASK_KEYCODES);
+                match osc {
+                    // Known bug: most non-characters-outputting keys are not
+                    // listed. I'm too lazy to list them all. Just use
+                    // character-outputting keys (and modifiers) in sequences
+                    // please! Or switch to a different input mode? It doesn't
+                    // really make sense to use non-typing characters other
+                    // than modifiers does it? Since those would probably be
+                    // further away from the home row, so why use them? If one
+                    // desired to fix this, a shorter list of keys would
+                    // probably be the list of keys that **do** output
+                    // characters than those that don't.
+                    OsCode::KEY_LEFTSHIFT
+                    | OsCode::KEY_RIGHTSHIFT
+                    | OsCode::KEY_LEFTMETA
+                    | OsCode::KEY_RIGHTMETA
+                    | OsCode::KEY_LEFTCTRL
+                    | OsCode::KEY_RIGHTCTRL
+                    | OsCode::KEY_LEFTALT
+                    | OsCode::KEY_RIGHTALT => continue,
+                    osc if matches!(u16::from(osc), KEY_IGNORE_MIN..=KEY_IGNORE_MAX) => continue,
+                    _ => {
+                        kbd_out.press_key(OsCode::KEY_BACKSPACE)?;
+                        kbd_out.release_key(OsCode::KEY_BACKSPACE)?;
+                    }
+                }
+            }
+        }
+    }
+    for k in state.sequence.iter().copied() {
+        if k == KEY_OVERLAP_MARKER {
+            continue;
+        };
+        let kc = KeyCode::from(OsCode::from(k & MASK_KEYCODES));
+        layout.states.retain(|s| match s {
+            State::NormalKey { keycode, .. } => kc != *keycode,
+            _ => true,
+        });
+    }
+    layout.event(Event::Press(i, j));
+    layout.event(Event::Release(i, j));
+    Ok(())
+}
+
+pub(super) fn cancel_sequence(state: &SequenceState, kbd_out: &mut KbdOut) -> Result<()> {
+    match state.sequence_input_mode {
+        SequenceInputMode::HiddenDelayType => {
+            for code in state.sequence.iter().copied() {
+                let code = code & kanata_parser::sequences::MASK_KEYCODES;
+                if let Some(osc) = OsCode::from_u16(code) {
+                    // BUG: chorded_hidden_delay_type
+                    press_key(kbd_out, osc)?;
+                    release_key(kbd_out, osc)?;
+                }
+            }
+        }
+        SequenceInputMode::HiddenSuppressed | SequenceInputMode::VisibleBackspaced => {}
+    }
+    Ok(())
+}

--- a/src/kanata/sequences.rs
+++ b/src/kanata/sequences.rs
@@ -188,9 +188,23 @@ pub(super) fn do_sequence_press_logic(
         // Simultaneous completion should take priority.
         state.overlapped_sequence.push(KEY_OVERLAP_MARKER);
         if let HasValue((oi, oj)) = sequences.get_or_descendant_exists(&state.overlapped_sequence) {
-            do_successful_sequence_termination(kbd_out, state, layout, oi, oj, EndSequenceType::Overlap)?;
+            do_successful_sequence_termination(
+                kbd_out,
+                state,
+                layout,
+                oi,
+                oj,
+                EndSequenceType::Overlap,
+            )?;
         } else {
-            do_successful_sequence_termination(kbd_out, state, layout, i, j, EndSequenceType::Standard)?;
+            do_successful_sequence_termination(
+                kbd_out,
+                state,
+                layout,
+                i,
+                j,
+                EndSequenceType::Standard,
+            )?;
         }
     }
     Ok(clear_sequence_state)

--- a/src/tests/sim_tests/seq_sim_tests.rs
+++ b/src/tests/sim_tests/seq_sim_tests.rs
@@ -34,7 +34,7 @@ fn chorded_keys_visible_backspaced() {
          d:0 u:0 d:rsft t:50 d:a u:rsft t:50 d:b u:a u:b t:500",
     );
     assert_eq!(
-        "t:2ms\nout:↓LShift\nt:48ms\nout:↓A\nt:1ms\nout:↓B\nout:↑LShift\nout:↑A\nout:↑B\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nt:1ms\nout:↑LShift\nout:↑A\nout:↑B\nout:↓Z\nt:1ms\nout:↑Z\nt:549ms\nout:↓RShift\nt:48ms\nout:↓A\nt:1ms\nout:↓B\nout:↑RShift\nout:↑A\nout:↑B\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nt:1ms\nout:↑RShift\nout:↑A\nout:↑B\nout:↓Z\nt:1ms\nout:↑Z\nt:549ms\nout:↓RShift\nt:48ms\nout:↓A\nt:1ms\nout:↑RShift\nt:49ms\nout:↓B\nt:1ms\nout:↑A\nt:1ms\nout:↑B",
+        "t:2ms\nout:↓LShift\nt:48ms\nout:↓A\nt:1ms\nout:↓B\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nt:1ms\nout:↑LShift\nout:↑A\nout:↑B\nout:↓Z\nt:1ms\nout:↑Z\nt:549ms\nout:↓RShift\nt:48ms\nout:↓A\nt:1ms\nout:↓B\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nt:1ms\nout:↑A\nout:↑B\nout:↓Z\nt:1ms\nout:↑Z\nt:47ms\nout:↑RShift\nt:502ms\nout:↓RShift\nt:48ms\nout:↓A\nt:1ms\nout:↑RShift\nt:49ms\nout:↓B\nt:1ms\nout:↑A\nt:1ms\nout:↑B",
         result
     );
 }
@@ -65,7 +65,7 @@ const OVERLAP_CFG: &str = "
 fn overlapping_activate_overlap() {
     let result = simulate(OVERLAP_CFG, "d:0 d:a d:b t:100 u:a u:b u:0");
     assert_eq!(
-        "t:1ms\nout:↓A\nt:1ms\nout:↓B\nout:↑A\nout:↑B\n\
+        "t:1ms\nout:↓A\nt:1ms\nout:↓B\n\
          out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nt:1ms\nout:↑A\nout:↑B\n\
          out:↓Y\nt:1ms\nout:↑Y",
         result
@@ -76,7 +76,7 @@ fn overlapping_activate_overlap() {
 fn overlapping_activate_nonoverlap() {
     let result = simulate(OVERLAP_CFG, "d:0 d:a t:10 u:a t:10 d:b t:10 u:b t:10 u:0");
     assert_eq!(
-        "t:1ms\nout:↓A\nt:9ms\nout:↑A\nt:10ms\nout:↓B\nout:↑B\n\
+        "t:1ms\nout:↓A\nt:9ms\nout:↑A\nt:10ms\nout:↓B\n\
         out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
         t:1ms\nout:↑B\nout:↓Z\nt:1ms\nout:↑Z",
         result
@@ -87,7 +87,7 @@ fn overlapping_activate_nonoverlap() {
 fn overlapping_then_nonoverlap_activate_overlap() {
     let result = simulate(OVERLAP_CFG, "d:0 d:c d:d d:e t:100 u:c u:d u:e u:0");
     assert_eq!(
-        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↓E\nout:↑C\nout:↑D\nout:↑E\n\
+        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↓E\n\
          out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
          t:1ms\nout:↑C\nout:↑D\nout:↑E\nout:↓L\nt:1ms\nout:↑L",
         result
@@ -98,7 +98,7 @@ fn overlapping_then_nonoverlap_activate_overlap() {
 fn overlapping_then_nonoverlap_activate_non_overlap() {
     let result = simulate(OVERLAP_CFG, "d:0 d:c u:c d:d d:e t:100 u:d u:e u:0");
     assert_eq!(
-        "t:1ms\nout:↓C\nt:1ms\nout:↑C\nt:1ms\nout:↓D\nt:1ms\nout:↓E\nout:↑D\nout:↑E\n\
+        "t:1ms\nout:↓C\nt:1ms\nout:↑C\nt:1ms\nout:↓D\nt:1ms\nout:↓E\n\
          out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
          t:1ms\nout:↑D\nout:↑E\nout:↓M\nt:1ms\nout:↑M",
         result
@@ -109,7 +109,7 @@ fn overlapping_then_nonoverlap_activate_non_overlap() {
 fn overlapping_then_overlap_activate_overlap1() {
     let result = simulate(OVERLAP_CFG, "d:0 d:c d:d d:f d:g t:100");
     assert_eq!(
-        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↓F\nt:1ms\nout:↓G\nout:↑C\nout:↑D\nout:↑F\nout:↑G\n\
+        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↓F\nt:1ms\nout:↓G\n\
          out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
          t:1ms\nout:↑C\nout:↑D\nout:↑F\nout:↑G\nout:↓N\nt:1ms\nout:↑N",
         result
@@ -120,7 +120,7 @@ fn overlapping_then_overlap_activate_overlap1() {
 fn overlapping_then_overlap_activate_overlap2() {
     let result = simulate(OVERLAP_CFG, "d:0 d:c d:d u:c u:d d:f d:g t:100");
     assert_eq!(
-        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↑C\nt:1ms\nout:↑D\nt:1ms\nout:↓F\nt:1ms\nout:↓G\nout:↑F\nout:↑G\n\
+        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↑C\nt:1ms\nout:↑D\nt:1ms\nout:↓F\nt:1ms\nout:↓G\n\
          out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
          t:1ms\nout:↑F\nout:↑G\nout:↓N\nt:1ms\nout:↑N",
         result
@@ -131,7 +131,7 @@ fn overlapping_then_overlap_activate_overlap2() {
 fn overlapping_then_overlap_activate_overlap3() {
     let result = simulate(OVERLAP_CFG, "d:0 d:c d:d u:c u:d t:10 d:f d:g t:100");
     assert_eq!(
-        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↑C\nt:1ms\nout:↑D\nt:6ms\nout:↓F\nt:1ms\nout:↓G\nout:↑F\nout:↑G\n\
+        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↑C\nt:1ms\nout:↑D\nt:6ms\nout:↓F\nt:1ms\nout:↓G\n\
          out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
          t:1ms\nout:↑F\nout:↑G\nout:↓N\nt:1ms\nout:↑N",
         result
@@ -142,7 +142,7 @@ fn overlapping_then_overlap_activate_overlap3() {
 fn overlapping_then_overlap_activate_nonoverlap() {
     let result = simulate(OVERLAP_CFG, "d:0 d:c d:d u:c u:d t:10 d:f u:f d:g t:100");
     assert_eq!(
-        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↑C\nt:1ms\nout:↑D\nt:6ms\nout:↓F\nt:1ms\nout:↑F\nt:1ms\nout:↓G\nout:↑G\n\
+        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↑C\nt:1ms\nout:↑D\nt:6ms\nout:↓F\nt:1ms\nout:↑F\nt:1ms\nout:↓G\n\
          out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
          t:1ms\nout:↑G\nout:↓O\nt:1ms\nout:↑O",
         result
@@ -153,7 +153,7 @@ fn overlapping_then_overlap_activate_nonoverlap() {
 fn non_overlapping_then_overlap_activate_overlap() {
     let result = simulate(OVERLAP_CFG, "d:0 d:c u:c d:d u:d d:f d:g t:100");
     assert_eq!(
-        "t:1ms\nout:↓C\nt:1ms\nout:↑C\nt:1ms\nout:↓D\nt:1ms\nout:↑D\nt:1ms\nout:↓F\nt:1ms\nout:↓G\nout:↑F\nout:↑G\n\
+        "t:1ms\nout:↓C\nt:1ms\nout:↑C\nt:1ms\nout:↓D\nt:1ms\nout:↑D\nt:1ms\nout:↓F\nt:1ms\nout:↓G\n\
          out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
          t:1ms\nout:↑F\nout:↑G\nout:↓P\nt:1ms\nout:↑P",
         result

--- a/src/tests/sim_tests/seq_sim_tests.rs
+++ b/src/tests/sim_tests/seq_sim_tests.rs
@@ -39,6 +39,136 @@ fn chorded_keys_visible_backspaced() {
     );
 }
 
+const OVERLAP_CFG: &str = "
+    (defcfg sequence-input-mode visible-backspaced)
+    (defsrc 0)
+    (deflayer base sldr)
+    (defvirtualkeys s1 y)
+    (defvirtualkeys s2 z)
+    (defvirtualkeys s3 l)
+    (defvirtualkeys s4 m)
+    (defvirtualkeys s5 n)
+    (defvirtualkeys s6 o)
+    (defvirtualkeys s7 p)
+    (defvirtualkeys s8 q)
+    (defseq s1 (O-(a b)))
+    (defseq s2 (a b))
+    (defseq s3 (O-(c d) e))
+    (defseq s4 (c d e))
+    (defseq s5 (O-(c d) O-(f g)))
+    (defseq s6 (O-(c d) f g))
+    (defseq s7 (c d O-(f g)))
+    ;; (defseq s8 (c d f g)) KNOWN BUGGY CASE! breaks s6 detection
+    ";
+
+#[test]
+fn overlapping_activate_overlap() {
+    let result = simulate(OVERLAP_CFG, "d:0 d:a d:b t:100 u:a u:b u:0");
+    assert_eq!(
+        "t:1ms\nout:↓A\nt:1ms\nout:↓B\nout:↑A\nout:↑B\n\
+         out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nt:1ms\nout:↑A\nout:↑B\n\
+         out:↓Y\nt:1ms\nout:↑Y",
+        result
+    );
+}
+
+#[test]
+fn overlapping_activate_nonoverlap() {
+    let result = simulate(OVERLAP_CFG, "d:0 d:a t:10 u:a t:10 d:b t:10 u:b t:10 u:0");
+    assert_eq!(
+        "t:1ms\nout:↓A\nt:9ms\nout:↑A\nt:10ms\nout:↓B\nout:↑B\n\
+        out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
+        t:1ms\nout:↑B\nout:↓Z\nt:1ms\nout:↑Z",
+        result
+    );
+}
+
+#[test]
+fn overlapping_then_nonoverlap_activate_overlap() {
+    let result = simulate(OVERLAP_CFG, "d:0 d:c d:d d:e t:100 u:c u:d u:e u:0");
+    assert_eq!(
+        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↓E\nout:↑C\nout:↑D\nout:↑E\n\
+         out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
+         t:1ms\nout:↑C\nout:↑D\nout:↑E\nout:↓L\nt:1ms\nout:↑L",
+        result
+    );
+}
+
+#[test]
+fn overlapping_then_nonoverlap_activate_non_overlap() {
+    let result = simulate(OVERLAP_CFG, "d:0 d:c u:c d:d d:e t:100 u:d u:e u:0");
+    assert_eq!(
+        "t:1ms\nout:↓C\nt:1ms\nout:↑C\nt:1ms\nout:↓D\nt:1ms\nout:↓E\nout:↑D\nout:↑E\n\
+         out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
+         t:1ms\nout:↑D\nout:↑E\nout:↓M\nt:1ms\nout:↑M",
+        result
+    );
+}
+
+#[test]
+fn overlapping_then_overlap_activate_overlap1() {
+    let result = simulate(OVERLAP_CFG, "d:0 d:c d:d d:f d:g t:100");
+    assert_eq!(
+        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↓F\nt:1ms\nout:↓G\nout:↑C\nout:↑D\nout:↑F\nout:↑G\n\
+         out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
+         t:1ms\nout:↑C\nout:↑D\nout:↑F\nout:↑G\nout:↓N\nt:1ms\nout:↑N",
+        result
+    );
+}
+
+#[test]
+fn overlapping_then_overlap_activate_overlap2() {
+    let result = simulate(OVERLAP_CFG, "d:0 d:c d:d u:c u:d d:f d:g t:100");
+    assert_eq!(
+        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↑C\nt:1ms\nout:↑D\nt:1ms\nout:↓F\nt:1ms\nout:↓G\nout:↑F\nout:↑G\n\
+         out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
+         t:1ms\nout:↑F\nout:↑G\nout:↓N\nt:1ms\nout:↑N",
+        result
+    );
+}
+
+#[test]
+fn overlapping_then_overlap_activate_overlap3() {
+    let result = simulate(OVERLAP_CFG, "d:0 d:c d:d u:c u:d t:10 d:f d:g t:100");
+    assert_eq!(
+        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↑C\nt:1ms\nout:↑D\nt:6ms\nout:↓F\nt:1ms\nout:↓G\nout:↑F\nout:↑G\n\
+         out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
+         t:1ms\nout:↑F\nout:↑G\nout:↓N\nt:1ms\nout:↑N",
+        result
+    );
+}
+
+#[test]
+fn overlapping_then_overlap_activate_nonoverlap() {
+    let result = simulate(OVERLAP_CFG, "d:0 d:c d:d u:c u:d t:10 d:f u:f d:g t:100");
+    assert_eq!(
+        "t:1ms\nout:↓C\nt:1ms\nout:↓D\nt:1ms\nout:↑C\nt:1ms\nout:↑D\nt:6ms\nout:↓F\nt:1ms\nout:↑F\nt:1ms\nout:↓G\nout:↑G\n\
+         out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
+         t:1ms\nout:↑G\nout:↓O\nt:1ms\nout:↑O",
+        result
+    );
+}
+
+#[test]
+fn non_overlapping_then_overlap_activate_overlap() {
+    let result = simulate(OVERLAP_CFG, "d:0 d:c u:c d:d u:d d:f d:g t:100");
+    assert_eq!(
+        "t:1ms\nout:↓C\nt:1ms\nout:↑C\nt:1ms\nout:↓D\nt:1ms\nout:↑D\nt:1ms\nout:↓F\nt:1ms\nout:↓G\nout:↑F\nout:↑G\n\
+         out:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\n\
+         t:1ms\nout:↑F\nout:↑G\nout:↓P\nt:1ms\nout:↑P",
+        result
+    );
+}
+
+#[test]
+fn non_overlapping_then_overlap_activate_nothing() {
+    let result = simulate(OVERLAP_CFG, "d:0 d:c u:c d:d u:d d:f u:f d:g t:100");
+    assert_eq!(
+        "t:1ms\nout:↓C\nt:1ms\nout:↑C\nt:1ms\nout:↓D\nt:1ms\nout:↑D\nt:1ms\nout:↓F\nt:1ms\nout:↑F\nt:1ms\nout:↓G",
+        result
+    );
+}
+
 /* BUG: chorded_hidden_delay_type
  *
  * Enable this test when fixing.


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Gets a lot of the way to #979, with the caveat that it is really quite inconvenient to configure. Perhaps a parser can help.

For example:
- `defchords` can be used for basic single-chords
- for composite/contextual chords, a `defchords` output action can trigger sequences, which themselves can use `O-(...)` for subsequent chords

Example:
```
(defsrc f1)
(deflayer base lrld)
(defcfg process-unmapped-keys yes
	sequence-input-mode visible-backspaced
	concurrent-tap-hold true)
(deftemplate seq (vk-name seq-keys action)
	(defseq $vk-name $seq-keys)
	(defvirtualkeys $vk-name $action))

(defvirtualkeys rls-sft (multi (release-key lsft)(release-key rsft)))
(deftemplate rls-sft () (on-press tap-vkey rls-sft) 5)

(defchordsv2-experimental
	(d a y) (macro sldr d (t! rls-sft) a y spc nop0) 200 first-release ()
	(h l o) (macro h (t! rls-sft) e l l o sldr spc nop0) 200 first-release ()
)
(t! seq Monday (d a y spc nop0 O-(m o n)) (macro S-m (t! rls-sft) o n d a y nop9 sldr spc nop0))
(t! seq Tuesday (d a y spc nop0 O-(t u e)) (macro S-t (t! rls-sft) u e s d a y nop9 sldr spc nop0))
(t! seq DelSpace_. (spc nop0 .) (macro .))
(t! seq DelSpace_; (spc nop0 ;) (macro ;))
```

The configuration can write all of the below without having to manually add or backspace the spaces, and only using shift+chords+punctuation.

```
day;
Day;
day hello 
hello day 
Hello day 
hello Tuesday 
hello Monday 
Tuesday.
Monday.
```

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes