### PR TITLE
Recommend high priority for Linux

### DIFF
--- a/docs/setup-linux.md
+++ b/docs/setup-linux.md
@@ -64,7 +64,10 @@ Documentation=https://github.com/jtroo/kanata
 
 [Service]
 Environment=PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin
-Environment=DISPLAY=:0
+CPUSchedulingPolicy=rr
+CPUSchedulingPriority=99
+IOSchedulingClass=realtime
+Nice=-20
 Type=simple
 ExecStart=/usr/bin/sh -c 'exec $$(which kanata) --cfg $${HOME}/.config/kanata/config.kbd'
 Restart=no


### PR DESCRIPTION
This change recommends using a higher
(in fact, the highest) CPU and IO priority
to the kanata process.

While this is not such an obvious default
due to the mouse being by default captured by kanata, the change still makes sense as keyboard input
is likely seen as a real-time priority for kanata users.

Additionally, I've removed the DISPLAY environment variable from the service. It's not needed.
Kanata works entirely outside of Xorg.
Nor does it have a GUI that would need to be shown.

## Describe your changes. Use imperative present tense.

## Checklist

- Add documentation to docs/config.adoc
  - [N/A] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [N/A] Yes or N/A
- Update error messages
  - [N/A] Yes or N/A
- Added tests, or did manual testing
  - [Yes] Yes  (I did a manual testing. It's what I'm using locally.)