### PR TITLE
doc(locales.adoc): Add Swedish QWERTY layout

### DIFF
--- a/docs/locales.adoc
+++ b/docs/locales.adoc
@@ -269,3 +269,43 @@ NOTE: This is for the https://kbdlayout.info/kbdbr[ABNT2 QWERTY layout]. Tested 
 )
 ----
 ====
+
+== ISO Swedish QWERTY (Linux)[[swedish]]
+
+[%collapsible]
+====
+----
+;; Swedish ISO105
+(deflocalkeys-linux
+  §   41
+  +   12
+  ´   13 ;; Acute accent. Opposite to the grave accent (grv).
+  å   26
+  ¨   27
+  ö   39
+  ä   40
+  '   43
+  <   86
+  ,   51
+  .   52
+  -   53
+)
+
+(defsrc ;; Swedish ISO105
+  §    1    2    3    4    5    6    7    8    9    0    +    ´    bspc
+  tab  q    w    e    r    t    y    u    i    o    p    å    ¨
+  caps a    s    d    f    g    h    j    k    l    ö    ä    '    ret
+  lsft <    z    x    c    v    b    n    m    ,    .    -         rsft
+  lctl lmet lalt                spc                 ralt rmet menu rctl
+)
+
+;; Empty layer that matches the Swedish layout
+(deflayer default
+  _    _    _    _    _    _    _    _    _    _    _    _    _    _
+  _    _    _    _    _    _    _    _    _    _    _    _    _
+  _    _    _    _    _    _    _    _    _    _    _    _    _    _
+  _    _    _    _    _    _    _    _    _    _    _    _         _
+  _    _    _                   _                   _    _    _    _
+)
+----
+====


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add deflocalkeys-linux and defsrc for Swedish keyboard.

A matching transparent deflayer is included to ease the configuration.

## Checklist

- Add documentation to docs/config.adoc
  - No. Doc added to sub-document locales.adoc.
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  - N/A
- Added tests, or did manual testing
  - Yes, manually tested by mapping each deflocal key to another key and see that the output is correct.
