### PR TITLE
Corrrect the typo "dactivate" to "deactivate" in config.adoc

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2536,8 +2536,10 @@ rather than all modifiers.
 
 **Reference**
 
-The fork action allows choosing between a default and an alternate action
-based on whether specific keys are active.
+The `fork` action allows choosing between a default and an alternate action
+based on whether specific keys are active. `fork` is the equivalent of the 
+basic key checks in `switch`, using none of the list logic items, i.e. virtual 
+keys are not supported.
 
 .Syntax:
 [source]

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2464,7 +2464,7 @@ otherwise `caps-word` will be activate as normal.
 
 **Reference**
 
-The `unmod` action will dactivate modifier keys while outputting
+The `unmod` action will deactivate modifier keys while outputting
 one or more defined keys.
 
 .Syntax:


### PR DESCRIPTION
## Describe your changes. C

Corrrect the typo "dactivate" to "deactivate" in config.adoc

## Checklist

- Add documentation to docs/config.adoc
  - [X] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [X] N/A
- Update error messages
  - [X] N/A
- Added tests, or did manual testing
  - [X] N/A
