### PR TITLE
fix(macro): keep macro states on macro completion

### DIFF
--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -1354,11 +1354,6 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
                     // Process it (SequenceEvent)
                     match seq.cur_event {
                         Some(SequenceEvent::Complete) => {
-                            for fake_key in self.states.clone().iter() {
-                                if let FakeKey { keycode } = *fake_key {
-                                    self.states.retain(|s| s.seq_release(keycode).is_some());
-                                }
-                            }
                             seq.remaining_events = &[];
                         }
                         Some(SequenceEvent::Press(keycode)) => {

--- a/src/tests/sim_tests/chord_sim_tests.rs
+++ b/src/tests/sim_tests/chord_sim_tests.rs
@@ -339,3 +339,29 @@ fn sim_chord_release_nonchord_key_has_correct_order() {
         result
     );
 }
+
+#[test]
+fn sim_chord_simultaneous_macro() {
+    let result = simulate(
+        "
+        (defsrc a b o)
+        (deflayer default
+          (chord base a)
+          (chord base b)
+          (chord base o)
+        )
+        (defchords base 500
+          (a) (macro a z)
+          (b) (macro b)
+          (o) o
+          (a o) o
+        )
+        ",
+        "d:a t:10 d:b t:500",
+    )
+    .to_ascii();
+    assert_eq!(
+        "t:502ms dn:A dn:B t:1ms up:A up:B t:1ms dn:Z t:1ms up:Z",
+        result
+    );
+}


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Fixes #1199, kinda. Macro no longer consumes other macro outputs but doesn't fix the exact described use case.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
