### PR TITLE
refactor(sequence): use patricia_tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
+name = "bytemuck"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,13 +555,14 @@ name = "kanata-parser"
 version = "0.161.0"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "itertools",
  "kanata-keyberon",
  "log",
  "miette",
  "once_cell",
  "parking_lot",
- "radix_trie",
+ "patricia_tree",
  "rustc-hash",
  "thiserror",
 ]
@@ -861,6 +868,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "patricia_tree"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f2f4539bffe53fc4b4da301df49d114b845b077bd5727b7fe2bd9d8df2ae68"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -16,7 +16,7 @@ log = { version = "0.4.8", default_features = false }
 anyhow = "1"
 parking_lot = "0.12"
 once_cell = "1"
-radix_trie = "0.2"
+patricia_tree = "0.8"
 rustc-hash = "1.1.0"
 miette = { version = "5.7.0", features = ["fancy"] }
 thiserror = "1.0.38"
@@ -26,6 +26,7 @@ thiserror = "1.0.38"
 # Otherwise any changes to the local files will not reflect in the compiled
 # binary.
 kanata-keyberon = { path = "../keyberon" }
+bytemuck = "1.15.0"
 
 [features]
 cmd = []


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

The `patricia_tree` crate is more maintained than the currently-used `radix_trie` crate and uses less memory because the radix_trie crate has radix 16 while the patricia tree has radix 2. Computation cost comparison unknown.. but reducing memory usage is a good thing!

- https://crates.io/crates/patricia_tree
- https://crates.io/crates/radix_trie

Comparison of memory usage:

```
(defseq woa (O-(a b c d e f g h i j)))

patricia_tree:  200 MB
radix_tree:    1700 MB
```

Since overlapped-key sequences generate a sequence for all permutations of the key combinations, having 10 simultaneous keys generates `10! = 3.6M` sequences. I should probably limit this to some reasonable number like 6...

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
