### PR TITLE
Don't hide error message on GUI creation

### DIFF
--- a/src/gui/win.rs
+++ b/src/gui/win.rs
@@ -1,5 +1,5 @@
 use crate::Kanata;
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use core::cell::RefCell;
 use log::Level::*;
 
@@ -986,7 +986,7 @@ pub fn build_tray(cfg: &Arc<Mutex<Kanata>>) -> Result<system_tray_ui::SystemTray
         app_data: RefCell::new(app_data),
         ..Default::default()
     };
-    SystemTray::build_ui(app).context("Failed to build UI")
+    Ok(SystemTray::build_ui(app)?)
 }
 
 pub use log::*;


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Previous `.context` was hiding the errors during the gui building stage, leading to https://github.com/jtroo/kanata/pull/990#issuecomment-2118880088

This fixes it and now it should bubble up the original error

(anyhow's trait isn't implemented for NWG errors, so not sure you can conveniently chain both)

## Checklist

- Add documentation to docs/config.adoc
  - N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  - [X] Yes or N/A
- Added tests, or did manual testing
  - [X] Yes
