### PR TITLE
refactor(test): add code to transform sim output

### DIFF
--- a/src/tests/sim_tests/mod.rs
+++ b/src/tests/sim_tests/mod.rs
@@ -61,3 +61,41 @@ fn simulate(cfg: &str, sim: &str) -> String {
     }
     k.kbd_out.outputs.events.join("\n")
 }
+
+trait SimTransform {
+    /// Changes newlines to spaces.
+    fn to_spaces(self) -> Self;
+    /// Removes out:↑_ items from the string. Also transforms newlines to spaces.
+    fn no_releases(self) -> Self;
+    /// Removes t:_ms items from the string. Also transforms newlines to spaces.
+    fn no_time(self) -> Self;
+    /// Replaces out:↓_ with dn:_ and out:↑_ with up:_. Also transforms newlines to spaces.
+    fn to_ascii(self) -> Self;
+}
+
+impl SimTransform for String {
+    fn to_spaces(self) -> Self {
+        self.replace('\n', " ")
+    }
+
+    fn no_time(self) -> Self {
+        self.split_ascii_whitespace()
+            .filter(|s| !s.starts_with("t:"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn no_releases(self) -> Self {
+        self.split_ascii_whitespace()
+            .filter(|s| !s.starts_with("out:↑") && !s.starts_with("up:"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn to_ascii(self) -> Self {
+        self.split_ascii_whitespace()
+            .map(|s| s.replace("out:↑", "up:").replace("out:↓", "dn:"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}

--- a/src/tests/sim_tests/seq_sim_tests.rs
+++ b/src/tests/sim_tests/seq_sim_tests.rs
@@ -32,7 +32,10 @@ fn chorded_keys_visible_backspaced() {
         "d:0 u:0 d:lsft t:50 d:a d:b t:50 u:lsft u:a u:b t:500
          d:0 u:0 d:rsft t:50 d:a d:b t:50 u:rsft u:a u:b t:500
          d:0 u:0 d:rsft t:50 d:a u:rsft t:50 d:b u:a u:b t:500",
-    ).no_time().no_releases().to_ascii();
+    )
+    .no_time()
+    .no_releases()
+    .to_ascii();
     assert_eq!(
         "dn:LShift dn:A dn:B dn:BSpace dn:BSpace dn:Z dn:RShift dn:A dn:B dn:BSpace dn:BSpace dn:Z dn:RShift dn:A dn:B",
         result

--- a/src/tests/sim_tests/seq_sim_tests.rs
+++ b/src/tests/sim_tests/seq_sim_tests.rs
@@ -34,12 +34,16 @@ fn chorded_keys_visible_backspaced() {
          d:0 u:0 d:rsft t:50 d:a u:rsft t:50 d:b u:a u:b t:500",
     )
     .no_time()
-    .no_releases()
     .to_ascii();
     assert_eq!(
-        "dn:LShift dn:A dn:B dn:BSpace dn:BSpace dn:Z \
-         dn:RShift dn:A dn:B dn:BSpace dn:BSpace dn:Z \
-         dn:RShift dn:A dn:B",
+        // 2nd row is buggy/unexpected! RShift isn't released before outputting Z
+        // Workarounds:
+        // - remap your rsft key to lsft
+        // - use release-key in the macro via virtual keys
+        // - accept and use the quirky behaviour; maybe it's what you wanted?
+        "dn:LShift dn:A dn:B dn:BSpace up:BSpace dn:BSpace up:BSpace up:LShift up:A up:B dn:Z up:Z \
+         dn:RShift dn:A dn:B dn:BSpace up:BSpace dn:BSpace up:BSpace up:A up:B dn:Z up:Z up:RShift \
+         dn:RShift dn:A up:RShift dn:B up:A up:B",
         result
     );
 }

--- a/src/tests/sim_tests/seq_sim_tests.rs
+++ b/src/tests/sim_tests/seq_sim_tests.rs
@@ -37,7 +37,9 @@ fn chorded_keys_visible_backspaced() {
     .no_releases()
     .to_ascii();
     assert_eq!(
-        "dn:LShift dn:A dn:B dn:BSpace dn:BSpace dn:Z dn:RShift dn:A dn:B dn:BSpace dn:BSpace dn:Z dn:RShift dn:A dn:B",
+        "dn:LShift dn:A dn:B dn:BSpace dn:BSpace dn:Z \
+         dn:RShift dn:A dn:B dn:BSpace dn:BSpace dn:Z \
+         dn:RShift dn:A dn:B",
         result
     );
 }

--- a/src/tests/sim_tests/seq_sim_tests.rs
+++ b/src/tests/sim_tests/seq_sim_tests.rs
@@ -32,9 +32,9 @@ fn chorded_keys_visible_backspaced() {
         "d:0 u:0 d:lsft t:50 d:a d:b t:50 u:lsft u:a u:b t:500
          d:0 u:0 d:rsft t:50 d:a d:b t:50 u:rsft u:a u:b t:500
          d:0 u:0 d:rsft t:50 d:a u:rsft t:50 d:b u:a u:b t:500",
-    );
+    ).no_time().no_releases().to_ascii();
     assert_eq!(
-        "t:2ms\nout:↓LShift\nt:48ms\nout:↓A\nt:1ms\nout:↓B\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nt:1ms\nout:↑LShift\nout:↑A\nout:↑B\nout:↓Z\nt:1ms\nout:↑Z\nt:549ms\nout:↓RShift\nt:48ms\nout:↓A\nt:1ms\nout:↓B\nout:↓BSpace\nout:↑BSpace\nout:↓BSpace\nout:↑BSpace\nt:1ms\nout:↑A\nout:↑B\nout:↓Z\nt:1ms\nout:↑Z\nt:47ms\nout:↑RShift\nt:502ms\nout:↓RShift\nt:48ms\nout:↓A\nt:1ms\nout:↑RShift\nt:49ms\nout:↓B\nt:1ms\nout:↑A\nt:1ms\nout:↑B",
+        "dn:LShift dn:A dn:B dn:BSpace dn:BSpace dn:Z dn:RShift dn:A dn:B dn:BSpace dn:BSpace dn:Z dn:RShift dn:A dn:B",
         result
     );
 }


### PR DESCRIPTION
Add a trait implemented on string to help transform simulated output into more useful/relevant/easy-to-read/easy-to-manipulate text.