### PR TITLE
fix(tcp): do not skip layer names

### DIFF
--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -127,8 +127,6 @@ impl TcpServer {
                                                         .lock()
                                                         .layer_info
                                                         .iter()
-                                                        .step_by(2) // skip every other name,
-                                                        // which is a duplicate
                                                         .map(|info| info.name.clone())
                                                         .collect::<Vec<_>>(),
                                                 };


### PR DESCRIPTION
The step_by call was originally done because there used to be two versions of the same layer; one which was the target of `layer-switch` and the other which was the target of `layer-while-held`. This has since been changed and there is only one version of each layer now, so the step_by needs to be removed now.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
