### PR TITLE
fix "any key" mappings in `deflayermap`

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -3071,7 +3071,7 @@ fn parse_layers(
                             bail_expr!(input, "must either use _ or ___ within a layer, not both")
                         }
                         for i in 0..s.mapping_order.len() {
-                            if layers_cfg[layer_level][0][s.mapping_order[i]] == Action::Trans {
+                            if layers_cfg[layer_level][0][s.mapping_order[i]] == DEFAULT_ACTION {
                                 layers_cfg[layer_level][0][s.mapping_order[i]] = *action;
                             }
                         }
@@ -3090,7 +3090,7 @@ fn parse_layers(
                             bail_expr!(input, "must either use __ or ___ within a layer, not both")
                         }
                         for i in 0..layers_cfg[0][0].len() {
-                            if layers_cfg[layer_level][0][i] == Action::Trans
+                            if layers_cfg[layer_level][0][i] == DEFAULT_ACTION
                                 && !s.mapping_order.contains(&i)
                             {
                                 layers_cfg[layer_level][0][i] = *action;
@@ -3114,7 +3114,7 @@ fn parse_layers(
                             );
                         }
                         for i in 0..layers_cfg[0][0].len() {
-                            if layers_cfg[layer_level][0][i] == Action::Trans {
+                            if layers_cfg[layer_level][0][i] == DEFAULT_ACTION {
                                 layers_cfg[layer_level][0][i] = *action;
                             }
                         }

--- a/parser/src/cfg/sexpr.rs
+++ b/parser/src/cfg/sexpr.rs
@@ -293,12 +293,11 @@ impl<'a> Iterator for PositionCountingBytesIterator<'a> {
     type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.bytes.next().map(|b| {
+        self.bytes.next().inspect(|&b| {
             if b == b'\n' {
                 self.line += 1;
                 self.line_beginning = self.source_length - self.bytes.len()
             }
-            b
         })
     }
 }


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
may fix https://github.com/jtroo/kanata/issues/1236, it fixes the behavior according to my manual testing, but not sure if the fix is a "correct" fix (in the sense of a "correct program").

Edit: may fix #1220 too apparently.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests
  -  [ ] Yes
- did manual testing
  - [x] Yes