### PR TITLE
fix(exit): change broken conditional compile logic from gui changes

### DIFF
--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -2114,8 +2114,7 @@ fn check_for_exit(_event: &KeyEvent) {
             }
             #[cfg(all(
                 not(target_os = "linux"),
-                not(target_os = "windows"),
-                not(feature = "gui")
+                not(all(target_os = "windows", feature = "gui"))
             ))]
             {
                 panic!("{EXIT_MSG}");


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Commit 7e5039 broke the force-exit-chord on Windows non-GUI. Seems there is another bug for Windows GUI+Interception; that bug is not fixed in this PR.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
