### PR TITLE
feat: `macos-dev-names-exclude`  config added and implemented

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,7 @@ dependencies = [
  "kanata-parser",
  "kanata-tcp-protocol",
  "karabiner-driverkit",
+ "libc",
  "log",
  "miette",
  "mio",
@@ -605,6 +606,7 @@ dependencies = [
  "objc",
  "once_cell",
  "open",
+ "os_pipe",
  "parking_lot",
  "radix_trie",
  "regex",
@@ -984,6 +986,16 @@ dependencies = [
  "log",
  "serde",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ karabiner-driverkit = "0.1.4"
 objc = "0.2.7"
 core-graphics = "0.24.0"
 open = { version = "5", optional = true }
+libc = "0.2"
+os_pipe = "1.2.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 signal-hook = "0.3.14"

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -3956,6 +3956,28 @@ Use `kanata -l` or `kanata --list` to list the available keyboards.
 )
 ----
 
+[[macos-only-macos-dev-names-exclude]]
+=== macOS only: macos-dev-names-exclude
+
+This option defines a list of device names that should be excluded.
+By default, kanata will try to detect which input devices are keyboards and try
+to intercept them all. However, you may specify certain keyboard devices to be ignored
+using the `macos-dev-names-exclude` configuration.
+Device names that do not exist in the list will be included.
+This option is parsed identically to `linux-dev`.
+
+Use `kanata -l` or `kanata --list` to list the available keyboards.
+
+.Example:
+[source]
+----
+(defcfg
+  macos-dev-names-exclude (
+    "Device name 1"
+    "Device name 2"
+  )
+)
+----
 [[windows-only-windows-altgr]]
 === Windows only: windows-altgr
 

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -61,6 +61,22 @@ pub enum LinuxCfgOutputBusType {
     BusI8042,
 }
 
+#[cfg(any(target_os = "macos", target_os = "unknown"))]
+#[derive(Debug, Clone)]
+pub struct CfgMacosOptions {
+    pub macos_dev_names_include: Option<Vec<String>>,
+    pub macos_dev_names_exclude: Option<Vec<String>>,
+}
+#[cfg(any(target_os = "macos", target_os = "unknown"))]
+impl Default for CfgMacosOptions {
+    fn default() -> Self {
+        Self {
+            macos_dev_names_include: None,
+            macos_dev_names_exclude: None,
+        }
+    }
+}
+
 #[cfg(any(
     all(feature = "interception_driver", target_os = "windows"),
     target_os = "unknown"
@@ -140,6 +156,8 @@ pub struct CfgOptions {
     pub chords_v2_min_idle: u16,
     #[cfg(any(target_os = "linux", target_os = "unknown"))]
     pub linux_opts: CfgLinuxOptions,
+    #[cfg(any(target_os = "macos", target_os = "unknown"))]
+    pub macos_opts: CfgMacosOptions,
     #[cfg(any(target_os = "windows", target_os = "unknown"))]
     pub windows_altgr: AltGrBehaviour,
     #[cfg(any(
@@ -147,8 +165,6 @@ pub struct CfgOptions {
         target_os = "unknown"
     ))]
     pub wintercept_opts: CfgWinterceptOptions,
-    #[cfg(any(target_os = "macos", target_os = "unknown"))]
-    pub macos_dev_names_include: Option<Vec<String>>,
     #[cfg(all(any(target_os = "windows", target_os = "unknown"), feature = "gui"))]
     pub gui_opts: CfgOptionsGui,
 }
@@ -187,7 +203,7 @@ impl Default for CfgOptions {
             ))]
             wintercept_opts: Default::default(),
             #[cfg(any(target_os = "macos", target_os = "unknown"))]
-            macos_dev_names_include: None,
+            macos_opts: Default::default(),
             #[cfg(all(any(target_os = "windows", target_os = "unknown"), feature = "gui"))]
             gui_opts: Default::default(),
         }
@@ -550,7 +566,13 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                             if dev_names.is_empty() {
                                 log::warn!("macos-dev-names-include is empty");
                             }
-                            cfg.macos_dev_names_include = Some(dev_names);
+                            cfg.macos_opts.macos_dev_names_include = Some(dev_names);
+                        }
+                    }
+                    "macos-dev-names-exclude" => {
+                        #[cfg(any(target_os = "macos", target_os = "unknown"))]
+                        {
+                            cfg.macos_opts.macos_dev_names_exclude = Some(parse_dev(val)?);
                         }
                     }
                     "tray-icon" => {

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -62,19 +62,10 @@ pub enum LinuxCfgOutputBusType {
 }
 
 #[cfg(any(target_os = "macos", target_os = "unknown"))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct CfgMacosOptions {
     pub macos_dev_names_include: Option<Vec<String>>,
     pub macos_dev_names_exclude: Option<Vec<String>>,
-}
-#[cfg(any(target_os = "macos", target_os = "unknown"))]
-impl Default for CfgMacosOptions {
-    fn default() -> Self {
-        Self {
-            macos_dev_names_include: None,
-            macos_dev_names_exclude: None,
-        }
-    }
 }
 
 #[cfg(any(

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -572,7 +572,11 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                     "macos-dev-names-exclude" => {
                         #[cfg(any(target_os = "macos", target_os = "unknown"))]
                         {
-                            cfg.macos_opts.macos_dev_names_exclude = Some(parse_dev(val)?);
+                            let dev_names = parse_dev(val)?;
+                            if dev_names.is_empty() {
+                                log::warn!("macos-dev-names-exclude is empty");
+                            }
+                            cfg.macos_opts.macos_dev_names_exclude = Some(dev_names);
                         }
                     }
                     "tray-icon" => {

--- a/src/kanata/macos.rs
+++ b/src/kanata/macos.rs
@@ -16,7 +16,7 @@ impl Kanata {
 
         let k = kanata.lock();
         let allow_hardware_repeat = k.allow_hardware_repeat;
-        let mut kb = match KbdIn::new(k.include_names.clone()) {
+        let mut kb = match KbdIn::new(k.include_names.clone(), k.exclude_names.clone()) {
             Ok(kbd_in) => kbd_in,
             Err(e) => bail!("failed to open keyboard device(s): {}", e),
         };

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -157,7 +157,7 @@ pub struct Kanata {
     /// included for interception and processing by kanata.
     pub include_names: Option<Vec<String>>,
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    /// Tracks the Linux user configuration for device names (instead of paths) that should be
+    /// Tracks the Linux/Macos user configuration for device names (instead of paths) that should be
     /// excluded for interception and processing by kanata.
     pub exclude_names: Option<Vec<String>>,
     #[cfg(all(feature = "interception_driver", target_os = "windows"))]

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -156,7 +156,7 @@ pub struct Kanata {
     /// Tracks the Linux/Macos user configuration for device names (instead of paths) that should be
     /// included for interception and processing by kanata.
     pub include_names: Option<Vec<String>>,
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     /// Tracks the Linux user configuration for device names (instead of paths) that should be
     /// excluded for interception and processing by kanata.
     pub exclude_names: Option<Vec<String>>,
@@ -367,7 +367,9 @@ impl Kanata {
             overrides: cfg.overrides,
             override_states: OverrideStates::new(),
             #[cfg(target_os = "macos")]
-            include_names: cfg.options.macos_dev_names_include,
+            include_names: cfg.options.macos_opts.macos_dev_names_include,
+            #[cfg(target_os = "macos")]
+            exclude_names: cfg.options.macos_opts.macos_dev_names_exclude,
             #[cfg(target_os = "linux")]
             kbd_in_paths: cfg.options.linux_opts.linux_dev,
             #[cfg(target_os = "linux")]
@@ -498,7 +500,9 @@ impl Kanata {
             overrides: cfg.overrides,
             override_states: OverrideStates::new(),
             #[cfg(target_os = "macos")]
-            include_names: cfg.options.macos_dev_names_include,
+            include_names: cfg.options.macos_opts.macos_dev_names_include,
+            #[cfg(target_os = "macos")]
+            exclude_names: cfg.options.macos_opts.macos_dev_names_exclude,
             #[cfg(target_os = "linux")]
             kbd_in_paths: cfg.options.linux_opts.linux_dev,
             #[cfg(target_os = "linux")]

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -78,7 +78,7 @@ where
         libc::dup2(writer.as_raw_fd(), stdout_fd);
     }
 
-    // Close the writer in the parent thread after redirecting
+    // Close `writer` to prevent `read_to_string` deadlock: https://docs.rs/os_pipe/latest/os_pipe/#common-deadlocks-related-to-pipes
     drop(writer);
 
     // Run the provided function

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -111,7 +111,7 @@ impl KbdIn {
             validate_and_register_devices(names)
         } else if let Some(names) = exclude_names {
             // TODO: filter include_names when both exclude_names and include_names are present
-            let kb_list = capture_stdout(|| list_keyboards());
+            let kb_list = capture_stdout(list_keyboards);
             let names_: Vec<String> = kb_list
                 .split("\n")
                 .filter(|kb| !kb.is_empty() && !names.contains(&kb.to_string()))

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -16,14 +16,14 @@ use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 use kanata_parser::custom_action::*;
 use kanata_parser::keys::*;
 use karabiner_driverkit::*;
+use libc;
 use objc::runtime::Class;
 use objc::{msg_send, sel, sel_impl};
+use os_pipe::pipe;
 use std::convert::TryFrom;
 use std::fmt;
 use std::io;
 use std::io::{Error, ErrorKind};
-use os_pipe::pipe;
-use libc;
 use std::io::{Read, Write};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::{Arc, Mutex};
@@ -127,13 +127,13 @@ impl KbdIn {
         } else if let Some(names) = exclude_names {
             // TODO: filter include_names when both exclude_names and include_names are present
             let kb_list = capture_stdout(|| list_keyboards());
-            let names_: Vec<String> = kb_list.split("\n")
-                                   .filter(|kb| !kb.is_empty() && !names.contains(&kb.to_string()))
-                                   .map(|kb| kb.to_string())
-                                   .collect();
+            let names_: Vec<String> = kb_list
+                .split("\n")
+                .filter(|kb| !kb.is_empty() && !names.contains(&kb.to_string()))
+                .map(|kb| kb.to_string())
+                .collect();
             validate_and_register_devices(names_)
-        }
-        else {
+        } else {
             vec![]
         };
 

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -23,11 +23,9 @@ use os_pipe::pipe;
 use std::convert::TryFrom;
 use std::fmt;
 use std::io;
+use std::io::Read;
 use std::io::{Error, ErrorKind};
-use std::io::{Read, Write};
-use std::os::unix::io::{AsRawFd, RawFd};
-use std::sync::{Arc, Mutex};
-use std::thread;
+use std::os::unix::io::AsRawFd;
 
 #[derive(Debug, Clone, Copy)]
 pub struct InputEvent {


### PR DESCRIPTION
Hi,

This PR implements `macos-dev-names-exclude` config by reading output from stdout as karabiner driver does to return the keyboard list. This partially addresses https://github.com/jtroo/kanata/issues/1033.

This currently does have one limitation: if `macos-dev-names-include` is provided then it takes precedence over `macos-dev-names-exclude`. We can use their set difference if so desired.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
