### PR TITLE
feat!: enable double-quote within string

### DIFF
--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -1,6 +1,6 @@
-use super::error::*;
 use super::sexpr::SExpr;
 use super::HashSet;
+use super::{error::*, TrimAtomQuotes};
 use crate::cfg::check_first_expr;
 use crate::custom_action::*;
 #[allow(unused)]
@@ -493,7 +493,7 @@ pub const BOOLEAN_VALUES: [&str; 6] = ["yes", "true", "1", "no", "false", "0"];
 fn parse_defcfg_val_bool(expr: &SExpr, label: &str) -> Result<bool> {
     match &expr {
         SExpr::Atom(v) => {
-            let val = v.t.trim_matches('"').to_ascii_lowercase();
+            let val = v.t.trim_atom_quotes().to_ascii_lowercase();
             if TRUE_VALUES.contains(&val.as_str()) {
                 Ok(true)
             } else if FALSE_VALUES.contains(&val.as_str()) {
@@ -519,7 +519,7 @@ fn parse_defcfg_val_bool(expr: &SExpr, label: &str) -> Result<bool> {
 fn parse_cfg_val_u16(expr: &SExpr, label: &str, exclude_zero: bool) -> Result<u16> {
     let start = if exclude_zero { 1 } else { 0 };
     match &expr {
-        SExpr::Atom(v) => Ok(str::parse::<u16>(v.t.trim_matches('"'))
+        SExpr::Atom(v) => Ok(str::parse::<u16>(v.t.trim_atom_quotes())
             .ok()
             .and_then(|u| {
                 if exclude_zero && u == 0 {
@@ -561,7 +561,7 @@ pub fn parse_colon_separated_text(paths: &str) -> Vec<String> {
 pub fn parse_dev(val: &SExpr) -> Result<Vec<String>> {
     Ok(match val {
         SExpr::Atom(a) => {
-            let devs = parse_colon_separated_text(a.t.trim_matches('"'));
+            let devs = parse_colon_separated_text(a.t.trim_atom_quotes());
             if devs.len() == 1 && devs[0].is_empty() {
                 bail_expr!(val, "an empty string is not a valid device name or path")
             }
@@ -572,7 +572,7 @@ pub fn parse_dev(val: &SExpr) -> Result<Vec<String>> {
                 l.t.iter()
                     .try_fold(Vec::with_capacity(l.t.len()), |mut acc, expr| match expr {
                         SExpr::Atom(path) => {
-                            let trimmed_path = path.t.trim_matches('"').to_string();
+                            let trimmed_path = path.t.trim_atom_quotes().to_string();
                             if trimmed_path.is_empty() {
                                 bail_span!(
                                     path,
@@ -594,7 +594,7 @@ pub fn parse_dev(val: &SExpr) -> Result<Vec<String>> {
 
 fn sexpr_to_str_or_err<'a>(expr: &'a SExpr, label: &str) -> Result<&'a str> {
     match expr {
-        SExpr::Atom(a) => Ok(a.t.trim_matches('"')),
+        SExpr::Atom(a) => Ok(a.t.trim_atom_quotes()),
         SExpr::List(_) => bail_expr!(expr, "The value for {label} can't be a list"),
     }
 }

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -2129,7 +2129,14 @@ fn parse_unicode(ac_params: &[SExpr], s: &ParserState) -> Result<&'static Kanata
     ac_params[0]
         .atom(s.vars())
         .map(|a| {
-            let a = a.trim_matches('"');
+            let a = match a.strip_prefix("r#\"") {
+                Some(a) => a.strip_suffix("\"#").unwrap_or(a),
+                None => a
+                    .strip_prefix('"')
+                    .unwrap_or(a)
+                    .strip_suffix('"')
+                    .unwrap_or(a),
+            };
             if a.chars().count() != 1 {
                 bail_expr!(&ac_params[0], "{ERR_STR}")
             }

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -91,6 +91,9 @@ pub use key_outputs::*;
 mod permutations;
 use permutations::*;
 
+mod str_ext;
+pub use str_ext::*;
+
 use crate::trie::Trie;
 use anyhow::anyhow;
 use std::cell::Cell;
@@ -490,7 +493,7 @@ fn expand_includes(
                     "Multiple filepaths are not allowed in include blocks. If you want to include multiple files, create a new include block for each of them."
                 )
             };
-            let include_file_path = spanned_filepath.t.trim_matches('"');
+            let include_file_path = spanned_filepath.t.trim_atom_quotes();
             let file_content = file_content_provider.get_file_content(Path::new(include_file_path))
                 .map_err(|e| anyhow_span!(spanned_filepath, "{e}"))?;
             let tree = sexpr::parse(&file_content, include_file_path)?;
@@ -1082,7 +1085,7 @@ fn parse_layer_indexes(
                     let layer_opts = parse_layer_opts(&list[1..])?;
                     let icon = layer_opts
                         .get(DEFLAYER_ICON[0])
-                        .map(|icon_s| icon_s.trim_matches('"').to_owned());
+                        .map(|icon_s| icon_s.trim_atom_quotes().to_owned());
                     (name.to_owned(), icon)
                 }
             },
@@ -1107,7 +1110,7 @@ fn parse_layer_indexes(
                 let layer_opts = parse_layer_opts(&list[1..])?;
                 let icon = layer_opts
                     .get(DEFLAYER_ICON[0])
-                    .map(|icon_s| icon_s.trim_matches('"').to_owned());
+                    .map(|icon_s| icon_s.trim_atom_quotes().to_owned());
                 (name.to_owned(), icon)
             }
         };
@@ -1279,7 +1282,7 @@ fn parse_list_var(expr: &Spanned<Vec<SExpr>>, vars: &HashMap<String, SExpr>) -> 
 fn push_all_atoms(exprs: &[SExpr], vars: &HashMap<String, SExpr>, pusheen: &mut String) {
     for expr in exprs {
         if let Some(a) = expr.atom(Some(vars)) {
-            pusheen.push_str(a.trim_matches('"'));
+            pusheen.push_str(a.trim_atom_quotes());
         } else if let Some(l) = expr.list(Some(vars)) {
             push_all_atoms(l, vars, pusheen);
         }
@@ -2129,14 +2132,7 @@ fn parse_unicode(ac_params: &[SExpr], s: &ParserState) -> Result<&'static Kanata
     ac_params[0]
         .atom(s.vars())
         .map(|a| {
-            let a = match a.strip_prefix("r#\"") {
-                Some(a) => a.strip_suffix("\"#").unwrap_or(a),
-                None => a
-                    .strip_prefix('"')
-                    .unwrap_or(a)
-                    .strip_suffix('"')
-                    .unwrap_or(a),
-            };
+            let a = a.trim_atom_quotes();
             if a.chars().count() != 1 {
                 bail_expr!(&ac_params[0], "{ERR_STR}")
             }
@@ -2179,7 +2175,7 @@ fn parse_cmd(
 fn collect_strings(params: &[SExpr], strings: &mut Vec<String>, s: &ParserState) {
     for param in params {
         if let Some(a) = param.atom(s.vars()) {
-            strings.push(a.trim_matches('"').to_owned());
+            strings.push(a.trim_atom_quotes().to_owned());
         } else {
             // unwrap: this must be a list, since it's not an atom.
             let l = param.list(s.vars()).unwrap();
@@ -2214,7 +2210,7 @@ fn to_simple_expr(params: &[SExpr], s: &ParserState) -> Vec<SimpleSExpr> {
     let mut result: Vec<SimpleSExpr> = Vec::new();
     for param in params {
         if let Some(a) = param.atom(s.vars()) {
-            result.push(SimpleSExpr::Atom(a.trim_matches('"').to_owned()));
+            result.push(SimpleSExpr::Atom(a.trim_atom_quotes().to_owned()));
         } else {
             // unwrap: this must be a list, since it's not an atom.
             let sexps = param.list(s.vars()).unwrap();
@@ -2863,7 +2859,7 @@ fn parse_live_reload_file(ac_params: &[SExpr], s: &ParserState) -> Result<&'stat
             bail_expr!(&expr, "Filepath cannot be a list")
         }
     };
-    let lrld_file_path = spanned_filepath.t.trim_matches('"');
+    let lrld_file_path = spanned_filepath.t.trim_atom_quotes();
     Ok(s.a.sref(Action::Custom(s.a.sref(s.a.sref_slice(
         CustomAction::LiveReloadFile(lrld_file_path.to_string()),
     )))))

--- a/parser/src/cfg/platform.rs
+++ b/parser/src/cfg/platform.rs
@@ -126,7 +126,7 @@ pub(crate) fn filter_env_specific_cfg(
                         })?,
                     ))
                 })?;
-            let env_var_val = env_var_val.trim_matches('"');
+            let env_var_val = env_var_val.trim_atom_quotes();
             match (
                 env.iter().find_map(|(name, val)| {
                     if name == env_var_name {

--- a/parser/src/cfg/sexpr.rs
+++ b/parser/src/cfg/sexpr.rs
@@ -382,7 +382,7 @@ impl<'a> Lexer<'a> {
                             _ => self.next_string(),
                         },
                         b'r' => {
-                            match (self.bytes.clone().next(), self.bytes.clone().skip(1).next()) {
+                            match (self.bytes.clone().next(), self.bytes.clone().nth(1)) {
                                 (Some(b'#'), Some(b'"')) => {
                                     // consume the # and "
                                     self.bytes.next();

--- a/parser/src/cfg/sexpr.rs
+++ b/parser/src/cfg/sexpr.rs
@@ -324,6 +324,20 @@ impl<'a> Lexer<'a> {
         }
     }
 
+    /// Looks for "#, consuming bytes until found. If not found, returns Err(...);
+    fn read_until_multiline_string_end(&mut self) -> TokenRes {
+        for b2 in self.bytes.clone().skip(1) {
+            // Iterating over a clone of this iterator that's 1 item ahead - this is guaranteed to
+            // be Some.
+            let b1 = self.bytes.next().expect("iter lag");
+            if b1 == b'"' && b2 == b'#' {
+                self.bytes.next();
+                return Ok(Token::StringTok);
+            }
+        }
+        Err("Unterminated multiline string. Add \"# after the end of your string.".to_string())
+    }
+
     /// Looks for "|#", consuming bytes until found. If not found, returns Err(...);
     fn read_until_multiline_comment_end(&mut self) -> TokenRes {
         for b2 in self.bytes.clone().skip(1) {
@@ -367,6 +381,21 @@ impl<'a> Lexer<'a> {
                             }
                             _ => self.next_string(),
                         },
+                        b'r' => {
+                            match (self.bytes.clone().next(), self.bytes.clone().skip(1).next()) {
+                                (Some(b'#'), Some(b'"')) => {
+                                    // consume the # and "
+                                    self.bytes.next();
+                                    self.bytes.next();
+                                    let tok: Token = match self.read_until_multiline_string_end() {
+                                        Ok(t) => t,
+                                        e @ Err(_) => return Some((start, e)),
+                                    };
+                                    tok
+                                }
+                                _ => self.next_string(),
+                            }
+                        }
                         b'#' => match self.bytes.clone().next() {
                             Some(b'|') => {
                                 // consume the '|'

--- a/parser/src/cfg/str_ext.rs
+++ b/parser/src/cfg/str_ext.rs
@@ -1,0 +1,29 @@
+pub trait TrimAtomQuotes {
+    fn trim_atom_quotes(&self) -> &str;
+}
+
+impl TrimAtomQuotes for str {
+    fn trim_atom_quotes(&self) -> &str {
+        match self.strip_prefix("r#\"") {
+            Some(a) => a.strip_suffix("\"#").unwrap_or(a),
+            None => self
+                .strip_prefix('"')
+                .unwrap_or(self)
+                .strip_suffix('"')
+                .unwrap_or(self),
+        }
+    }
+}
+
+impl TrimAtomQuotes for String {
+    fn trim_atom_quotes(&self) -> &str {
+        match self.as_str().strip_prefix("r#\"") {
+            Some(a) => a.strip_suffix("\"#").unwrap_or(a),
+            None => self
+                .strip_prefix('"')
+                .unwrap_or(self)
+                .strip_suffix('"')
+                .unwrap_or(self),
+        }
+    }
+}

--- a/src/tests/sim_tests/unicode_sim_tests.rs
+++ b/src/tests/sim_tests/unicode_sim_tests.rs
@@ -3,13 +3,19 @@ use super::*;
 #[test]
 fn special_nop_keys() {
     let result = simulate(
-        r#"
+        r##"
          (defcfg)
-         (defsrc a b)
-         (deflayer base (unicode "(") (unicode ")"))
-        "#,
-        "d:a d:b t:10",
+         (defsrc 6 7 8 9 0)
+         (deflayer base
+             (unicode r#"("#)
+             (unicode r#")"#)
+             (unicode r#"""#)
+             (unicode "(")
+             (unicode ")")
+         )
+        "##,
+        "d:6 d:7 d:8 d:9 d:0 t:100",
     )
     .no_time();
-    assert_eq!("outU:( outU:)", result);
+    assert_eq!(r#"outU:( outU:) outU:" outU:( outU:)"#, result);
 }


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Enables outputting of `"` within the `unicode` action by using a Rust-style `r#"..."#` string. I.e. it can be done via `r#"""#`.

This change to syntax _might_ break someone... but I'm not sure if there's any good reason someone might be using this syntax for a real use case today.

As another note, surely there is some better way to remove quotes from atoms than what has been done historically - and how this PR continues to do. But this seems good enough for now. Perhaps unquoting all atoms everywhere in some early parsing step might be a breaking change too?

## Checklist

- Find and modify other places that `r#"..."#` processing should be done
  - [x] Yes
- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes
