### PR TITLE
fix: Release RAlt after zippy-chording

### DIFF
--- a/src/kanata/output_logic/zippychord.rs
+++ b/src/kanata/output_logic/zippychord.rs
@@ -521,6 +521,9 @@ impl ZchState {
             OsCode::KEY_RIGHTSHIFT => {
                 self.zchd.zchd_is_rsft_active = false;
             }
+            OsCode::KEY_RIGHTALT => {
+                self.zchd.zchd_is_altgr_active = false;
+            }
             _ => {}
         }
         if osc.is_zippy_ignored() {

--- a/src/tests/sim_tests/zippychord_sim_tests.rs
+++ b/src/tests/sim_tests/zippychord_sim_tests.rs
@@ -232,6 +232,55 @@ fn sim_zippychord_rsft() {
 }
 
 #[test]
+fn sim_zippychord_ralt() {
+    // test ralt behaviour while pressed
+    let result = simulate_with_zippy_file_content(
+        ZIPPY_CFG,
+        "d:ralt t:10 d:d t:10 d:y t:10",
+        ZIPPY_FILE_CONTENT,
+    )
+    .to_ascii();
+    assert_eq!(
+        "dn:RAlt t:10ms dn:D t:10ms dn:BSpace up:BSpace up:RAlt up:D dn:D dn:A up:A up:Y dn:Y dn:RAlt",
+        result
+    );
+    let result = simulate_with_zippy_file_content(
+        ZIPPY_CFG,
+        "d:ralt t:10 d:x t:10 d:y t:10",
+        ZIPPY_FILE_CONTENT,
+    )
+    .to_ascii();
+    assert_eq!(
+        "dn:RAlt t:10ms dn:X t:10ms dn:BSpace up:BSpace \
+         up:RAlt dn:LShift dn:W up:W up:LShift up:X dn:X dn:LShift up:Y dn:Y up:LShift dn:Z up:Z dn:RAlt",
+        result
+    );
+
+    // ensure rsft-held behaviour goes away when released
+    let result = simulate_with_zippy_file_content(
+        ZIPPY_CFG,
+        "d:ralt t:10 d:d u:ralt t:10 d:y t:10",
+        ZIPPY_FILE_CONTENT,
+    )
+    .to_ascii();
+    assert_eq!(
+        "dn:RAlt t:10ms dn:D t:1ms up:RAlt t:9ms dn:BSpace up:BSpace up:D dn:D dn:A up:A up:Y dn:Y",
+        result
+    );
+    let result = simulate_with_zippy_file_content(
+        ZIPPY_CFG,
+        "d:ralt t:10 d:x u:ralt t:10 d:y t:10",
+        ZIPPY_FILE_CONTENT,
+    )
+    .to_ascii();
+    assert_eq!(
+        "dn:RAlt t:10ms dn:X t:1ms up:RAlt t:9ms dn:BSpace up:BSpace \
+         dn:LShift dn:W up:W up:LShift up:X dn:X dn:LShift up:Y dn:Y up:LShift dn:Z up:Z",
+        result
+    );
+}
+
+#[test]
 fn sim_zippychord_caps_word() {
     let result = simulate_with_zippy_file_content(
         ZIPPY_CFG,


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
I noticed that after zippy-chording the `RAlt` Key got stuck until I used another `RAlt` key.
This PR releases `RAlt` the same way it is done for the Shift keys.
I added a test by copy & pasting from the Shift tests and modifying it such that it works with the fixed implementation and fails with the old one.

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
