### PR TITLE
Add Interception builds of the Windows GUI app

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,6 +21,8 @@ build_release_windows output_dir:
   cargo build --release --features passthru_ahk --package=simulated_passthru; cp target/release/kanata_passthru.dll "{{output_dir}}\kanata_passthru.dll"
   cargo build --release --features win_manifest,gui    ; cp target/release/kanata.exe "{{output_dir}}\kanata_gui.exe"
   cargo build --release --features win_manifest,gui,cmd; cp target/release/kanata.exe "{{output_dir}}\kanata_gui_cmd_allowed.exe"
+  cargo build --release --features win_manifest,gui    ,interception_driver; cp target/release/kanata.exe "{{output_dir}}\kanata_gui_wintercept.exe"
+  cargo build --release --features win_manifest,gui,cmd,interception_driver; cp target/release/kanata.exe "{{output_dir}}\kanata_gui_wintercept_cmd_allowed.exe"
   cp cfg_samples/kanata.kbd "{{output_dir}}"
 
 # Generate the sha256sums for all files in the output directory

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -15,3 +15,4 @@ pub static GUI_TX: OnceLock<native_windows_gui::NoticeSender> = OnceLock::new();
 pub static GUI_CFG_TX: OnceLock<native_windows_gui::NoticeSender> = OnceLock::new();
 pub static GUI_ERR_TX: OnceLock<native_windows_gui::NoticeSender> = OnceLock::new();
 pub static GUI_ERR_MSG_TX: OnceLock<ASender<(String, String)>> = OnceLock::new();
+pub static GUI_EXIT_TX: OnceLock<native_windows_gui::NoticeSender> = OnceLock::new();

--- a/src/gui/win.rs
+++ b/src/gui/win.rs
@@ -97,6 +97,7 @@ pub struct SystemTray {
     pub layer_notice: nwg::Notice,
     pub cfg_notice: nwg::Notice,
     pub err_notice: nwg::Notice,
+    pub exit_notice: nwg::Notice,
     pub tt_notice: nwg::Notice,
     /// Receiver of error message content sent from other threads
     /// (e.g., from key event thread via WinDbgLogger that will also notify our GUI
@@ -130,7 +131,7 @@ const ASSET_FD: [&str; 4] = ["", "icon", "img", "icons"];
 const IMG_EXT: [&str; 7] = ["ico", "jpg", "jpeg", "png", "bmp", "dds", "tiff"];
 const PRE_LAYER: &str = "\n🗍: "; // : invalid path marker, so should be safe to use as a separator
 const TTTIMER_L: u16 = 9; // lifetime delta to duration for a tooltip timer
-use crate::gui::{CFG, GUI_CFG_TX, GUI_ERR_MSG_TX, GUI_ERR_TX, GUI_TX};
+use crate::gui::{CFG, GUI_CFG_TX, GUI_ERR_MSG_TX, GUI_ERR_TX, GUI_TX, GUI_EXIT_TX};
 
 pub fn send_gui_notice() {
     if let Some(gui_tx) = GUI_TX.get() {
@@ -152,6 +153,10 @@ pub fn send_gui_err_notice() {
     } else {
         error!("no GUI_ERR_TX to notify GUI thread of errors");
     }
+}
+pub fn send_gui_exit_notice() {
+  if let Some(gui_tx) = GUI_EXIT_TX.get() {gui_tx.notice();
+  } else {error!("no GUI_EXIT_TX to ask GUI thread to exit");}
 }
 pub fn show_err_msg_nofail(title: String, msg: String) {
     // log gets insalized before gui, so some errors might have no target to log to, ignore them
@@ -1318,6 +1323,9 @@ pub mod system_tray_ui {
             nwg::Notice::builder()
                 .parent(&d.window)
                 .build(&mut d.err_notice)?;
+            nwg::Notice::builder()
+                .parent(&d.window)
+                .build(&mut d.exit_notice)?;
             nwg::Menu::builder()
                 .parent(&d.tray_menu)
                 .text("&F Load config") //
@@ -1519,6 +1527,8 @@ pub mod system_tray_ui {
                                 SystemTray::reload_cfg_icon(&evt_ui);
                             } else if handle == evt_ui.err_notice {
                                 SystemTray::notify_error(&evt_ui);
+                            } else if handle == evt_ui.exit_notice {
+                                SystemTray::exit(&evt_ui);
                             } else if handle == evt_ui.tt_notice {
                                 SystemTray::update_tooltip_pos(&evt_ui);}
                         E::OnWindowClose =>

--- a/src/gui/win.rs
+++ b/src/gui/win.rs
@@ -131,7 +131,7 @@ const ASSET_FD: [&str; 4] = ["", "icon", "img", "icons"];
 const IMG_EXT: [&str; 7] = ["ico", "jpg", "jpeg", "png", "bmp", "dds", "tiff"];
 const PRE_LAYER: &str = "\n🗍: "; // : invalid path marker, so should be safe to use as a separator
 const TTTIMER_L: u16 = 9; // lifetime delta to duration for a tooltip timer
-use crate::gui::{CFG, GUI_CFG_TX, GUI_ERR_MSG_TX, GUI_ERR_TX, GUI_TX, GUI_EXIT_TX};
+use crate::gui::{CFG, GUI_CFG_TX, GUI_ERR_MSG_TX, GUI_ERR_TX, GUI_EXIT_TX, GUI_TX};
 
 pub fn send_gui_notice() {
     if let Some(gui_tx) = GUI_TX.get() {
@@ -155,8 +155,11 @@ pub fn send_gui_err_notice() {
     }
 }
 pub fn send_gui_exit_notice() {
-  if let Some(gui_tx) = GUI_EXIT_TX.get() {gui_tx.notice();
-  } else {error!("no GUI_EXIT_TX to ask GUI thread to exit");}
+    if let Some(gui_tx) = GUI_EXIT_TX.get() {
+        gui_tx.notice();
+    } else {
+        error!("no GUI_EXIT_TX to ask GUI thread to exit");
+    }
 }
 pub fn show_err_msg_nofail(title: String, msg: String) {
     // log gets insalized before gui, so some errors might have no target to log to, ignore them

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -2029,7 +2029,13 @@ fn check_for_exit(_event: &KeyEvent) {
             log::info!("{EXIT_MSG}");
             #[cfg(all(target_os = "windows", feature = "gui"))]
             {
+                #[cfg(not(feature = "interception_driver"))]
                 native_windows_gui::stop_thread_dispatch();
+                #[cfg(feature = "interception_driver")]
+                send_gui_exit_notice(); // interception driver is running in another thread to allow
+                                        // GUI take the main one, so it's calling check_for_exit
+                                        // from a thread that has no access to the main one, so
+                                        // can't stop main thread's dispatch
             }
             #[cfg(all(
                 not(target_os = "linux"),

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -115,7 +115,9 @@ impl Kanata {
         #[cfg(feature = "gui")] ui: crate::gui::system_tray_ui::SystemTrayUi,
     ) -> Result<()> {
         #[cfg(not(feature = "gui"))]
-        Self::event_loop_inner(kanata, tx);
+        {
+            Self::event_loop_inner(kanata, tx)
+        }
         #[cfg(feature = "gui")]
         {
             std::thread::spawn(move || -> Result<()> { Self::event_loop_inner(kanata, tx) });

--- a/src/main_lib/win_gui.rs
+++ b/src/main_lib/win_gui.rs
@@ -152,6 +152,7 @@ fn main_impl() -> Result<()> {
     let gui_tx = ui.layer_notice.sender();
     let gui_cfg_tx = ui.cfg_notice.sender(); // allows notifying GUI on config reloads
     let gui_err_tx = ui.err_notice.sender(); // allows notifying GUI on erorrs (from logger)
+    let gui_exit_tx = ui.exit_notice.sender(); // allows notifying GUI on app quit
     if GUI_TX.set(gui_tx).is_err() {
         warn!("Someone else set our ‘GUI_TX’");
     };
@@ -160,6 +161,9 @@ fn main_impl() -> Result<()> {
     };
     if GUI_ERR_TX.set(gui_err_tx).is_err() {
         warn!("Someone else set our ‘GUI_ERR_TX’");
+    };
+    if GUI_EXIT_TX.set(gui_exit_tx).is_err() {
+        warn!("Someone else set our ‘GUI_EXIT_TX’");
     };
     Kanata::start_processing_loop(kanata_arc.clone(), rx, ntx, args.nodelay);
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add Interception builds of the Windows GUI app

(also based on the notification PR https://github.com/jtroo/kanata/pull/1031 to make it easier to add later and also test since I can just observe mouse tooltips changing to see whether it works, so will rebase on whatever that one ends up being after review)


By the way, the docs say that
> I think it has something to do with being installed in the privileged location of `system32\drivers`.

But on my system the install script didn't copy/move any of the dlls anywhere, so I guess that's the real reason why it's incosistent - if you copy the dlls to a PATH'ed location, it works, otherwise it fails
Are you sure that you have `interception.dll` in `Windows\system32\drivers`?

Fixes the other part of  https://github.com/jtroo/kanata/pull/990#issuecomment-2118880088

## Checklist

- Add documentation to docs/config.adoc
  - N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  - N/A
- Added tests, or did manual testing
  - [X] Yes
