### PR TITLE
feat(unmod): accept optional mod list as first param

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,7 @@ name = "kanata-parser"
 version = "0.161.0"
 dependencies = [
  "anyhow",
+ "bitflags 2.5.0",
  "bytemuck",
  "itertools",
  "kanata-keyberon",

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -603,6 +603,11 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   de{ (unshift ralt 7)
   de[ (unshift ralt 8)
 
+  ;; unmod can optionally take a list as the first parameter,
+  ;; and then will only temporarily remove
+  ;; the listed modifiers instead of all modifiers.
+  unalt-a (unmod (lalt ralt) a)
+
   ;; unicode accepts a single unicode character. The unicode character will
   ;; not be automatically repeated by holding the key down. The alias name
   ;; is the unicode character itself and is referenced by @🙁 in deflayer.

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1548,6 +1548,21 @@ This can be useful for forcing unshifted keys while AltGr is still held.
 )
 ----
 
+Introduced more recently is an optional list as the first parameter of `unmod`,
+which must be a non-empty list of modifier keys,
+namely keys in the affected modifiers list from earlier in the unmod section
+of the document.
+
+When this list exists `unmod` will temporarily release only the keys listed
+rather than all modifiers.
+
+.Example:
+[source]
+----
+;; only unshift the alt keys
+(unshift (lalt ralt) a)
+----
+
 [[cmd]]
 === cmd
 <<table-of-contents,Back to ToC>>

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1527,7 +1527,7 @@ otherwise `caps-word` will be activate as normal.
 The `unmod` action will release all modifiers temporarily
 and send one or more keys.
 After the `unmod` key is released, the released modifiers are pressed again.
-The modifiers affected are: `lsft,rsft,lctl,rctl,lmet,rmet,lalt,ralt`.
+The affected modifiers are: `lsft,rsft,lctl,rctl,lmet,rmet,lalt,ralt`.
 
 A variant of `unmod` is `unshift` or `un⇧`.
 This action only releases the `lsft,rsft` keys.
@@ -1548,19 +1548,20 @@ This can be useful for forcing unshifted keys while AltGr is still held.
 )
 ----
 
-Introduced more recently is an optional list as the first parameter of `unmod`,
-which must be a non-empty list of modifier keys,
-namely keys in the affected modifiers list from earlier in the unmod section
-of the document.
+Introduced more recently is an optional list as the first parameter of `unmod`.
+The list must be non-empty and must contain only modifier keys,
+which are the keys in the affected modifiers list from earlier in this document section.
 
-When this list exists `unmod` will temporarily release only the keys listed
+When this list exists, the action will temporarily release only the keys listed
 rather than all modifiers.
 
 .Example:
 [source]
 ----
-;; only unshift the alt keys
-(unshift (lalt ralt) a)
+(defalias
+	;; only unshift the alt keys
+	unalt-a (unmod (lalt ralt) a)
+)
 ----
 
 [[cmd]]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0.38"
 # binary.
 kanata-keyberon = { path = "../keyberon" }
 bytemuck = "1.15.0"
+bitflags = "2.5.0"
 
 [features]
 cmd = []

--- a/parser/src/cfg/key_outputs.rs
+++ b/parser/src/cfg/key_outputs.rs
@@ -116,7 +116,7 @@ pub(crate) fn add_key_output_from_action_to_key_pos(
         Action::Custom(cacs) => {
             for ac in cacs.iter() {
                 match ac {
-                    CustomAction::Unmodded { keys } | CustomAction::Unshifted { keys } => {
+                    CustomAction::Unmodded { keys, .. } | CustomAction::Unshifted { keys } => {
                         for k in keys.iter() {
                             add_kc_output(osc_slot, k.into(), outputs, overrides);
                         }

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -3497,7 +3497,7 @@ fn parse_unmod(
     ac_params: &[SExpr],
     s: &ParserState,
 ) -> Result<&'static KanataAction> {
-   const ERR_MSG: &str = "expects expects at least one key name";
+    const ERR_MSG: &str = "expects expects at least one key name";
     if ac_params.is_empty() {
         bail!("{unmod_type} {ERR_MSG}\nfound {} items", ac_params.len());
     }
@@ -3507,32 +3507,39 @@ fn parse_unmod(
     // Parse the optional first-list that specifies the mod keys to use.
     if let Some(mod_list) = ac_params[0].list(s.vars()) {
         if unmod_type != UNMOD {
-            bail_expr!(&ac_params[0], "{unmod_type} only expects key names but found a list");
+            bail_expr!(
+                &ac_params[0],
+                "{unmod_type} only expects key names but found a list"
+            );
         }
-        mods = mod_list.iter().try_fold(UnmodMods::empty(), |mod_flags, mod_key| {
-            let flag = mod_key
-                .atom(s.vars())
-                .and_then(str_to_oscode)
-                .and_then(|osc|
-                     match osc {
-                         OsCode::KEY_LEFTSHIFT => Some(UnmodMods::LSft),
-                         OsCode::KEY_RIGHTSHIFT => Some(UnmodMods::RSft),
-                         OsCode::KEY_LEFTCTRL => Some(UnmodMods::LCtl),
-                         OsCode::KEY_RIGHTCTRL => Some(UnmodMods::RCtl),
-                         OsCode::KEY_LEFTMETA => Some(UnmodMods::LMet),
-                         OsCode::KEY_RIGHTMETA => Some(UnmodMods::RMet),
-                         OsCode::KEY_LEFTALT => Some(UnmodMods::LAlt),
-                         OsCode::KEY_RIGHTALT => Some(UnmodMods::RAlt),
-                         _ => None,
-                     }
-                 )
-                .ok_or_else(|| anyhow_expr!(mod_key,
-                       "{UNMOD} expects modifier key names within the modifier list"))?;
-            if !(mod_flags & flag).is_empty() {
-                bail_expr!(mod_key, "duplicate key name in modifier key list");
-            }
-            Ok::<_, ParseError>(mod_flags | flag)
-        })?;
+        mods = mod_list
+            .iter()
+            .try_fold(UnmodMods::empty(), |mod_flags, mod_key| {
+                let flag = mod_key
+                    .atom(s.vars())
+                    .and_then(str_to_oscode)
+                    .and_then(|osc| match osc {
+                        OsCode::KEY_LEFTSHIFT => Some(UnmodMods::LSft),
+                        OsCode::KEY_RIGHTSHIFT => Some(UnmodMods::RSft),
+                        OsCode::KEY_LEFTCTRL => Some(UnmodMods::LCtl),
+                        OsCode::KEY_RIGHTCTRL => Some(UnmodMods::RCtl),
+                        OsCode::KEY_LEFTMETA => Some(UnmodMods::LMet),
+                        OsCode::KEY_RIGHTMETA => Some(UnmodMods::RMet),
+                        OsCode::KEY_LEFTALT => Some(UnmodMods::LAlt),
+                        OsCode::KEY_RIGHTALT => Some(UnmodMods::RAlt),
+                        _ => None,
+                    })
+                    .ok_or_else(|| {
+                        anyhow_expr!(
+                            mod_key,
+                            "{UNMOD} expects modifier key names within the modifier list"
+                        )
+                    })?;
+                if !(mod_flags & flag).is_empty() {
+                    bail_expr!(mod_key, "duplicate key name in modifier key list");
+                }
+                Ok::<_, ParseError>(mod_flags | flag)
+            })?;
         if mods.is_empty() {
             bail_expr!(&ac_params[0], "an empty modifier key list is invalid");
         }
@@ -3547,7 +3554,12 @@ fn parse_unmod(
             param
                 .atom(s.vars())
                 .and_then(str_to_oscode)
-                .ok_or_else(|| anyhow_expr!(&ac_params[0], "{unmod_type} {ERR_MSG}\nfound invalid key name"))?
+                .ok_or_else(|| {
+                    anyhow_expr!(
+                        &ac_params[0],
+                        "{unmod_type} {ERR_MSG}\nfound invalid key name"
+                    )
+                })?
                 .into(),
         );
         Ok::<_, ParseError>(keys)

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -3502,7 +3502,7 @@ fn parse_unmod(
         bail!("{unmod_type} {ERR_MSG}\nfound {} items", ac_params.len());
     }
 
-    let mut mods = UnmodMods(0b11111111);
+    let mut mods = UnmodMods::all();
     let mut params = ac_params;
     // Parse the optional first-list that specifies the mod keys to use.
     if let Some(mod_list) = ac_params[0].list(s.vars()) {

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -3497,12 +3497,13 @@ fn parse_unmod(
     ac_params: &[SExpr],
     s: &ParserState,
 ) -> Result<&'static KanataAction> {
-    const ERR_MSG: &str = "expects expects at least one key name";
+   const ERR_MSG: &str = "expects expects at least one key name";
     if ac_params.is_empty() {
         bail!("{unmod_type} {ERR_MSG}\nfound {} items", ac_params.len());
     }
 
     let mut mods = UnmodMods(0b11111111);
+    let mut params = ac_params;
     // Parse the optional first-list that specifies the mod keys to use.
     if let Some(mod_list) = ac_params[0].list(s.vars()) {
         if unmod_type != UNMOD {
@@ -3538,14 +3539,15 @@ fn parse_unmod(
         if ac_params[1..].is_empty() {
             bail!("at least one key is required after the modifier key list");
         }
+        params = &ac_params[1..];
     }
 
-    let keys: Vec<KeyCode> = ac_params.iter().try_fold(Vec::new(), |mut keys, param| {
+    let keys: Vec<KeyCode> = params.iter().try_fold(Vec::new(), |mut keys, param| {
         keys.push(
             param
                 .atom(s.vars())
                 .and_then(str_to_oscode)
-                .ok_or_else(|| anyhow_expr!(&ac_params[0], "{unmod_type} {ERR_MSG}"))?
+                .ok_or_else(|| anyhow_expr!(&ac_params[0], "{unmod_type} {ERR_MSG}\nfound invalid key name"))?
                 .into(),
         );
         Ok::<_, ParseError>(keys)

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -3501,6 +3501,36 @@ fn parse_unmod(
     if ac_params.is_empty() {
         bail!("{unmod_type} {ERR_MSG}\nfound {} items", ac_params.len());
     }
+    let mut mods = UnmodMods(0b11111111);
+    if let Some(mod_list) = ac_params[0].list(s.vars()) {
+        if unmod_type != UNMOD {
+            bail_expr!(&ac_params[0], "{unmod_type} only expects key names but found a list");
+        }
+        mods = mod_list.iter().try_fold(UnmodMods::empty(), |mod_flags, mod_key| {
+            let flag = mod_key
+                .atom(s.vars())
+                .and_then(str_to_oscode)
+                .and_then(|osc|
+                     match osc {
+                         OsCode::KEY_LEFTSHIFT => Some(UnmodMods::LSft),
+                         OsCode::KEY_RIGHTSHIFT => Some(UnmodMods::RSft),
+                         OsCode::KEY_LEFTCTRL => Some(UnmodMods::LCtl),
+                         OsCode::KEY_RIGHTCTRL => Some(UnmodMods::RCtl),
+                         OsCode::KEY_LEFTMETA => Some(UnmodMods::LMet),
+                         OsCode::KEY_RIGHTMETA => Some(UnmodMods::RMet),
+                         OsCode::KEY_LEFTALT => Some(UnmodMods::LAlt),
+                         OsCode::KEY_RIGHTALT => Some(UnmodMods::RAlt),
+                         _ => None,
+                     }
+                 )
+                .ok_or_else(|| anyhow_expr!(mod_key,
+                       "{UNMOD} expects modifier key names within the modifier list"))?;
+            if !(mod_flags & flag).is_empty() {
+                bail_expr!(mod_key, "duplicate key name in modifier key list");
+            }
+            Ok::<_, ParseError>(mod_flags | flag)
+        })?;
+    }
     let mut keys: Vec<KeyCode> = ac_params.iter().try_fold(Vec::new(), |mut keys, param| {
         keys.push(
             param
@@ -3514,7 +3544,7 @@ fn parse_unmod(
     keys.shrink_to_fit();
     match unmod_type {
         UNMOD => Ok(s.a.sref(Action::Custom(
-            s.a.sref(s.a.sref_slice(CustomAction::Unmodded { keys })),
+            s.a.sref(s.a.sref_slice(CustomAction::Unmodded { keys, mods })),
         ))),
         UNSHIFT => Ok(s.a.sref(Action::Custom(
             s.a.sref(s.a.sref_slice(CustomAction::Unshifted { keys })),

--- a/parser/src/custom_action.rs
+++ b/parser/src/custom_action.rs
@@ -73,11 +73,11 @@ pub enum CustomAction {
         y: u16,
     },
     Unmodded {
-        keys: Vec<KeyCode>,
+        keys: Box<[KeyCode]>,
         mods: UnmodMods,
     },
     Unshifted {
-        keys: Vec<KeyCode>,
+        keys: Box<[KeyCode]>,
     },
 }
 

--- a/parser/src/custom_action.rs
+++ b/parser/src/custom_action.rs
@@ -74,6 +74,7 @@ pub enum CustomAction {
     },
     Unmodded {
         keys: Vec<KeyCode>,
+        mods: UnmodMods,
     },
     Unshifted {
         keys: Vec<KeyCode>,
@@ -220,5 +221,21 @@ impl SequenceInputMode {
 
     pub fn err_msg() -> String {
         format!("sequence input mode must be one of: {SEQ_VISIBLE_BACKSPACED}, {SEQ_HIDDEN_SUPPRESSED}, {SEQ_HIDDEN_DELAY_TYPE}")
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UnmodMods(pub u8);
+
+bitflags::bitflags! {
+    impl UnmodMods: u8 {
+        const LSft = 0b00000001;
+        const RSft = 0b00000010;
+        const LAlt = 0b00000100;
+        const RAlt = 0b00001000;
+        const LCtl = 0b00010000;
+        const RCtl = 0b00100000;
+        const LMet = 0b01000000;
+        const RMet = 0b10000000;
     }
 }

--- a/parser/src/custom_action.rs
+++ b/parser/src/custom_action.rs
@@ -225,7 +225,7 @@ impl SequenceInputMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct UnmodMods(pub u8);
+pub struct UnmodMods(u8);
 
 bitflags::bitflags! {
     impl UnmodMods: u8 {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -890,7 +890,7 @@ impl Kanata {
                             self.unmodded_mods = *mods;
                         }
                         CustomAction::Unshifted { keys } => {
-                            self.unshifted_keys.extend(keys.iter()); // test_unmodmods_bits
+                            self.unshifted_keys.extend(keys.iter());
                         }
                         _ => {}
                     }
@@ -1937,8 +1937,8 @@ impl Kanata {
 
 #[test]
 fn test_unmodmods_bits() {
-    assert_eq!(UnmodMods::empty(), UnmodMods(0u8));
-    assert_eq!(UnmodMods::all(), UnmodMods(255u8));
+    assert_eq!(UnmodMods::empty().bits(), 0u8);
+    assert_eq!(UnmodMods::all().bits(), 255u8);
 }
 
 #[cfg(feature = "cmd")]

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -193,6 +193,8 @@ pub struct Kanata {
     dynamic_macro_replay_behaviour: ReplayBehaviour,
     /// Keys that should be unmodded. If non-empty, any modifier should be cleared.
     unmodded_keys: Vec<KeyCode>,
+    /// Modifiers to be cleared in case the above is non-empty.
+    unmodded_mods: UnmodMods,
     /// Keys that should be unshifted. If non-empty, left+right shift keys should be cleared.
     unshifted_keys: Vec<KeyCode>,
     /// Keep track of last pressed key for [`CustomAction::Repeat`].
@@ -364,6 +366,7 @@ impl Kanata {
             ticks_since_idle: 0,
             movemouse_buffer: None,
             unmodded_keys: vec![],
+            unmodded_mods: UnmodMods::empty(),
             unshifted_keys: vec![],
             last_pressed_key: KeyCode::No,
             #[cfg(feature = "tcp_server")]
@@ -462,6 +465,7 @@ impl Kanata {
             ticks_since_idle: 0,
             movemouse_buffer: None,
             unmodded_keys: vec![],
+            unmodded_mods: UnmodMods::empty(),
             unshifted_keys: vec![],
             last_pressed_key: KeyCode::No,
             #[cfg(feature = "tcp_server")]
@@ -881,11 +885,12 @@ impl Kanata {
             CustomEvent::Press(custacts) => {
                 for custact in custacts.iter() {
                     match custact {
-                        CustomAction::Unmodded { keys } => {
-                            self.unmodded_keys.extend(keys);
+                        CustomAction::Unmodded { keys, mods } => {
+                            self.unmodded_keys.extend(keys.iter());
+                            self.unmodded_mods = *mods;
                         }
                         CustomAction::Unshifted { keys } => {
-                            self.unshifted_keys.extend(keys);
+                            self.unshifted_keys.extend(keys.iter()); // test_unmodmods_bits
                         }
                         _ => {}
                     }
@@ -894,7 +899,7 @@ impl Kanata {
             CustomEvent::Release(custacts) => {
                 for custact in custacts.iter() {
                     match custact {
-                        CustomAction::Unmodded { keys } => {
+                        CustomAction::Unmodded { keys, mods: _ } => {
                             self.unmodded_keys.retain(|k| !keys.contains(k));
                         }
                         CustomAction::Unshifted { keys } => {
@@ -907,19 +912,20 @@ impl Kanata {
             _ => {}
         }
         if !self.unmodded_keys.is_empty() {
-            cur_keys.retain(|k| {
-                !matches!(
-                    k,
-                    KeyCode::LShift
-                        | KeyCode::RShift
-                        | KeyCode::LGui
-                        | KeyCode::RGui
-                        | KeyCode::LCtrl
-                        | KeyCode::RCtrl
-                        | KeyCode::LAlt
-                        | KeyCode::RAlt
-                )
-            });
+            for mod_key in self.unmodded_mods.iter() {
+                let kc = match mod_key {
+                    UnmodMods::LSft => KeyCode::LShift,
+                    UnmodMods::RSft => KeyCode::RShift,
+                    UnmodMods::LAlt => KeyCode::LGui,
+                    UnmodMods::RAlt => KeyCode::RGui,
+                    UnmodMods::LCtl => KeyCode::LCtrl,
+                    UnmodMods::RCtl => KeyCode::RCtrl,
+                    UnmodMods::LMet => KeyCode::LAlt,
+                    UnmodMods::RMet => KeyCode::RAlt,
+                    _ => unreachable!("all bits of u8 should be covered"), // test_unmodmods_bits
+                };
+                cur_keys.retain(|k| *k != kc);
+            }
             cur_keys.extend(self.unmodded_keys.iter());
         }
         if !self.unshifted_keys.is_empty() {
@@ -1927,6 +1933,12 @@ impl Kanata {
                 .map(|cv2| cv2.is_idle_chv2())
                 .unwrap_or(true)
     }
+}
+
+#[test]
+fn test_unmodmods_bits() {
+    assert_eq!(UnmodMods::empty(), UnmodMods(0u8));
+    assert_eq!(UnmodMods::all(), UnmodMods(255u8));
 }
 
 #[cfg(feature = "cmd")]

--- a/src/kanata/windows/mod.rs
+++ b/src/kanata/windows/mod.rs
@@ -22,7 +22,7 @@ pub fn set_win_altgr_behaviour(b: AltGrBehaviour) {
 }
 
 impl Kanata {
-    #[cfg(not(feature = "interception_driver"))]
+    #[cfg(all(not(feature = "interception_driver"), not(feature = "simulated_output")))]
     pub fn check_release_non_physical_shift(&mut self) -> Result<()> {
         fn state_filter(v: &State<'_, &&[&CustomAction]>) -> Option<State<'static, ()>> {
             match v {
@@ -124,7 +124,7 @@ impl Kanata {
         Ok(())
     }
 
-    #[cfg(feature = "interception_driver")]
+    #[cfg(any(feature = "interception_driver", feature = "simulated_output"))]
     pub fn check_release_non_physical_shift(&mut self) -> Result<()> {
         Ok(())
     }

--- a/src/kanata/windows/mod.rs
+++ b/src/kanata/windows/mod.rs
@@ -22,7 +22,10 @@ pub fn set_win_altgr_behaviour(b: AltGrBehaviour) {
 }
 
 impl Kanata {
-    #[cfg(all(not(feature = "interception_driver"), not(feature = "simulated_output")))]
+    #[cfg(all(
+        not(feature = "interception_driver"),
+        not(feature = "simulated_output")
+    ))]
     pub fn check_release_non_physical_shift(&mut self) -> Result<()> {
         fn state_filter(v: &State<'_, &&[&CustomAction]>) -> Option<State<'static, ()>> {
             match v {

--- a/src/kanata/windows/mod.rs
+++ b/src/kanata/windows/mod.rs
@@ -24,7 +24,8 @@ pub fn set_win_altgr_behaviour(b: AltGrBehaviour) {
 impl Kanata {
     #[cfg(all(
         not(feature = "interception_driver"),
-        not(feature = "simulated_output")
+        not(feature = "simulated_output"),
+        not(feature = "win_sendinput_send_scancodes"),
     ))]
     pub fn check_release_non_physical_shift(&mut self) -> Result<()> {
         fn state_filter(v: &State<'_, &&[&CustomAction]>) -> Option<State<'static, ()>> {
@@ -127,7 +128,11 @@ impl Kanata {
         Ok(())
     }
 
-    #[cfg(any(feature = "interception_driver", feature = "simulated_output"))]
+    #[cfg(any(
+        feature = "interception_driver",
+        feature = "simulated_output",
+        feature = "win_sendinput_send_scancodes"
+    ))]
     pub fn check_release_non_physical_shift(&mut self) -> Result<()> {
         Ok(())
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,7 +24,7 @@ fn init_log() {
         CombinedLogger::init(vec![TermLogger::new(
             // Note: set to a different level to see logs in tests.
             // Also, not all tests call init_log so you might have to add the call there too.
-            LevelFilter::Debug,
+            LevelFilter::Off,
             log_cfg.build(),
             TerminalMode::Stderr,
             ColorChoice::AlwaysAnsi,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,7 +24,7 @@ fn init_log() {
         CombinedLogger::init(vec![TermLogger::new(
             // Note: set to a different level to see logs in tests.
             // Also, not all tests call init_log so you might have to add the call there too.
-            LevelFilter::Off,
+            LevelFilter::Debug,
             log_cfg.build(),
             TerminalMode::Stderr,
             ColorChoice::AlwaysAnsi,

--- a/src/tests/sim_tests/mod.rs
+++ b/src/tests/sim_tests/mod.rs
@@ -19,6 +19,7 @@ mod repeat_sim_tests;
 mod seq_sim_tests;
 mod switch_sim_tests;
 mod unicode_sim_tests;
+mod unmod_sim_tests;
 
 fn simulate(cfg: &str, sim: &str) -> String {
     init_log();

--- a/src/tests/sim_tests/mod.rs
+++ b/src/tests/sim_tests/mod.rs
@@ -64,6 +64,7 @@ fn simulate(cfg: &str, sim: &str) -> String {
             None => panic!("invalid item {pair}"),
         }
     }
+    drop(_lk);
     k.kbd_out.outputs.events.join("\n")
 }
 

--- a/src/tests/sim_tests/override_tests.rs
+++ b/src/tests/sim_tests/override_tests.rs
@@ -16,7 +16,7 @@ fn override_with_unmod() {
 (defsrc a b)
 (deflayer base @a @b)
         ",
-        "d:lsft t:50 d:a t:50 u:a t:50 d:b t:50 u:b t:50 u:lsft",
+        "d:lsft t:50 d:a t:50 u:a t:50 d:b t:50 u:b t:50",
     )
     .to_ascii()
     .no_time();

--- a/src/tests/sim_tests/override_tests.rs
+++ b/src/tests/sim_tests/override_tests.rs
@@ -16,7 +16,7 @@ fn override_with_unmod() {
 (defsrc a b)
 (deflayer base @a @b)
         ",
-        "d:lsft d:a t:50 u:a t:50 d:b t:50 u:b t:50 u:lsft",
+        "d:lsft t:50 d:a t:50 u:a t:50 d:b t:50 u:b t:50 u:lsft",
     )
     .to_ascii()
     .no_time();

--- a/src/tests/sim_tests/unmod_sim_tests.rs
+++ b/src/tests/sim_tests/unmod_sim_tests.rs
@@ -1,0 +1,42 @@
+
+use super::*;
+
+#[test]
+fn special_nop_keys() {
+    let result = simulate(
+        r##"
+         (defcfg)
+         (defsrc f1 1 2 3 4 5 6 7 8 9 0)
+         (deflayer base
+             (multi lctl rctl lsft rsft lmet rmet lalt ralt)
+             (unmod a)
+             (unmod (lctl) b)
+             (unmod (rctl) c)
+             (unmod (lsft) d)
+             (unmod (rsft) e)
+             (unmod (lmet) f)
+             (unmod (rmet) g)
+             (unmod (lalt) h)
+             (unmod (ralt) i)
+             (unmod (lctl lsft lmet lalt) j)
+         )
+        "##,
+        "d:f1 t:5 d:1 u:1 t:5 d:2 u:2 t:5 d:3 u:3 t:5 d:4 u:4 t:5 d:5 u:5 t:5 d:6 u:6 t:5
+                  d:7 u:7 t:5 d:8 u:8 t:5 d:9 u:9 t:5 d:0 u:0 t:5",
+    )
+    .no_time()
+    .to_ascii();
+    assert_eq!("dn:LCtrl dn:RCtrl dn:LShift dn:RShift dn:LGui dn:RGui dn:LAlt dn:RAlt \
+                up:LCtrl up:RCtrl up:LShift up:RShift up:LGui up:RGui up:LAlt up:RAlt dn:A up:A \
+                dn:LCtrl dn:RCtrl dn:LShift dn:RShift dn:LGui dn:RGui dn:LAlt dn:RAlt \
+                up:LCtrl dn:B up:B dn:LCtrl \
+                up:RCtrl dn:C up:C dn:RCtrl \
+                up:LShift dn:D up:D dn:LShift \
+                up:RShift dn:E up:E dn:RShift \
+                up:LAlt dn:F up:F dn:LAlt \
+                up:RAlt dn:G up:G dn:RAlt \
+                up:LGui dn:H up:H dn:LGui \
+                up:RGui dn:I up:I dn:RGui \
+                up:LCtrl up:LShift up:LGui up:LAlt dn:J up:J dn:LCtrl dn:LShift dn:LGui dn:LAlt",
+                result);
+}

--- a/src/tests/sim_tests/unmod_sim_tests.rs
+++ b/src/tests/sim_tests/unmod_sim_tests.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 
 #[test]
@@ -26,17 +25,19 @@ fn special_nop_keys() {
     )
     .no_time()
     .to_ascii();
-    assert_eq!("dn:LCtrl dn:RCtrl dn:LShift dn:RShift dn:LGui dn:RGui dn:LAlt dn:RAlt \
-                up:LCtrl up:RCtrl up:LShift up:RShift up:LGui up:RGui up:LAlt up:RAlt dn:A up:A \
-                dn:LCtrl dn:RCtrl dn:LShift dn:RShift dn:LGui dn:RGui dn:LAlt dn:RAlt \
-                up:LCtrl dn:B up:B dn:LCtrl \
-                up:RCtrl dn:C up:C dn:RCtrl \
-                up:LShift dn:D up:D dn:LShift \
-                up:RShift dn:E up:E dn:RShift \
-                up:LAlt dn:F up:F dn:LAlt \
-                up:RAlt dn:G up:G dn:RAlt \
-                up:LGui dn:H up:H dn:LGui \
-                up:RGui dn:I up:I dn:RGui \
-                up:LCtrl up:LShift up:LGui up:LAlt dn:J up:J dn:LCtrl dn:LShift dn:LGui dn:LAlt",
-                result);
+    assert_eq!(
+        "dn:LCtrl dn:RCtrl dn:LShift dn:RShift dn:LGui dn:RGui dn:LAlt dn:RAlt \
+         up:LCtrl up:RCtrl up:LShift up:RShift up:LGui up:RGui up:LAlt up:RAlt dn:A up:A \
+         dn:LCtrl dn:RCtrl dn:LShift dn:RShift dn:LGui dn:RGui dn:LAlt dn:RAlt \
+         up:LCtrl dn:B up:B dn:LCtrl \
+         up:RCtrl dn:C up:C dn:RCtrl \
+         up:LShift dn:D up:D dn:LShift \
+         up:RShift dn:E up:E dn:RShift \
+         up:LAlt dn:F up:F dn:LAlt \
+         up:RAlt dn:G up:G dn:RAlt \
+         up:LGui dn:H up:H dn:LGui \
+         up:RGui dn:I up:I dn:RGui \
+         up:LCtrl up:LShift up:LGui up:LAlt dn:J up:J dn:LCtrl dn:LShift dn:LGui dn:LAlt",
+        result
+    );
 }

--- a/src/tests/sim_tests/unmod_sim_tests.rs
+++ b/src/tests/sim_tests/unmod_sim_tests.rs
@@ -80,3 +80,29 @@ fn unmod_keys_mod_list_cannot_have_empty_keys_after_mod_list() {
         "",
     );
 }
+
+#[test]
+#[should_panic]
+fn unmod_keys_mod_list_cannot_have_empty_keys() {
+    simulate(
+        "
+         (defcfg)
+         (defsrc a)
+         (deflayer base (unmod))
+        ",
+        "",
+    );
+}
+
+#[test]
+#[should_panic]
+fn unmod_keys_mod_list_cannot_have_invalid_keys() {
+    simulate(
+        "
+         (defcfg)
+         (defsrc a)
+         (deflayer base (unmod invalid-key))
+        ",
+        "",
+    );
+}

--- a/src/tests/sim_tests/unmod_sim_tests.rs
+++ b/src/tests/sim_tests/unmod_sim_tests.rs
@@ -1,9 +1,9 @@
 use super::*;
 
 #[test]
-fn special_nop_keys() {
+fn unmod_keys_functionality_works() {
     let result = simulate(
-        r##"
+        "
          (defcfg)
          (defsrc f1 1 2 3 4 5 6 7 8 9 0)
          (deflayer base
@@ -19,7 +19,7 @@ fn special_nop_keys() {
              (unmod (ralt) i)
              (unmod (lctl lsft lmet lalt) j)
          )
-        "##,
+        ",
         "d:f1 t:5 d:1 u:1 t:5 d:2 u:2 t:5 d:3 u:3 t:5 d:4 u:4 t:5 d:5 u:5 t:5 d:6 u:6 t:5
                   d:7 u:7 t:5 d:8 u:8 t:5 d:9 u:9 t:5 d:0 u:0 t:5",
     )
@@ -39,5 +39,44 @@ fn special_nop_keys() {
          up:RGui dn:I up:I dn:RGui \
          up:LCtrl up:LShift up:LGui up:LAlt dn:J up:J dn:LCtrl dn:LShift dn:LGui dn:LAlt",
         result
+    );
+}
+
+#[test]
+#[should_panic]
+fn unmod_keys_mod_list_cannot_be_empty() {
+    simulate(
+        "
+         (defcfg)
+         (defsrc a)
+         (deflayer base (unmod () a))
+        ",
+        "",
+    );
+}
+
+#[test]
+#[should_panic]
+fn unmod_keys_mod_list_cannot_have_nonmod_key() {
+    simulate(
+        "
+         (defcfg)
+         (defsrc a)
+         (deflayer base (unmod (lmet c) a))
+        ",
+        "",
+    );
+}
+
+#[test]
+#[should_panic]
+fn unmod_keys_mod_list_cannot_have_empty_keys_after_mod_list() {
+    simulate(
+        "
+         (defcfg)
+         (defsrc a)
+         (deflayer base (unmod (lmet)))
+        ",
+        "",
     );
 }


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add backwards-compatible change to accept an optional list as the first parameter of `unmod` to specify a specific set of modifiers to temporarily release.

This also includes:
- fix for a test consistency issue on Windows related to the state kept for the numlock shift workaround
- removal of the numlock shift workaround for scancode output because it does not need the code, and the workaround is strictly a downgrade in functionality

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes