### PR TITLE
feat: allow for include files to be absent

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1801,6 +1801,8 @@ The path will be relative to the defined configuration file.
 At the time of writing, includes can only be placed at the top level.
 The included files also cannot contain includes themselves.
 
+Non-existing files will be ignored.
+
 .Example:
 ----
 ;; This is in the file initially read by kanata, e.g. kanata.kbd

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -430,15 +430,13 @@ fn parse_cfg_raw(p: &Path, s: &mut ParserState) -> MResult<IntermediateCfg> {
             relative_main_cfg_file_dir.join(filepath)
         };
 
-        let abs_filepath: PathBuf = filepath_relative_to_loaded_kanata_cfg
-            .canonicalize()
-            .map_err(|e| {
-                format!(
-                    "Failed to resolve relative path: {}: {}",
-                    filepath_relative_to_loaded_kanata_cfg.to_string_lossy(),
-                    e
-                )
-            })?;
+        let Ok(abs_filepath) = filepath_relative_to_loaded_kanata_cfg.canonicalize() else {
+            log::info!(
+                "Failed to resolve relative path: {}. Ignoring this file.",
+                filepath_relative_to_loaded_kanata_cfg.to_string_lossy()
+            );
+            return Ok("".to_owned());
+        };
 
         // Forbid loading the same file multiple times.
         // This prevents a potential recursive infinite loop of includes

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -603,6 +603,15 @@ fn test_include_bad2_has_original_filename() {
 }
 
 #[test]
+fn test_include_ignore_optional_filename() {
+    let _lk = lock(&CFG_PARSE_LOCK);
+    new_from_file(&std::path::PathBuf::from(
+        "./test_cfgs/include-good-optional-absent.kbd",
+    ))
+    .unwrap();
+}
+
+#[test]
 fn parse_bad_submacro() {
     // Test exists since it used to crash. It should not crash.
     let _lk = lock(&CFG_PARSE_LOCK);

--- a/parser/test_cfgs/include-good-optional-absent.kbd
+++ b/parser/test_cfgs/include-good-optional-absent.kbd
@@ -1,0 +1,3 @@
+(defsrc a)
+(include included-non-existing-file.kbd)
+(include included-good.kbd)


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Up to now files to be included need to exist. With these changes any non-existing file is just ignored.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes
