### PR TITLE
locales.adoc: adding 100% keyboard defsrc, event.code only

### DIFF
--- a/docs/locales.adoc
+++ b/docs/locales.adoc
@@ -21,6 +21,24 @@ Commented out since doc is short enough without a ToC for the time being.
 :toclevels: 3
 ////
 
+== ISO 100% Keyboard (event.code)
+
+NOTE: Tested on Linux only
+
+[%collapsible]
+====
+----
+(defsrc
+  Escape                   F1      F2     F3     F4         F5     F6     F7     F8             F9         F10            F11  F12      PrintScreen  ScrollLock  Pause
+  Backquote        Digit1 Digit2 Digit3 Digit4 Digit5 Digit6 Digit7 Digit8 Digit9 Digit0       Minus       Equal         Backspace      Insert       Home        PageUp        NumLock NumpadDivide NumpadMultiply NumpadSubtract
+  Tab                   KeyQ   KeyW   KeyE   KeyR   KeyT   KeyY   KeyU   KeyI   KeyO    KeyP       BracketLeft BracketRight  Enter      Delete       End         PageDown      Numpad7 Numpad8      Numpad9        NumpadAdd
+  CapsLock              KeyA   KeyS   KeyD   KeyF   KeyG   KeyH   KeyJ   KeyK   KeyL   Semicolon     Quote      Backslash                                                      Numpad4 Numpad5      Numpad6
+  ShiftLeft IntlBackslash  KeyZ   KeyX   KeyC   KeyV   KeyB   KeyN   KeyM   Comma  Period       Slash                   ShiftRight                   ArrowUp                   Numpad3 Numpad2      Numpad1        NumpadEnter
+  ControlLeft       MetaLeft AltLeft                   Space                   AltRight       MetaRight   ContextMenu ControlRight      ArrowLeft    ArrowDown   ArrowRight    Numpad0              NumpadDecimal  
+)
+----
+====
+
 == ISO German QWERTZ (Windows, non-interception)[[german]]
 
 === Using `deflocalkeys-win`:[[german-defwin]]


### PR DESCRIPTION
Adding a defsrc example to locales.adoc. example is a 100% keyboard, uses only event.code. works on my arch linux installation.