### PR TITLE
feat: implement unicode for MacOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +355,33 @@ dependencies = [
  "nix 0.23.2",
  "thiserror",
 ]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "funty"
@@ -489,6 +556,7 @@ version = "1.7.0-prerelease"
 dependencies = [
  "anyhow",
  "clap",
+ "core-graphics",
  "dirs",
  "embed-resource",
  "encode_unicode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ kanata-tcp-protocol = { path = "tcp_protocol" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 karabiner-driverkit = "0.1.3"
+core-graphics = "0.23.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 signal-hook = "0.3.14"

--- a/docs/platform-known-issues.adoc
+++ b/docs/platform-known-issues.adoc
@@ -83,4 +83,3 @@ and explicitly map keys in `defsrc` instead
 
 * Mouse output actions are not implemented
 * Mouse input processing is not implemented
-* Unicode output action is not implemented

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -9,6 +9,8 @@ use super::*;
 use crate::kanata::CalculatedMouseMove;
 use crate::oskbd::KeyEvent;
 use anyhow::anyhow;
+use core_graphics::event::{CGEvent, CGEventTapLocation, CGEventType};
+use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 use kanata_parser::custom_action::*;
 use kanata_parser::keys::*;
 use karabiner_driverkit::*;
@@ -110,6 +112,8 @@ fn validate_and_register_devices(include_names: Vec<String>) -> Vec<String> {
 }
 
 use std::fmt;
+use std::io::ErrorKind;
+
 impl fmt::Display for InputEvent {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use kanata_keyberon::key_code::KeyCode;
@@ -219,10 +223,25 @@ impl KbdOut {
         self.write_key(key, KeyValue::Release)
     }
 
-    /// Send using C-S-u + <unicode hex number> + spc
     pub fn send_unicode(&mut self, c: char) -> Result<(), io::Error> {
-        log::error!("Unable to send unicode {c}, unsupported functionality");
-        todo!()
+        let event_source =
+            CGEventSource::new(CGEventSourceStateID::CombinedSessionState).map_err(|_| {
+                io::Error::new(
+                    ErrorKind::Other,
+                    "failed to create core graphics event source",
+                )
+            })?;
+        let event = CGEvent::new(event_source).map_err(|_| {
+            io::Error::new(ErrorKind::Other, "failed to create core graphics event")
+        })?;
+        let mut arr: [u16; 2] = [0; 2];
+        c.encode_utf16(&mut arr);
+        event.set_string_from_utf16_unchecked(&arr);
+        event.set_type(CGEventType::KeyDown);
+        event.post(CGEventTapLocation::AnnotatedSession);
+        event.set_type(CGEventType::KeyUp);
+        event.post(CGEventTapLocation::AnnotatedSession);
+        Ok(())
     }
 
     pub fn scroll(&mut self, _direction: MWheelDirection, _distance: u16) -> Result<(), io::Error> {


### PR DESCRIPTION
Implemented `unicode` support for MacOS using the core-graphics crate.

Closes #963 

## Checklist

- Add documentation to docs/config.adoc
  - N/A - it is already documented. I did remove the docs note that said that `unicode` is unsupported on MacOS
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A - already documented
- Update error messages
  - Yes - I provided error messages, but I am not particularly happy since I don't know what the actual failure scearios are
- Added tests, or did manual testing
  - Yes, I performed manual testing. If you can give my a hint how/where I can do automated testing I am happy to try my hand at it
