### PR TITLE
fix(win-llhook): before blocking, check bad keystates

### DIFF
--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -293,14 +293,14 @@ impl<'a, T> Clone for State<'a, T> {
     }
 }
 impl<'a, T: 'a> State<'a, T> {
-    fn keycode(&self) -> Option<KeyCode> {
+    pub fn keycode(&self) -> Option<KeyCode> {
         match self {
             NormalKey { keycode, .. } => Some(*keycode),
             FakeKey { keycode } => Some(*keycode),
             _ => None,
         }
     }
-    fn coord(&self) -> Option<KCoord> {
+    pub fn coord(&self) -> Option<KCoord> {
         match self {
             NormalKey { coord, .. }
             | LayerModifier { coord, .. }

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -1189,6 +1189,12 @@ impl From<OsCode> for u32 {
     }
 }
 
+impl From<OsCode> for i32 {
+    fn from(item: OsCode) -> Self {
+        item.as_u16() as i32
+    }
+}
+
 impl From<OsCode> for u16 {
     fn from(item: OsCode) -> Self {
         item.as_u16()

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1804,7 +1804,7 @@ impl Kanata {
                                 // If kanata has been inactive for long enough, clear all states.
                                 // This won't trigger if there are macros running, or if a key is
                                 // held down for a long time and is sending OS repeats. The reason
-                                // for this code is in case like Win+L which locks the Windows
+                                // for this code is in cases like Win+L which locks the Windows
                                 // desktop. When this happens, the Win key and L key will be stuck
                                 // as pressed in the kanata state because LLHOOK kanata cannot read
                                 // keys in the lock screen or administrator applications. So this
@@ -1816,7 +1816,7 @@ impl Kanata {
                                 // a fake key pressed for a long period of time, so make sure those
                                 // are not cleared.
                                 if (now - last_input_time)
-                                    > time::Duration::from_secs(LLHOOK_IDLE_TIME_CLEAR_INPUTS)
+                                    > time::Duration::from_secs(LLHOOK_IDLE_TIME_SECS_CLEAR_INPUTS)
                                 {
                                     log::debug!(
                                         "clearing keyberon normal key states due to inactivity"
@@ -1952,7 +1952,7 @@ impl Kanata {
                                 // a fake key pressed for a long period of time, so make sure those
                                 // are not cleared.
                                 if (instant::Instant::now() - (last_input_time))
-                                    > time::Duration::from_secs(LLHOOK_IDLE_TIME_CLEAR_INPUTS)
+                                    > time::Duration::from_secs(LLHOOK_IDLE_TIME_SECS_CLEAR_INPUTS)
                                     && !idle_clear_happened
                                 {
                                     idle_clear_happened = true;

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -88,9 +88,11 @@ pub struct Kanata {
     /// Handle to the keyberon library layout.
     pub layout: cfg::KanataLayout,
     /// Reusable vec (to save on allocations) that stores the currently active output keys.
+    /// This can be cleared and reused in various procedures as buffer space.
     pub cur_keys: Vec<KeyCode>,
     /// Reusable vec (to save on allocations) that stores the active output keys from the previous
-    /// tick.
+    /// tick. This must only be updated once per tick and must not be modified outside of the one
+    /// procedure that updates it.
     pub prev_keys: Vec<KeyCode>,
     /// Used for printing layer info to the info log when changing layers.
     pub layer_info: Vec<LayerInfo>,
@@ -1788,8 +1790,6 @@ impl Kanata {
                     k.can_block_update_idle_waiting(ms_elapsed)
                 };
                 if can_block {
-                    log::debug!("checking win keystates");
-
                     #[cfg(all(
                         target_os = "windows",
                         not(feature = "interception_driver"),

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1788,6 +1788,15 @@ impl Kanata {
                     k.can_block_update_idle_waiting(ms_elapsed)
                 };
                 if can_block {
+                    log::debug!("checking win keystates");
+
+                    #[cfg(all(
+                        target_os = "windows",
+                        not(feature = "interception_driver"),
+                        not(feature = "simulated_input"),
+                    ))]
+                    kanata.lock().win_synchronize_keystates();
+
                     log::trace!("blocking on channel");
                     match rx.recv() {
                         Ok(kev) => {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1979,6 +1979,11 @@ impl Kanata {
         });
     }
 
+    /// Returns `true` if kanata's processing thread loop can block on the channel instead of doing
+    /// a non-blocking channel read and then sleeping for ~1ms.
+    ///
+    /// In addition to doing the logic for the above, this mutates the `waiting_for_idle` state
+    /// used by the `on-idle` action for virtual keys.
     pub fn can_block_update_idle_waiting(&mut self, ms_elapsed: u16) -> bool {
         let k = self;
         let is_idle = k.is_idle();

--- a/src/kanata/windows/llhook.rs
+++ b/src/kanata/windows/llhook.rs
@@ -128,9 +128,79 @@ impl Kanata {
     ///    Clear in PK and clear all states with the same coordinate as key output.
     /// 2. For all active in GKS and exists in MK, check it is in SPV.
     ///    If not in SPV, call SendInput to release.
-    fn win_synchronize_keystates(&mut self) {
+    #[cfg(not(feature = "simulated_input"))]
+    pub(crate) fn win_synchronize_keystates(&mut self) {
+        use winapi::um::winuser::*;
+        use winapi::um::errhandlingapi::*;
+        use kanata_keyberon::layout::*;
+
         log::debug!("synchronizing win keystates");
-        todo!()
+        let mut win_key_states = [0u8; 256];
+        let res = unsafe { GetKeyboardState(win_key_states.as_mut_ptr()) };
+        if res == 0 {
+            let err_code = unsafe { GetLastError() };
+            log::error!("GetKeyboardState returned error code: {err_code}");
+            return;
+        }
+
+        for pvk in self.prev_keys.iter() {
+            // Each pvk is expected to be pressed.
+            let osc: OsCode = pvk.into();
+            let idx = usize::from(osc);
+            let wks = win_key_states[idx];
+            let is_pressed_in_windows = wks >= 0b1000000;
+            if is_pressed_in_windows {
+                continue;
+            }
+
+            log::error!("Unexpected keycode is pressed in kanata but not in Windows. Clearing it: {pvk}");
+            // Need to clear internal state about this key.
+                // find coordinate(s) in keyberon associated with pvk
+                let mut coords_to_clear = Vec::<KCoord>::new();
+                let layout = self.layout.bm();
+                layout
+                    .states
+                    .retain(|s| {
+                        let retain = match s.keycode() {
+                            Some(k) => k != *pvk,
+                            _ => true,
+                        };
+                        if !retain {
+                            if let Some(coord) = s.coord() {
+                                coords_to_clear.push(coord);
+                            }
+                        }
+                        retain
+                    });
+
+                // Clear other states other than keycode associated with a keycode that needs to be
+                // cleaned up.
+                layout.states.retain(|s| {
+                    match s.coord() {
+                        Some(c) => !coords_to_clear.contains(&c),
+                        None => false,
+                    }
+                });
+
+                // Clear PRESSED_KEYS for coordinates associated with real and not virtual keys
+                let mut pressed_keys = PRESSED_KEYS.lock();
+                for osc in coords_to_clear
+                    .iter()
+                    .copied()
+                    .filter_map(|c| {
+                        match c {
+                            (FAKE_KEY_ROW, _) => None,
+                            (_, kc) => Some(OsCode::from(kc)),
+                        }
+                    })
+                {
+                    pressed_keys.remove(&osc);
+                }
+                drop(pressed_keys);
+        }
+
+        for (vk, state) in win_key_states.iter().copied().enumerate() {
+        }
     }
 }
 

--- a/src/oskbd/windows/exthook_os.rs
+++ b/src/oskbd/windows/exthook_os.rs
@@ -12,7 +12,7 @@ use kanata_keyberon::key_code::KeyCode;
 
 use kanata_parser::keys::*;
 
-pub const LLHOOK_IDLE_TIME_CLEAR_INPUTS: u64 = 60;
+pub const LLHOOK_IDLE_TIME_SECS_CLEAR_INPUTS: u64 = 60;
 
 type HookFn = dyn FnMut(InputEvent) -> bool + Send + Sync + 'static;
 

--- a/src/oskbd/windows/llhook.rs
+++ b/src/oskbd/windows/llhook.rs
@@ -24,7 +24,7 @@ use kanata_keyberon::key_code::KeyCode;
 use kanata_parser::custom_action::*;
 use kanata_parser::keys::*;
 
-pub const LLHOOK_IDLE_TIME_CLEAR_INPUTS: u64 = 60;
+pub const LLHOOK_IDLE_TIME_SECS_CLEAR_INPUTS: u64 = 60;
 
 type HookFn = dyn FnMut(InputEvent) -> bool;
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Synchronize Kanata and Windows keystates.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
