### PR TITLE
enable using vars as layer name

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -471,7 +471,6 @@ Variables can be used to substitute most values.
 Some notable exceptions are:
 
 - variables cannot be used in `defcfg`, `defsrc`, or `deflocalkeys`
-- variables cannot be used to substitute a layer name
 - variables cannot be used to substitute an action name
 
 Variables are referred to by prefixing their name with `$`.

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1094,7 +1094,7 @@ fn parse_layer_indexes(
                         (name.to_owned(), icon)
                     }
                 }
-            },
+            }
             SpannedLayerExprs::CustomMapping(_) => {
                 let list = layer_expr
                     .list(None)

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1662,19 +1662,15 @@ fn layer_idx(ac_params: &[SExpr], layers: &LayerIndexes, s: &ParserState) -> Res
             ac_params.len()
         )
     }
-    let layer_name = match &ac_params[0] {
-        SExpr::Atom(_) => ac_params[0].atom(s.vars()),
-        _ => bail_expr!(&ac_params[0], "layer name should be a string not a list",),
-    };
-    match layer_name {
-        Some(layer_name) => match layers.get(layer_name) {
-            Some(i) => Ok(*i),
-            None => err_expr!(
-                &ac_params[0],
-                "layer name is not declared in any deflayer: {layer_name}"
-            ),
-        },
-        None => err_expr!(&ac_params[0], "layer name is not declared in any deflayer"),
+    let layer_name = ac_params[0]
+        .atom(s.vars())
+        .ok_or_else(|| anyhow_expr!(&ac_params[0], "layer name should be a string not a list",))?;
+    match layers.get(layer_name) {
+        Some(i) => Ok(*i),
+        None => err_expr!(
+            &ac_params[0],
+            "layer name is not declared in any deflayer: {layer_name}"
+        ),
     }
 }
 

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1871,3 +1871,22 @@ fn disallow_dupe_layer_opts_icon_layermap() {
 ";
     parse_cfg(source).map(|_| ()).expect_err("fails");
 }
+
+#[test]
+fn layer_name_allows_var() {
+    let source = "
+(defvar l1name base)
+(defvar l2name l2)
+(defvar l3name (concat $l1name $l2name))
+(defvar l4name (concat $l3name actually-4))
+(defsrc a)
+(deflayer $l1name (layer-while-held $l2name))
+(deflayermap ($l2name)
+  a (layer-while-held $l3name))
+(deflayer ($l3name) (layer-while-held $l4name))
+(deflayer ($l4name icon icon.ico) (layer-while-held $l1name))
+";
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("parse succeeds");
+}


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
enable using vars as layer name 

potentially may partially fix #1027 

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
    - ~error handling in layer_idx() (parser/src/cfg/mod.rs:1669) is bad and needs fixing/improving~
- Added tests, or did manual testing
  - [x] Yes
