### PR TITLE
feat(macOS): add missing macos fn row keys

### DIFF
--- a/parser/src/keys/macos.rs
+++ b/parser/src/keys/macos.rs
@@ -625,6 +625,26 @@ impl TryFrom<OsCode> for PageCode {
                 page: 0xFF,
                 code: 0x01,
             }),
+            OsCode::KEY_249 => Ok(PageCode {
+                page: 0x0C,
+                code: 0x221,
+            }),
+            OsCode::KEY_250 => Ok(PageCode {
+                page: 0x0C,
+                code: 0xCF,
+            }),
+            OsCode::KEY_251 => Ok(PageCode {
+                page: 0x01,
+                code: 0x9B,
+            }),
+            OsCode::KEY_252 => Ok(PageCode {
+                page: 0x0C,
+                code: 0x29F,
+            }),
+            OsCode::KEY_253 => Ok(PageCode {
+                page: 0x0C,
+                code: 0x2A0,
+            }),
             // OsCode::KEY_FN_ESC          => 0x07,
             // OsCode::KEY_FN_F1           => 0x07,
             // OsCode::KEY_FN_F2           => 0x07,
@@ -1255,6 +1275,27 @@ impl TryFrom<PageCode> for OsCode {
                 page: 0xFF,
                 code: 0x01,
             } => Ok(OsCode::KEY_SEARCH),
+            PageCode {
+                page: 0x0C,
+                code: 0x221,
+            } => Ok(OsCode::KEY_249),
+            PageCode {
+                page: 0x0C,
+                code: 0xCF,
+            } => Ok(OsCode::KEY_250),
+            PageCode {
+                // not working
+                page: 0x01,
+                code: 0x9B,
+            } => Ok(OsCode::KEY_251),
+            PageCode {
+                page: 0x0C,
+                code: 0x29F,
+            } => Ok(OsCode::KEY_252),
+            PageCode {
+                page: 0x0C,
+                code: 0x2A0,
+            } => Ok(OsCode::KEY_253),
             _ => Err("PageCode unrecognized!"),
         }
     }

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -355,6 +355,12 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         #[cfg(any(target_os = "linux", target_os = "unknown"))]
         "zzz" | "sleep" => OsCode::KEY_SLEEP,
 
+        "sls" | "SpotLightSearch" => OsCode::KEY_249,
+        "dtn" | "Dictation" => OsCode::KEY_250,
+        "dnd" | "DoNotDisturb" => OsCode::KEY_251,
+        "mctl" | "MissionControl" => OsCode::KEY_252,
+        "lpad" | "LaunchPad" => OsCode::KEY_253,
+        
         // Keys that behave as no-ops but can be used in sequences.
         // Also see: POTENTIAL PROBLEM - G-keys
         "nop0" => OsCode::KEY_676,


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add the missing key codes for the fn row key on mac.

More specifically:

* mission control
* spot light search
* dictation
* launch pad
* do not disturb — unfortunately this one is not yet working

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
