### PR TITLE
Change logged time format to be more concise on sim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "kanata",
  "log",
  "simplelog",
+ "time",
 ]
 
 [[package]]

--- a/simulated_input/Cargo.toml
+++ b/simulated_input/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4", features = [ "std", "derive", "help", "suggestions" ], d
 dirs = "5.0.1"
 log = { version = "0.4.8", default_features = false }
 simplelog = "0.12.0"
+time = "0.3.36"
 
 kanata = { path = ".." , default_features = false }
 

--- a/simulated_input/src/sim.rs
+++ b/simulated_input/src/sim.rs
@@ -2,8 +2,7 @@ use anyhow::Result;
 use anyhow::{anyhow, bail};
 use clap::Parser;
 use kanata_state_machine::{oskbd::*, *};
-use simplelog::*;
-
+use simplelog::{format_description, *};
 use std::path::PathBuf;
 
 pub fn default_sim() -> Vec<PathBuf> {
@@ -87,7 +86,10 @@ fn log_init() {
     if let Err(e) = log_cfg.set_time_offset_to_local() {
         eprintln!("WARNING: could not set log TZ to local: {e:?}");
     };
-    log_cfg.set_time_format_rfc3339();
+    log_cfg.set_time_format_custom(format_description!(
+        version = 2,
+        "[hour]:[minute]:[second].[subsecond digits:4]"
+    ));
     CombinedLogger::init(vec![TermLogger::new(
         LevelFilter::Info,
         log_cfg.build(),


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Shorten log to the same format as in https://github.com/jtroo/kanata/pull/1011 but for simulated input

## Checklist

- Add documentation to docs/config.adoc
  - N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  - N/A
- Added tests, or did manual testing
  - [x] Yes
