### PR TITLE
fix(win,gui): allow renaming of the executable

### DIFF
--- a/src/gui/win.rs
+++ b/src/gui/win.rs
@@ -738,7 +738,7 @@ pub mod system_tray_ui {
             d.handlers_dyn = RefCell::new(Default::default());
             // Resources
             d.embed = Default::default();
-            d.embed = nwg::EmbedResource::load(Some("kanata.exe"))?;
+            d.embed = nwg::EmbedResource::load(None)?;
             nwg::Icon::builder()
                 .source_embed(Some(&d.embed))
                 .source_embed_str(Some("iconMain"))


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Allow renaming of `kanata.exe` gui app

Fixes one of https://github.com/jtroo/kanata/pull/990#issuecomment-2119047041


## Checklist

- Add documentation to docs/config.adoc
  - N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  - N/A
- Added tests, or did manual testing
  - [X] Yes
