### PR TITLE
fix: add a missing console disabling attribute

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "gui", windows_subsystem = "windows")]
+// disable default console for a Windows GUI app
 mod main_lib;
 
 use anyhow::{bail, Result};


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Gui app should have no console when launched with a double-click, but the attribute doing that didn't make it to your main

## Checklist

- Add documentation to docs/config.adoc
  - N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  - N/A
- Added tests, or did manual testing
  - [X] Yes
