### PR TITLE
change logged time format to be more concise

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "simplelog",
+ "time",
  "winapi",
 ]
 
@@ -1229,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -1252,9 +1253,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ radix_trie = "0.2"
 rustc-hash = "1.1.0"
 simplelog = "0.12.0"
 serde_json = { version = "1", features = ["std"], default_features = false, optional = true }
+time = "0.3.36"
 
 # kanata-keyberon = "0.161.0"
 # kanata-parser = "0.161.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ fn cli_init() -> Result<ValidatedArgs> {
     };
     log_cfg.set_time_format_custom(format_description!(
         version = 2,
-        "[year]-[month]-[day]_[hour]:[minute]:[second].[subsecond digits:5]"
+        "[hour]:[minute]:[second].[subsecond digits:4]"
     ));
     CombinedLogger::init(vec![TermLogger::new(
         log_lvl,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,7 @@ use clap::Parser;
 use kanata_parser::cfg;
 use kanata_state_machine::*;
 use log::info;
-use simplelog::*;
-
+use simplelog::{format_description, *};
 use std::path::PathBuf;
 
 #[cfg(test)]
@@ -117,7 +116,10 @@ fn cli_init() -> Result<ValidatedArgs> {
     if let Err(e) = log_cfg.set_time_offset_to_local() {
         eprintln!("WARNING: could not set log TZ to local: {e:?}");
     };
-    log_cfg.set_time_format_rfc3339();
+    log_cfg.set_time_format_custom(format_description!(
+        version = 2,
+        "[year]-[month]-[day]_[hour]:[minute]:[second].[subsecond digits:5]"
+    ));
     CombinedLogger::init(vec![TermLogger::new(
         log_lvl,
         log_cfg.build(),


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Closes https://github.com/jtroo/kanata/issues/1009

Shorten logged time format.

`time` crate needs to be added to Cargo.toml excplicitly, otherwise `format_description` gives an error.

Before vs after:
```
2024-05-04T17:07:38.975459272+02:00 [INFO] config file is valid
2024-05-04_17:07:59.88683 [INFO] config file is valid
```

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
