### PR TITLE
Correct typos for `tap-hold-*` in config.adoc

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1907,26 +1907,26 @@ results in `$tap-action` activating.
 
 [cols="1,2"]
 |===
-| `$tap-hold-press`
+| `tap-hold-press`
 | Activate `$hold-action` early if held and another input key is pressed.
 
-| `$tap-hold-release`
+| `tap-hold-release`
 | Activate `$hold-action` early if held and another input key is pressed and released.
 
-| `$tap-hold-press-timeout`
+| `tap-hold-press-timeout`
 | Activate `$hold-action` if held and another input key is pressed.
 If the defined timeout elapses, `$timeout-action` will activate.
 
-| `$tap-hold-release-timeout`
+| `tap-hold-release-timeout`
 | Activate `$hold-action` early if held and another input key is pressed and released.
 If the defined timeout elapses, `$timeout-action` will activate.
 
-| `$tap-hold-release-keys`
+| `tap-hold-release-keys`
 | Activate `$hold-action` early if held and another input key is pressed and released.
 The `$tap-keys` parameter is a list of key names.
 Activates `$tap-action` early if a key within `$tap-keys` is pressed before hold activates.
 
-| `$tap-hold-except-keys`
+| `tap-hold-except-keys`
 | The `$tap-keys` parameter is a list of key names.
 Activates $tap-action if a key within $tap-keys is pressed
 or if the action key is released before hold timeout.


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Change `tap-hold-*` actions from variables in the table to actions. 

Also, change behaviour (British) to behavior (American) to remove the various spell checks' red underlines including Grammarly. Perhaps not that important.

## Checklist

- Add documentation to docs/config.adoc
  - [X] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [X] Yes or N/A
- Update error messages
  - [X] Yes or N/A
- Added tests, or did manual testing
  - [X] Yes
