### PR TITLE
fix(wintercept): remove extra whitespace in the build script cli args

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ build_release_windows output_dir:
   cargo build --release --features passthru_ahk --package=simulated_passthru; cp target/release/kanata_passthru.dll "{{output_dir}}\kanata_passthru.dll"
   cargo build --release --features win_manifest,gui    ; cp target/release/kanata.exe "{{output_dir}}\kanata_gui.exe"
   cargo build --release --features win_manifest,gui,cmd; cp target/release/kanata.exe "{{output_dir}}\kanata_gui_cmd_allowed.exe"
-  cargo build --release --features win_manifest,gui    ,interception_driver; cp target/release/kanata.exe "{{output_dir}}\kanata_gui_wintercept.exe"
+  cargo build --release --features win_manifest,gui,interception_driver    ; cp target/release/kanata.exe "{{output_dir}}\kanata_gui_wintercept.exe"
   cargo build --release --features win_manifest,gui,cmd,interception_driver; cp target/release/kanata.exe "{{output_dir}}\kanata_gui_wintercept_cmd_allowed.exe"
   cp cfg_samples/kanata.kbd "{{output_dir}}"
 


### PR DESCRIPTION
fixes https://github.com/jtroo/kanata/issues/1190

## Describe your changes. Use imperative present tense.

Remove extra space between comma-seperated arguments in the just build file

## Checklist

- Add documentation to docs/config.adoc
  - N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  - N/A
- Added tests, or did manual testing
  - [x] Yes, manual
