### PR TITLE
Correct typo in config.adoc

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2536,8 +2536,10 @@ rather than all modifiers.
 
 **Reference**
 
-The fork action allows choosing between a default and an alternate action
-based on whether specific keys are active.
+The `fork` action allows choosing between a default and an alternate action
+based on whether specific keys are active. `fork` is the equivalent of the 
+basic key checks in `switch`, using none of the list logic items, i.e. virtual 
+keys are not supported.
 
 .Syntax:
 [source]

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2515,7 +2515,7 @@ states to be tracked correctly.
 )
 ----
 
-An list may optionally be used as the first parameter of `unmod`.
+A list may optionally be used as the first parameter of `unmod`.
 The list must be non-empty and must contain only modifier keys,
 which are the keys in the affected modifiers list from earlier in this document section.
 

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2464,7 +2464,7 @@ otherwise `caps-word` will be activate as normal.
 
 **Reference**
 
-The `unmod` action will dactivate modifier keys while outputting
+The `unmod` action will deactivate modifier keys while outputting
 one or more defined keys.
 
 .Syntax:


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Change typo 'An list' to 'A list'

## Checklist

- Add documentation to docs/config.adoc
  - [X] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [X] Yes or N/A
- Update error messages
  - [X] Yes or N/A
- Added tests, or did manual testing
  - [X] Yes
