### PR TITLE
fix(gui): Open a log file on arg parsing errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abe875cf6439eb5d98f0fdbcc6128fdef4870c47e0f898735105ff77685dfcd1"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +518,16 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -576,6 +595,7 @@ dependencies = [
  "native-windows-gui",
  "nix 0.26.4",
  "once_cell",
+ "open",
  "parking_lot",
  "radix_trie",
  "regex",
@@ -911,6 +931,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "open"
+version = "5.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb49fbd5616580e9974662cb96a3463da4476e649a7e4b258df0de065db0657"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +986,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "patricia_tree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ regex = { version = "1.10.4", optional = true }
 kanata-interception = { version = "0.2.0", optional = true }
 muldiv = { version = "1.0.1", optional = true }
 strip-ansi-escapes = { version = "0.2.0", optional = true }
-open = { version = "5", features = ["shellexecute-on-windows"] }
+open = { version = "5", features = ["shellexecute-on-windows"], optional = true}
 # shellexecute fix allows opening files already opened for writing, needs _detached mode
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
@@ -129,7 +129,7 @@ passthru_ahk = ["simulated_input","simulated_output"]
 wasm = [ "instant/wasm-bindgen" ]
 gui = ["win_manifest","kanata-parser/gui",
   "win_sendinput_send_scancodes","win_llhook_read_scancodes",
-  "muldiv","strip-ansi-escapes",
+  "muldiv","strip-ansi-escapes","open",
   "dep:windows-sys",
   "winapi/processthreadsapi",
   "native-windows-gui/tray-notification","native-windows-gui/message-window","native-windows-gui/menu","native-windows-gui/cursor","native-windows-gui/high-dpi","native-windows-gui/embed-resource","native-windows-gui/image-decoder","native-windows-gui/notice","native-windows-gui/animation-timer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ rustc-hash = "1.1.0"
 simplelog = "0.12.0"
 serde_json = { version = "1", features = ["std"], default_features = false, optional = true }
 time = "0.3.36"
-
 # kanata-keyberon = "0.161.0"
 # kanata-parser = "0.161.0"
 # kanata-tcp-protocol = "0.161.0"
@@ -65,6 +64,7 @@ kanata-tcp-protocol = { path = "tcp_protocol" }
 [target.'cfg(target_os = "macos")'.dependencies]
 karabiner-driverkit = "0.1.3"
 core-graphics = "0.23.2"
+open = "5"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 signal-hook = "0.3.14"
@@ -72,6 +72,7 @@ inotify = { version = "0.10.0", default_features = false }
 mio = { version = "0.8.11", features = ["os-poll", "os-ext"] }
 nix = { version = "0.26.1", features = ["ioctl"] }
 sd-notify = "0.4.1"
+open = "5"
 
 evdev = ">=0.12.2" # Pinned to avoid a bug in 0.12.1, which also has a new interface
 
@@ -105,6 +106,8 @@ regex = { version = "1.10.4", optional = true }
 kanata-interception = { version = "0.2.0", optional = true }
 muldiv = { version = "1.0.1", optional = true }
 strip-ansi-escapes = { version = "0.2.0", optional = true }
+open = { version = "5", features = ["shellexecute-on-windows"] }
+# shellexecute fix allows opening files already opened for writing, needs _detached mode
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 embed-resource = { version = "2.4.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ kanata-tcp-protocol = { path = "tcp_protocol" }
 [target.'cfg(target_os = "macos")'.dependencies]
 karabiner-driverkit = "0.1.3"
 core-graphics = "0.23.2"
-open = "5"
+open = { version = "5", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 signal-hook = "0.3.14"
@@ -72,7 +72,7 @@ inotify = { version = "0.10.0", default_features = false }
 mio = { version = "0.8.11", features = ["os-poll", "os-ext"] }
 nix = { version = "0.26.1", features = ["ioctl"] }
 sd-notify = "0.4.1"
-open = "5"
+open = { version = "5", optional = true }
 
 evdev = ">=0.12.2" # Pinned to avoid a bug in 0.12.1, which also has a new interface
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

On arg parsing errors at launch when there is no console to show errors to the user, create a `kanata_log.txt`¹ file to record all logging info and then open it with the OS default `.txt` handler

¹ `txt` to make sure some other system logger doesn't open it instead of a text editor, had some issues with this in the past on a Mac

(the proper future way would be to show a gui window, but then what if that fails ;) so this simple workaround would still be useful)

Also might be extended for personal statistics logging https://github.com/jtroo/kanata/issues/259, though that one would be useful with a better serializable format

(again based on top of other PR to avoid conflicts)

## Checklist

- Add documentation to docs/config.adoc
  - n/a
- Add example and basic docs to cfg_samples/kanata.kbd
  - n/a
- Update error messages
  - [X] Yes or N/A
- Added tests, or did manual testing
  - [X] Yes but only on Windows (the file should be created on other platforms, but those don't have non-console launchers)
