### PR TITLE
doc: fix example 2 in the "Sequences" section of config.adoc

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -4400,8 +4400,8 @@ alongside templates to define sequences below.
 (deflayer base
         sldr nop0 nop1 nop2)
 (deftemplate seq (vk-name input-keys output-action)
-        sldr(defvirtualkeys $vk-name $output-action)
-        sldr(defseq $vk-name $input-keys)
+    (defvirtualkeys $vk-name $output-action)
+    (defseq $vk-name $input-keys)
 )
 ;; template-expand has a shortened form: t!
 (t! seq dotcom (nop0 nop1) (macro . c o m))


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Fix the second example config in the "Sequences" section of config.adoc. [kanata simulator link showing the original error](https://jtroo.github.io?data=BQEwpgZgzgTgxgAggdgWiAONSCc2ICMADAJQBQokANgIYCeYMCARjVGGdlwlFSEwDsA9gAciCYSIITRAJnKUIAFzABbEbRU8wARwTAAbgGsAtAJqqwCAJYCRAVyUmjYOlARDHDpzThLrQgLk3Ni8-IoG1jBK9jRULm4IACTGZhZWSZ5K3ia+-oHBITx8MIrseimm5pbJtjkJUOTkANzNCCrqmmAmYAAeIjQCIAgAFmwINDwjQtFgAmDDEDOqAFztAIQUSuvaeiBCSnBCqvqS4pIEJPqqvjBCCAB0CIj3qiQK27sI+0ozAOanUTnORXYA3OB3R4eBBMP7vAA+iKRyJR8JAKwAYqglCsMOJ7JjsSsACw4cTojFYHGkhAEyntFYAZkZqDIFLwOIAbKg6RyVshkABWb6EhkYRm00U4xlECVszFUkl4OmKxkYPAU4gM5mSjFanFkohEIA). Here is the [fixed version](https://jtroo.github.io?data=BQEwpgZgzgTgxgAggdgWiAONSCc2ICMADAJQBQokANgIYCeYMCARjVGGdlwlFSEwDsA9gAciCYSIITRAJnKUIAFzABbEbRU8wARwTAAbgGsAtAJqqwCAJYCRAVyUmjYOlARDHDpzThLrQgLkXIoG1jBK9jRULm4IACTGZhZW8Z5K3ia+-oHB2Irseomm5pYJtpmxUOTkANy1CCrqmmAmYAAeIjQCIAgAFmwINDx9QhFgAmC9EGOqAFyNAIQUSovaeiBCSnBCqvqS4pIEJPqqvjBCCAB0CIiXqiQKq+sIm0pjAOb7oodyJ8BnOAXa4eBBMD6PAA+0JhsLhkJAcwAYqglHMAMx4ezI1FzDDIACsr2RWDRGHRCGxSNJcwALEQiWREUi8GSKVTWXMCOjaahmbicFicY0MQyEEySSKAGy0ymStHIIhYZnEEXo2RypGqtE4Ih6oA).

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
