### PR TITLE
[ProofOfConcept] AutoMouseKeys layer switching

### DIFF
--- a/cfg_samples/automousekeys-only.kbd
+++ b/cfg_samples/automousekeys-only.kbd
@@ -1,0 +1,32 @@
+(defcfg
+  ;; we are only mapping the keys we want to use for mouse keys
+  process-unmapped-keys yes
+
+  ;; you may wish to only capture a trackpoint and keyboard
+  ;; but not e.g. a trackpad or external mouse
+  ;;linux-dev-names-include (
+  ;;                         "AT Translated Set 2 keyboard"
+  ;;                         "TPPS/2 Elan TrackPoint"
+  ;;                          )
+  ;; optional, but useful with the trackpoint
+  ;;linux-use-trackpoint-property yes
+)
+
+(defsrc
+  k l ;
+  F24
+)
+
+(defalias
+  msk (layer-while-held mouse)
+)
+
+(deflayer qwerty
+  k l ;
+  @msk
+)
+
+(deflayer mouse
+  mlft mmid mrgt
+  XX
+)

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -17,6 +17,7 @@ use kanata_keyberon::layout::{CustomEvent, Event, Layout, State};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time;
+use std::time::SystemTime;
 
 use crate::oskbd::{KeyEvent, *};
 #[cfg(feature = "tcp_server")]
@@ -207,6 +208,8 @@ pub struct Kanata {
     #[cfg(all(target_os = "windows", feature = "gui"))]
     /// Various GUI-related options.
     pub gui_opts: CfgOptionsGui,
+    /// timestamp
+    pub automousekeys_timestamp: Option<SystemTime>,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -373,6 +376,7 @@ impl Kanata {
             tcp_server_address: args.tcp_server_address.clone(),
             #[cfg(all(target_os = "windows", feature = "gui"))]
             gui_opts: cfg.options.gui_opts,
+            automousekeys_timestamp: None,
         })
     }
 
@@ -471,6 +475,7 @@ impl Kanata {
             tcp_server_address: None,
             #[cfg(all(target_os = "windows", feature = "gui"))]
             gui_opts: cfg.options.gui_opts,
+            automousekeys_timestamp: None,
         })
     }
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
when `RelAxis` x or y events occur, a timestamp is updated and if the timestamp was previously `None`, an F24 key Press event is injected. If a non-`RelAxis` event occurs more than a timeout value (750 ms right now) since the last timestamp update, an F24 key Release event is injected prior to processing the event and the timestamp is reset to `None`.

the expectation is that the user will map F24 to a `layer-while-held` action to switch to a mouse keys layer.

in a finalized version, the timeout and the key event would be configurable as part of a feature toggle.


## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [ ] Yes