### PR TITLE
feat(win-gui): Add more correct winiov2 handling method to the gui app

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ simulated_output = ["indoc"]
 simulated_input = ["indoc"]
 passthru_ahk = ["simulated_input","simulated_output"]
 wasm = [ "instant/wasm-bindgen" ]
-gui = ["win_manifest","native-windows-derive","win_dbg_logger","win_dbg_logger/simple_shared","kanata-parser/gui","native-windows-gui/tray-notification","native-windows-gui/message-window","native-windows-gui/menu","native-windows-gui/cursor","native-windows-gui/high-dpi","native-windows-gui/embed-resource","native-windows-gui/image-decoder","native-windows-gui/notice","dep:windows-sys"]
+gui = ["win_manifest","native-windows-derive","win_dbg_logger","win_dbg_logger/simple_shared","kanata-parser/gui","native-windows-gui/tray-notification","native-windows-gui/message-window","native-windows-gui/menu","native-windows-gui/cursor","native-windows-gui/high-dpi","native-windows-gui/embed-resource","native-windows-gui/image-decoder","native-windows-gui/notice","dep:windows-sys","win_sendinput_send_scancodes","win_llhook_read_scancodes"]
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Switch to the better llhook input handling methods (only in the new experimental gui app, so should be fine) used in winio2 to avoid issues like https://github.com/jtroo/kanata/issues/1042

## Checklist

- Add documentation to docs/config.adoc
  - N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  - N/A
- Added tests, or did manual testing
  - [X] Yes manual
