### PR TITLE
fix!(linux): include name should disregard autodetect classification

### DIFF
--- a/src/kanata/output_logic/zippychord.rs
+++ b/src/kanata/output_logic/zippychord.rs
@@ -346,7 +346,9 @@ impl ZchState {
                     self.zchd.zchd_previous_activation_output_count =
                         ZchOutput::display_len(&a.zch_output);
                 }
-                self.zchd.zchd_prioritized_chords.clone_from(&a.zch_followups);
+                self.zchd
+                    .zchd_prioritized_chords
+                    .clone_from(&a.zch_followups);
                 let mut released_sft = false;
 
                 #[cfg(feature = "interception_driver")]

--- a/src/kanata/output_logic/zippychord.rs
+++ b/src/kanata/output_logic/zippychord.rs
@@ -346,7 +346,7 @@ impl ZchState {
                     self.zchd.zchd_previous_activation_output_count =
                         ZchOutput::display_len(&a.zch_output);
                 }
-                self.zchd.zchd_prioritized_chords = a.zch_followups.clone();
+                self.zchd.zchd_prioritized_chords.clone_from(&a.zch_followups);
                 let mut released_sft = false;
 
                 #[cfg(feature = "interception_driver")]

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -674,7 +674,7 @@ fn discover_devices(
         })
         .filter(|pd| {
             let is_input = is_input_device(&pd.0, device_detect_mode);
-            match include_names {
+            (match include_names {
                 None => is_input,
                 Some(include_names) => {
                     let name = pd.0.name().unwrap_or("");
@@ -686,8 +686,7 @@ fn discover_devices(
                         false
                     }
                 }
-            }
-            &&match exclude_names {
+            }) && (match exclude_names {
                 None => true,
                 Some(exclude_names) => {
                     let name = pd.0.name().unwrap_or("");
@@ -698,7 +697,7 @@ fn discover_devices(
                         true
                     }
                 }
-            }
+            })
         })
         .collect();
     devices

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -274,14 +274,17 @@ pub fn is_input_device(device: &Device, detect_mode: DeviceDetectMode) -> bool {
     let device_name = device.name().unwrap_or("unknown device name");
     match (detect_mode, device_type) {
         (_, DeviceType::Other) => {
-            log::debug!("Use for input: false. Non-input device: {}", device_name,);
+            log::debug!(
+                "Use for input autodetect: false. Non-input device: {}",
+                device_name,
+            );
             false
         }
         (DeviceDetectMode::Any, _)
         | (DeviceDetectMode::KeyboardMice, DeviceType::Keyboard | DeviceType::KeyboardMouse)
         | (DeviceDetectMode::KeyboardOnly, DeviceType::Keyboard) => {
             log::debug!(
-                "Use for input: true. detect type {:?}; device type {:?}, device name: {}",
+                "Use for input autodetect: true. detect type {:?}; device type {:?}, device name: {}",
                 detect_mode,
                 device_type,
                 device_name,
@@ -290,7 +293,7 @@ pub fn is_input_device(device: &Device, detect_mode: DeviceDetectMode) -> bool {
         }
         _ => {
             log::debug!(
-                "Use for input: false. detect type {:?}; device type {:?}, device name: {}",
+                "Use for input autodetect: false. detect type {:?}; device type {:?}, device name: {}",
                 detect_mode,
                 device_type,
                 device_name,
@@ -670,32 +673,32 @@ fn discover_devices(
             )
         })
         .filter(|pd| {
-            is_input_device(&pd.0, device_detect_mode)
-                && match include_names {
-                    None => true,
-                    Some(include_names) => {
-                        let name = pd.0.name().unwrap_or("");
-                        if include_names.iter().any(|include| name == include) {
-                            log::info!("device [{}:{name}] is included", &pd.1);
-                            true
-                        } else {
-                            log::info!("device [{}:{name}] is ignored", &pd.1);
-                            false
-                        }
+            let is_input = is_input_device(&pd.0, device_detect_mode);
+            match include_names {
+                None => is_input,
+                Some(include_names) => {
+                    let name = pd.0.name().unwrap_or("");
+                    if include_names.iter().any(|include| name == include) {
+                        log::info!("device [{}:{name}] is included", &pd.1);
+                        true
+                    } else {
+                        log::info!("device [{}:{name}] is ignored", &pd.1);
+                        false
                     }
                 }
-                && match exclude_names {
-                    None => true,
-                    Some(exclude_names) => {
-                        let name = pd.0.name().unwrap_or("");
-                        if exclude_names.iter().any(|exclude| name == exclude) {
-                            log::info!("device [{}:{name}] is excluded", &pd.1);
-                            false
-                        } else {
-                            true
-                        }
+            }
+            &&match exclude_names {
+                None => true,
+                Some(exclude_names) => {
+                    let name = pd.0.name().unwrap_or("");
+                    if exclude_names.iter().any(|exclude| name == exclude) {
+                        log::info!("device [{}:{name}] is excluded", &pd.1);
+                        false
+                    } else {
+                        true
                     }
                 }
+            }
         })
         .collect();
     devices


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Autodetection is based on checking a single key capability, `KEY_ENTER`. For some reason, some input devices are split into multiple devices, and likely only one of them has `KEY_ENTER` while the others do not. Today the `include` option will still ignore devices that are autodetected to not be keyboards. This commit fixes the use case where a device that is **not** being autodetected but is desired to be grabbed by Kanata is being referenced by its device name rather than path.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
