### PR TITLE
refactor(win): adjust default feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ indoc = { version = "2.0.4", optional = true }
 regex = { version = "1.10.4", optional = true }
 
 [features]
-default = ["tcp_server"]
+default = ["tcp_server","win_sendinput_send_scancodes"]
 perf_logging = []
 tcp_server = ["serde_json"]
 win_sendinput_send_scancodes = []

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ build_release_linux output_dir:
 
 # Build the release binaries for Windows and put the binaries+cfg in the output directory.
 build_release_windows output_dir:
-  cargo build --release --features win_manifest; cp target/release/kanata.exe "{{output_dir}}\kanata_legacy_output.exe"
+  cargo build --release --no-default-features --features tcp,win_manifest; cp target/release/kanata.exe "{{output_dir}}\kanata_legacy_output.exe"
   cargo build --release --features win_manifest,interception_driver; cp target/release/kanata.exe "{{output_dir}}\kanata_wintercept.exe"
   cargo build --release --features win_manifest,win_sendinput_send_scancodes; cp target/release/kanata.exe "{{output_dir}}\kanata.exe"
   cargo build --release --features win_manifest,win_sendinput_send_scancodes,win_llhook_read_scancodes; cp target/release/kanata.exe "{{output_dir}}\kanata_winIOv2.exe"


### PR DESCRIPTION
This commit adds win_sendinput_send_scancodes as a default feature. The feature has had some time to be tested and should be good enough to replace vkey output by default. With this change, anyone compiling the default kanata binary on Windows without knowing about the difference between vkey codes and scan codes and no awareness of winiov2 will hopefully have a better experience than they used to.

The justfile line for compiling the legacy binary is adjusted as well so that it compiles without the now-default feature and continues to use vkey output, in case someone really needs it.