### PR TITLE
fix(sequence): limit overlap keys; memory concerns

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2699,6 +2699,14 @@ For an example, `O-(a b c)` is equivalent to `O-(c b a)`.
 (defseq hello (O-(h l o)))
 ----
 
+WARNING: The way that sequences implements this functionality behind the scenes
+is by generating a sequence for every permutation of the overlapping keys.
+This can make kanata use up a lot of memory.
+Due to this, the maximum keys allowed in a given `O-(...)` list is 6,
+but you are still permitted to add more to the sequence,
+including more `O-(...)` lists.
+Doing the above can balloon kanata's memory consumption.
+
 .Sample of more advanced usage
 [%collapsible]
 ====

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -3034,13 +3034,17 @@ fn parse_sequences(exprs: &[&Vec<SExpr>], s: &ParserState) -> Result<KeySeqsToFK
                     values_to_permute.push(val);
                 }
 
-                if values_to_permute.len() < 2 {
-                    bail_expr!(
+                let ps = match values_to_permute.len() {
+                    0 | 1 => bail_expr!(
                         key_seq_expr,
                         "O-(...) lists must have a minimum of 2 elements"
-                    );
-                }
-                let ps = gen_permutations(&values_to_permute[..]);
+                    ),
+                    2..=6 => gen_permutations(&values_to_permute[..]),
+                    _ => bail_expr!(
+                        key_seq_expr,
+                        "O-(...) lists must have a maximum of 6 elements"
+                    ),
+                };
 
                 let mut new_permutations: Vec<Vec<u16>> = vec![];
                 for p in permutations.iter() {

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1817,3 +1817,30 @@ fn parse_platform_specific() {
         .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
         .expect("parses");
 }
+
+#[test]
+fn parse_defseq_overlap_limits() {
+    let source = r#"
+(defsrc)
+(deflayer base)
+(defvirtualkeys v v)
+(defseq v (O-(a b c d e f)))
+(defseq v (O-(a b)))
+"#;
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("parses");
+}
+
+#[test]
+fn parse_defseq_overlap_too_many() {
+    let source = r#"
+(defsrc)
+(deflayer base)
+(defvirtualkeys v v)
+(defseq v (O-(a b c d e f g)))
+"#;
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect_err("fails");
+}


### PR DESCRIPTION
Due to generating a sequence for all permutations of an overlapping key list, the code now restricts the maximum length of simultaneous keys to 6.

A user can still blow themselves up by using multiple sequences of 6 simultaneous keys but it needs to be a little more intentional now. And `(O-(a b c d e f) O-(a b c d e f))`, for example, is still fewer permutations than `(O-(a b c d e f g h i j))`.