### PR TITLE
Update fancy_symbols.md (fix many outdated symbols)

### DIFF
--- a/docs/fancy_symbols.md
+++ b/docs/fancy_symbols.md
@@ -10,19 +10,19 @@
   |⇪             	| capslock                                 	|
   |⎋             	|`escape`                                  	|
   |⭾ ↹           	|`tab`                                     	|
-  |␠ ␣           	|`spacebar`                                	|
-  |␈ ⌫           	|`delete_or_backspace`                     	|
-  |␡ ⌦           	|`delete_forward`                          	|
-  |⏎ ↩ ⌤ ␤       	|`return_or_enter`                         	|
-  |︔ ⸴ ．⁄        	|`semicolon` / `comma` / `period` / `slash`	|
-  |⧵ ＼           	|`backslash`                               	|
+  |␠ ␣           	| `spc` spacebar                             	|
+  |␈ ⌫           	|`bspc` backspace (delete backward)         |
+  |␡ ⌦           	|`del` delete forward                      	|
+  |⏎ ↩ ⌤ ␤       	|`ret` return or enter                     	|
+  |︔ ⸴ ．⁄        	|semicolon `;` / comma `,` / period `.` / slash `/`	|
+  |⧵ ＼           	| backslash `\`                            	|
   |﹨ <           	|`non_us_backslash`                        	|
   |【 「 〔 ⎡       	|`open_bracket`                            	|
   |】 」 〕 ⎣       	|`close_bracket`                           	|
   |ˋ ˜           	|`grave_accent_and_tilde`                  	|
   |‐ ₌           	|`hyphen` `equal_sign`                     	|
-  |▲ ▼ ◀ ▶       	|`up`/`down`/`left`/`right` `_arrow`
-  |⇞ ⇟           	|`page_` `up`/`down`                    	|
+  |▲ ▼ ◀ ▶       	|`up`/`down`/`left`/`right` (arrows)        |
+  |⇞ ⇟           	|`pgup`/`pgdn` (page up, page down)	      |
   |⎀             	|`insert`                               	|
   |⇤ ⤒ ↖         	|`home`                                 	|
   |⇥ ⤓ ↘         	|`end`                                  	|


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Update some outdated key names in the list of fancy symbols. For example, the table says `page_down`, but this throws an error in kanata because it actually expects `pgdn`.

It took me time to find the actual name (I had to use the symbol ⇟ while I found it was `pgdn`), so I think it's beter to put the actual key name in the table. I pressume that `page_down` was used in eralier versions of kanata, which would explain the mismatch. I updated the ones I noticed. Not all of them are fixed I think.

## Checklist

- Add documentation to docs/config.adoc
  - N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  - N/A
- Added tests, or did manual testing
  - Yes, I tested the new names: `pgup`, `pgdn`, `spc`, `bspc`, etc.
