### PR TITLE
fix: add lsp hints for vkeys in switch

### DIFF
--- a/parser/src/cfg/fake_key.rs
+++ b/parser/src/cfg/fake_key.rs
@@ -179,7 +179,7 @@ fn parse_delay(
         })))))
 }
 
-fn parse_vkey_coord(param: &SExpr, s: &ParserState) -> Result<Coord> {
+pub(crate) fn parse_vkey_coord(param: &SExpr, s: &ParserState) -> Result<Coord> {
     let name = param
         .atom(s.vars())
         .ok_or_else(|| anyhow_expr!(param, "key-name must not be a list",))?;

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -425,7 +425,7 @@ pub struct IntermediateCfg {
 }
 
 // A snapshot of enviroment variables, or an error message with an explanation
-// why env vars are not not supported.
+// why env vars are not supported.
 pub type EnvVars = std::result::Result<Vec<(String, String)>, String>;
 
 #[allow(clippy::type_complexity)] // return type is not pub

--- a/parser/src/cfg/switch.rs
+++ b/parser/src/cfg/switch.rs
@@ -160,21 +160,17 @@ pub fn parse_switch_case_bool(
                     "fake" | "virtual" => InputType::Virtual,
                     _ => bail_expr!(op_expr, "key-type must be virtual|real"),
                 };
-                let input = l[2]
-                    .atom(s.vars())
-                    .ok_or_else(|| anyhow_expr!(&l[2], "input key name must not be a list"))?;
                 let input = match input_type {
-                    InputType::Real => u16::from(
-                        str_to_oscode(input)
-                            .ok_or_else(|| anyhow_expr!(&l[2], "invalid input key name"))?,
-                    ),
-                    InputType::Virtual => {
-                        let vk = s.virtual_keys.get(input).ok_or_else(|| {
-                            anyhow_expr!(&l[2], "virtual key name is not defined")
+                    InputType::Real => {
+                        let key = l[2].atom(s.vars()).ok_or_else(|| {
+                            anyhow_expr!(&l[2], "input key name must not be a list")
                         })?;
-                        assert!(vk.0 < usize::from(KEY_MAX));
-                        vk.0 as u16
+                        u16::from(
+                            str_to_oscode(key)
+                                .ok_or_else(|| anyhow_expr!(&l[2], "invalid input key name"))?,
+                        )
                     }
+                    InputType::Virtual => parse_vkey_coord(&l[2], s)?.y,
                 };
                 let (op1, op2) = OpCode::new_active_input((input_type.to_row(), input));
                 ops.extend(&[op1, op2]);
@@ -193,21 +189,17 @@ pub fn parse_switch_case_bool(
                     "fake" | "virtual" => InputType::Virtual,
                     _ => bail_expr!(&l[1], "key-type must be virtual|real"),
                 };
-                let input = l[2]
-                    .atom(s.vars())
-                    .ok_or_else(|| anyhow_expr!(&l[2], "input key name must not be a list"))?;
                 let input = match input_type {
-                    InputType::Real => u16::from(
-                        str_to_oscode(input)
-                            .ok_or_else(|| anyhow_expr!(&l[2], "invalid input key name"))?,
-                    ),
-                    InputType::Virtual => {
-                        let vk = s.virtual_keys.get(input).ok_or_else(|| {
-                            anyhow_expr!(&l[2], "virtual key name is not defined")
+                    InputType::Real => {
+                        let key = l[2].atom(s.vars()).ok_or_else(|| {
+                            anyhow_expr!(&l[2], "input key name must not be a list")
                         })?;
-                        assert!(vk.0 < usize::from(KEY_MAX));
-                        vk.0 as u16
+                        u16::from(
+                            str_to_oscode(key)
+                                .ok_or_else(|| anyhow_expr!(&l[2], "invalid input key name"))?,
+                        )
                     }
+                    InputType::Virtual => parse_vkey_coord(&l[2], s)?.y,
                 };
                 let key_recency = parse_u8_with_range(&l[3], s, "key-recency", 1, 8)? - 1;
                 let (op1, op2) =


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

use `parse_vkey_coord` when parsing vkeys in switch because it internally calls `set_virtual_key_reference_lsp_hint` which we want to be called in order to add lsp hints for vkeys in switch.

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [ ] Yes
