### PR TITLE
fix(linux): limit event reading

### DIFF
--- a/src/kanata/linux.rs
+++ b/src/kanata/linux.rs
@@ -41,7 +41,7 @@ impl Kanata {
 
         loop {
             let events = kbd_in.read().map_err(|e| anyhow!("failed read: {}", e))?;
-            log::trace!("{events:?}");
+            log::trace!("event count: {}\nevents:\n{events:?}", events.len());
 
             for in_event in events.iter().copied() {
                 let key_event = match KeyEvent::try_from(in_event) {

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -144,13 +144,16 @@ impl KbdIn {
                 return Ok(vec![]);
             }
 
+            const EVENT_LIMIT: usize = 48;
+
             let mut do_rediscover = false;
             for event in &self.events {
                 if let Some((device, _)) = self.devices.get_mut(&event.token()) {
-                    if let Err(e) = device
-                        .fetch_events()
-                        .map(|evs| evs.into_iter().for_each(|ev| input_events.push(ev)))
-                    {
+                    if let Err(e) = device.fetch_events().map(|evs| {
+                        evs.into_iter()
+                            .take(EVENT_LIMIT)
+                            .for_each(|ev| input_events.push(ev))
+                    }) {
                         // Currently the kind() is uncategorized... not helpful, need to match
                         // on os error. code 19 is ENODEV, "no such device".
                         match e.raw_os_error() {


### PR DESCRIPTION
Fix infinite memory growth when a device has an endless event stream.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
