### PR TITLE
Fix compile error on Linux with simulated_input

### DIFF
--- a/src/oskbd/sim_passthru.rs
+++ b/src/oskbd/sim_passthru.rs
@@ -34,7 +34,11 @@ impl KbdOut {
         Ok(Self { tx_kout: None })
     }
     #[cfg(target_os = "linux")]
-    pub fn new(_: &Option<String>) -> Result<Self, io::Error> {
+    pub fn new(
+        _s: &Option<String>,
+        _tp: bool,
+        _bustype: evdev::BusType,
+    ) -> Result<Self, io::Error> {
         Ok(Self { tx_kout: None })
     }
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
Just fix up a method signature.

## Checklist

- Add documentation to docs/config.adoc
  - [ ✅] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ✅] Yes or N/A
- Update error messages
  - [ ✅] Yes or N/A
- Added tests, or did manual testing
  - [ ✅] Yes
