### PR TITLE
add defcfg "linux-use-trackpoint-property" to set the pointingstick property on kanata's virtual device

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ mio = { version = "0.8.11", features = ["os-poll", "os-ext"] }
 nix = { version = "0.26.1", features = ["ioctl"] }
 sd-notify = "0.4.1"
 
-evdev = "=0.12.0" # Pinned to avoid a bug in 0.12.1
+evdev = ">=0.12.1" # XXX was Pinned to avoid a bug in 0.12.1
 
 [target.'cfg(target_os = "windows")'.dependencies]
 encode_unicode = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ mio = { version = "0.8.11", features = ["os-poll", "os-ext"] }
 nix = { version = "0.26.1", features = ["ioctl"] }
 sd-notify = "0.4.1"
 
-evdev = ">=0.12.1" # XXX was Pinned to avoid a bug in 0.12.1
+evdev = ">=0.12.2" # Pinned to avoid a bug in 0.12.1, which also has a new interface
 
 [target.'cfg(target_os = "windows")'.dependencies]
 encode_unicode = "0.3.6"

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -92,6 +92,18 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;;
   ;; linux-x11-repeat-delay-rate 400,50
 
+  ;; On linux, you can ask kanata to label itself as a trackpoint. This has several
+  ;; effects on libinput including enabling middle mouse button scrolling and using
+  ;; a different acceleration curve. Otherwise, a trackpoint intercepted by kanata
+  ;; may not behave as expected.
+  ;;
+  ;; If using this feature, it is recommended to filter out any non-trackpoint
+  ;; pointing devices using linux-only-linux-dev-names-include,
+  ;; linux-only-linux-dev-names-exclude or linux-only-linux-dev to avoid changing
+  ;; their behavior as well.
+  ;;
+  ;; linux-use-trackpoint-property yes
+
   ;; Unicode on Linux works by pressing Ctrl+Shift+U, typing the unicode hex value,
   ;; then pressing Enter. However, if you do remapping in userspace, e.g. via
   ;; xmodmap/xkb, the keycode "U" that kanata outputs may not become a keysym "u"

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -525,7 +525,7 @@ When live reload is activated,
 the active kanata layer will be the first `deflayer` defined in the configuration.
 
 NOTE: live reload does not read or apply changes to device-related configurations,
-such as `linux-dev`, `macos-dev-names-include`,
+such as `linux-dev`, `macos-dev-names-include`, `linux-use-trackpoint-property`
 or `windows-only-windows-interception-keyboard-hwids`.
 
 .Example:
@@ -2258,6 +2258,28 @@ This configuration item does not affect Wayland or no-desktop environments.
 ----
 (defcfg
   linux-x11-repeat-delay-rate 400,50
+)
+----
+
+[[linux-only-linux-use-trackpoint-property]]
+=== Linux only: linux-use-trackpoint-property
+<<table-of-contents,Back to ToC>>
+
+On linux, you can ask kanata to label itself as a trackpoint. This has several
+effects on libinput including enabling middle mouse button scrolling and using a
+different acceleration curve. Otherwise, a trackpoint intercepted by kanata may
+not behave as expected.
+
+If using this feature, it is recommended to filter out any non-trackpoint
+pointing devices using <<linux-only-linux-dev-names-include>>,
+<<linux-only-linux-dev-names-exclude>> or <<linux-only-linux-dev>> to avoid
+changing their behavior as well.
+
+.Example:
+[source]
+----
+(defcfg
+  linux-use-trackpoint-property yes
 )
 ----
 

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -40,7 +40,7 @@ pub struct CfgOptions {
     #[cfg(any(target_os = "linux", target_os = "unknown"))]
     pub linux_x11_repeat_delay_rate: Option<KeyRepeatSettings>,
     #[cfg(any(target_os = "linux", target_os = "unknown"))]
-    pub linux_trackpoint: bool,
+    pub linux_use_trackpoint_property: bool,
     #[cfg(any(target_os = "windows", target_os = "unknown"))]
     pub windows_altgr: AltGrBehaviour,
     #[cfg(any(
@@ -94,7 +94,7 @@ impl Default for CfgOptions {
             #[cfg(any(target_os = "linux", target_os = "unknown"))]
             linux_x11_repeat_delay_rate: None,
             #[cfg(any(target_os = "linux", target_os = "unknown"))]
-            linux_trackpoint: false,
+            linux_use_trackpoint_property: false,
             #[cfg(any(target_os = "windows", target_os = "unknown"))]
             windows_altgr: AltGrBehaviour::default(),
             #[cfg(any(
@@ -240,10 +240,10 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                             });
                         }
                     }
-                    "linux-trackpoint" => {
+                    "linux-use-trackpoint-property" => {
                         #[cfg(any(target_os = "linux", target_os = "unknown"))]
                         {
-                            cfg.linux_trackpoint = parse_defcfg_val_bool(val, label)?
+                            cfg.linux_use_trackpoint_property = parse_defcfg_val_bool(val, label)?
                         }
                     }
                     "windows-altgr" => {

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -39,6 +39,8 @@ pub struct CfgOptions {
     pub linux_unicode_termination: UnicodeTermination,
     #[cfg(any(target_os = "linux", target_os = "unknown"))]
     pub linux_x11_repeat_delay_rate: Option<KeyRepeatSettings>,
+    #[cfg(any(target_os = "linux", target_os = "unknown"))]
+    pub linux_trackpoint: bool,
     #[cfg(any(target_os = "windows", target_os = "unknown"))]
     pub windows_altgr: AltGrBehaviour,
     #[cfg(any(
@@ -91,6 +93,8 @@ impl Default for CfgOptions {
             linux_unicode_termination: UnicodeTermination::Enter,
             #[cfg(any(target_os = "linux", target_os = "unknown"))]
             linux_x11_repeat_delay_rate: None,
+            #[cfg(any(target_os = "linux", target_os = "unknown"))]
+            linux_trackpoint: false,
             #[cfg(any(target_os = "windows", target_os = "unknown"))]
             windows_altgr: AltGrBehaviour::default(),
             #[cfg(any(
@@ -234,6 +238,12 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                                     Err(_) => bail_expr!(val, "{}", ERRMSG),
                                 },
                             });
+                        }
+                    }
+                    "linux-trackpoint" => {
+                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+                        {
+                            cfg.linux_trackpoint = parse_defcfg_val_bool(val, label)?
                         }
                     }
                     "windows-altgr" => {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -264,7 +264,7 @@ impl Kanata {
             #[cfg(target_os = "linux")]
             &args.symlink_path,
             #[cfg(target_os = "linux")]
-            cfg.options.linux_trackpoint,
+            cfg.options.linux_use_trackpoint_property,
         ) {
             Ok(kbd_out) => kbd_out,
             Err(err) => {
@@ -381,7 +381,7 @@ impl Kanata {
             #[cfg(target_os = "linux")]
             &None,
             #[cfg(target_os = "linux")]
-            cfg.options.linux_trackpoint,
+            cfg.options.linux_use_trackpoint_property,
         ) {
             Ok(kbd_out) => kbd_out,
             Err(err) => {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -263,6 +263,8 @@ impl Kanata {
         let kbd_out = match KbdOut::new(
             #[cfg(target_os = "linux")]
             &args.symlink_path,
+            #[cfg(target_os = "linux")]
+            cfg.options.linux_trackpoint,
         ) {
             Ok(kbd_out) => kbd_out,
             Err(err) => {
@@ -378,6 +380,8 @@ impl Kanata {
         let kbd_out = match KbdOut::new(
             #[cfg(target_os = "linux")]
             &None,
+            #[cfg(target_os = "linux")]
+            cfg.options.linux_trackpoint,
         ) {
             Ok(kbd_out) => kbd_out,
             Err(err) => {

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -324,7 +324,7 @@ pub struct KbdOut {
 
 #[cfg(not(feature = "simulated_output"))]
 impl KbdOut {
-    pub fn new(symlink_path: &Option<String>, trackpoint:bool) -> Result<Self, io::Error> {
+    pub fn new(symlink_path: &Option<String>, trackpoint: bool) -> Result<Self, io::Error> {
         // Support pretty much every feature of a Keyboard or a Mouse in a VirtualDevice so that no event from the original input devices gets lost
         // TODO investigate the rare possibility that a device is e.g. a Joystick and a Keyboard or a Mouse at the same time, which could lead to lost events
 

--- a/src/oskbd/simulated.rs
+++ b/src/oskbd/simulated.rs
@@ -352,7 +352,7 @@ impl KbdOut {
         Self::new_actual()
     }
     #[cfg(target_os = "linux")]
-    pub fn new(_s: &Option<String>) -> Result<Self, io::Error> {
+    pub fn new(_s: &Option<String>, _tp: bool) -> Result<Self, io::Error> {
         Self::new_actual()
     }
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
add defcfg "linux-use-trackpoint-property" to set the pointingstick property on kanata's virtual device. 
resolves #586

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes

I wanted to get some feedback on this approach before completing the checklist.

This is blocked by the bug in evdev-0.12.1, since this patch depends on a method introduced in that version. see emberian/evdev#129

I was initially hoping to dynamically detect trackpoints in `KbdIn` and then alter the virtual device created by `KbdOut` accordingly. However, the `KbdOut` is created first so the dynamic approach would require rearchitecting a bit. 

Instead I opted for a config option. It should be noted that if you change the new setting, `linux-trackpoint`, live reloading is not sufficient for the change to take effect. It might be possible to fix this and if so the dynamic approach might be easier than I thought.  