### PR TITLE
feat: Include numeric key code in KeyEvent Debug

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -309,7 +309,8 @@ Please contribute to the document if you are able!
 The number used for a custom key represents the converted value for an OsCode in
 base 10. This differs between Windows-hooks, Windows-interception, and Linux.
 
-Running katana with the `--debug` flag lets you read the correct number number, show in parenthesis of `code` in the `KeyEvent` log lines.
+Running kanata with the `--debug` flag lets you read the correct number,
+shown in parenthesis of `code` in the `KeyEvent` log lines.
 
 It also possible to use native tools, as described below.
 

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -309,6 +309,10 @@ Please contribute to the document if you are able!
 The number used for a custom key represents the converted value for an OsCode in
 base 10. This differs between Windows-hooks, Windows-interception, and Linux.
 
+Running katana with the `--debug` flag lets you read the correct number number, show in parenthesis of `code` in the `KeyEvent` log lines.
+
+It also possible to use native tools, as described below.
+
 In Linux, `evtest` will give the correct number for the physical key you press.
 
 In Windows using the default hook mechanism, the non-interception version of the

--- a/src/oskbd/mod.rs
+++ b/src/oskbd/mod.rs
@@ -101,7 +101,7 @@ impl From<KeyValue> for bool {
 
 use kanata_parser::keys::OsCode;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct KeyEvent {
     pub code: OsCode,
     pub value: KeyValue,
@@ -127,5 +127,17 @@ impl fmt::Display for KeyEvent {
         };
         let key_name = KeyCode::from(self.code);
         write!(f, "{}{:?}", direction, key_name)
+    }
+}
+
+impl fmt::Debug for KeyEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("KeyEvent")
+            .field(
+                "code",
+                &format_args!("{:?} ({})", self.code, self.code.as_u16()),
+            )
+            .field("value", &self.value)
+            .finish()
     }
 }


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add the numeric key code value after the enum literal name in debug prints of KeyEvent.

Printing the numeric key code together with the pressed key enum value makes it much easier to create custom deflocalkeys.

Example --debug output:
```
21:42:09.5202 [DEBUG] (3) kanata_state_machine::kanata: process recv ev KeyEvent { code: KEY_LEFTCTRL (29), value: Press }
21:42:09.6403 [DEBUG] (3) kanata_state_machine::kanata: process recv ev KeyEvent { code: KEY_I (23), value: Press }
```

## Checklist

- Add documentation to docs/config.adoc
  - N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - Yes, short info.
- Update error messages
  - N/A
- Added tests, or did manual testing
  - Yes, tested on Linux


It might be a better fit to modify the Debug implementation of OsCode, but I'm not sure how to do it correctly.