### PR TITLE
feat: add --log-layer-changes flag

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -235,6 +235,13 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;; Kanata does send the events in the correct order,
   ;; so the fault is more in the environment, but kanata provides a workaround anyway.
   rapid-event-delay 5
+
+  ;; This setting defaults to yes but can be configured to no to save on
+  ;; logging. However, if --log-layer-changes is passed as a command line
+  ;; argument, a "no" in the configuration file will be overridden and layer
+  ;; changes will be logged.
+  ;;
+  ;; log-layer-changes no
 )
 
 ;; deflocalkeys-* enables you to define and use key names that match your locale

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1960,6 +1960,14 @@ overhead. If you do not care for the logging, you can choose to disable it.
 )
 ----
 
+If `+--log-layer-changes+` is passed as a command line argument,
+a `no` in the configuration file will be overridden
+and layer changes will again be logged.
+This flag can be helpful when testing new configuration changes
+while keeping the default behaviour as "no logging" to save on processing,
+so that the `defcfg` item does not need to be adjusted back and forth
+when experimenting vs. stable usage.
+
 [[delegate-to-first-layer]]
 === delegate-to-first-layer
 <<table-of-contents,Back to ToC>>

--- a/src/kanata/cfg_forced.rs
+++ b/src/kanata/cfg_forced.rs
@@ -1,0 +1,19 @@
+//! Options in the configuration file that are overidden/forced to some value other than what's in
+//! the configuration file, with the primary example being CLI arguments.
+
+use std::sync::OnceLock;
+
+static LOG_LAYER_CHANGES: OnceLock<bool> = OnceLock::new();
+
+/// Force the log_layer_changes configuration to some value.
+/// This can only be called up to once. Panics if called a second time.
+pub fn force_log_layer_changes(v: bool) {
+    LOG_LAYER_CHANGES
+        .set(v)
+        .expect("force cfg fns can only be called once");
+}
+
+/// Get the forced log_layer_changes configuration if it was set.
+pub fn get_forced_log_layer_changes() -> Option<bool> {
+    LOG_LAYER_CHANGES.get().copied()
+}

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -37,6 +37,9 @@ mod key_repeat;
 mod sequences;
 use sequences::*;
 
+pub mod cfg_forced;
+use cfg_forced::*;
+
 #[cfg(feature = "cmd")]
 mod cmd;
 #[cfg(feature = "cmd")]
@@ -346,7 +349,8 @@ impl Kanata {
             dynamic_macro_replay_state: None,
             dynamic_macro_record_state: None,
             dynamic_macros: Default::default(),
-            log_layer_changes: cfg.options.log_layer_changes,
+            log_layer_changes: get_forced_log_layer_changes()
+                .unwrap_or(cfg.options.log_layer_changes),
             caps_word: None,
             movemouse_smooth_diagonals: cfg.options.movemouse_smooth_diagonals,
             movemouse_inherit_accel_state: cfg.options.movemouse_inherit_accel_state,
@@ -443,7 +447,8 @@ impl Kanata {
             dynamic_macro_replay_state: None,
             dynamic_macro_record_state: None,
             dynamic_macros: Default::default(),
-            log_layer_changes: cfg.options.log_layer_changes,
+            log_layer_changes: get_forced_log_layer_changes()
+                .unwrap_or(cfg.options.log_layer_changes),
             caps_word: None,
             movemouse_smooth_diagonals: cfg.options.movemouse_smooth_diagonals,
             movemouse_inherit_accel_state: cfg.options.movemouse_inherit_accel_state,
@@ -491,7 +496,8 @@ impl Kanata {
         self.layer_info = cfg.layer_info;
         self.sequences = cfg.sequences;
         self.overrides = cfg.overrides;
-        self.log_layer_changes = cfg.options.log_layer_changes;
+        self.log_layer_changes =
+            get_forced_log_layer_changes().unwrap_or(cfg.options.log_layer_changes);
         self.movemouse_smooth_diagonals = cfg.options.movemouse_smooth_diagonals;
         self.movemouse_inherit_accel_state = cfg.options.movemouse_inherit_accel_state;
         self.dynamic_macro_max_presses = cfg.options.dynamic_macro_max_presses;

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,13 @@ kanata.kbd in the current working directory and
     /// Validate configuration file and exit
     #[arg(long, verbatim_doc_comment)]
     check: bool,
+
+    /// Log layer changes even if the configuration file has set
+    /// the defcfg option to false.
+    /// Useful if you are experimenting with a new configuration
+    /// but want to default to no logging.
+    #[arg(long, verbatim_doc_comment)]
+    log_layer_changes: bool,
 }
 
 #[cfg(not(feature = "gui"))]
@@ -160,6 +167,10 @@ mod cli {
             use std::sync::atomic::Ordering;
             log::info!("Setting device registration wait time to {wait} ms.");
             oskbd::WAIT_DEVICE_MS.store(wait, Ordering::SeqCst);
+        }
+
+        if args.log_layer_changes {
+            cfg_forced::force_log_layer_changes(true);
         }
 
         Ok(ValidatedArgs {

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ kanata.kbd in the current working directory and
     #[arg(short, long)]
     trace: bool,
 
-    /// Remove the startup delay on kanata.
+    /// Remove the startup delay.
     /// In some cases, removing the delay may cause keyboard issues on startup.
     #[arg(short, long, verbatim_doc_comment)]
     nodelay: bool,
@@ -87,10 +87,9 @@ kanata.kbd in the current working directory and
     #[arg(long, verbatim_doc_comment)]
     check: bool,
 
-    /// Log layer changes even if the configuration file has set
-    /// the defcfg option to false.
-    /// Useful if you are experimenting with a new configuration
-    /// but want to default to no logging.
+    /// Log layer changes even if the configuration file has set the defcfg
+    /// option to false. Useful if you are experimenting with a new
+    /// configuration but want to default to no logging.
     #[arg(long, verbatim_doc_comment)]
     log_layer_changes: bool,
 }


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Closes #1018.

No short form is added in case some future flag wants to use it; this flag doesn't seem important enough to warrant the short `-l` variant.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes, manual tests
