### PR TITLE
Update locales.adoc with Swedish QWERTY for Windows

### DIFF
--- a/docs/locales.adoc
+++ b/docs/locales.adoc
@@ -309,3 +309,26 @@ NOTE: This is for the https://kbdlayout.info/kbdbr[ABNT2 QWERTY layout]. Tested 
 )
 ----
 ====
+
+
+== Swedish QWERTY Localkeys (Windows)[[swedish]]
+
+[%collapsible]
+====
+----
+(deflocalkeys-win
+  §   220
+  +   187
+  ´   219
+  å   221
+  ¨   186
+  ö   192
+  ä   222
+  '   191
+  <   226
+  ,   188
+  .   190
+  -   189
+)
+----
+====


### PR DESCRIPTION
Add Localkey definitions for Swedish QWERTY keyboards on Windows (without intercept nor IOv2)