### PR TITLE
typo: correct "Release behaviour" in the configuration guide

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1882,7 +1882,7 @@ activated by a chord.
 ----
 (defcfg concurrent-tap-hold yes)
 (defchordsv2-experimental
-  (a s)    c                200 last-release  (non-chord-layer)
+  (a s)    c                200 all-released  (non-chord-layer)
   (a s d) (macro h e l l o) 250 first-release (non-chord-layer)
   (s d f) (macro b y e)     400 first-release (non-chord-layer)
 )


### PR DESCRIPTION
should be `all-released` instead of `last-release` which doesn't exist

## Describe your changes. Use imperative present tense.
fixed typo
## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [ ] Yes
