### PR TITLE
doc: add note about `process-unmapped-keys` to `unmod`

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1553,7 +1553,7 @@ A variant of `unmod` is `unshift` or `un⇧`.
 This action only releases the `lsft,rsft` keys.
 This can be useful for forcing unshifted keys while AltGr is still held.
 
-NOTE: In case the modifiers to be undone are not part of the source layout,
+NOTE: In case the modifiers to be undone are not part of `defsrc`,
 <<process-unmapped-keys>> needs to be enabled in `defcfg` in order for their
 states to be tracked correctly.
 

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1553,6 +1553,10 @@ A variant of `unmod` is `unshift` or `un⇧`.
 This action only releases the `lsft,rsft` keys.
 This can be useful for forcing unshifted keys while AltGr is still held.
 
+NOTE: In case the modifiers to be undone are not part of the source layout,
+<<process-unmapped-keys>> needs to be enabled in `defcfg` in order for their
+states to be tracked correctly.
+
 .Example:
 [source]
 ----


### PR DESCRIPTION
It has taken me a while to figure out why `unmod` had no effect in my mappings. After running in debug mode I realized that the events sent by the modifiers are not tracked at all, since they are not part of my source mapping. When seeing this I remembered seeing `process-unmapped-keys` enabled in [this comment](https://github.com/jtroo/kanata/issues/615#issuecomment-1803448264) while digging through some issues. Doing so resulted in the expected behavior.