### PR TITLE
fix: unicode on macos print nul byte

### DIFF
--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -226,9 +226,11 @@ impl KbdOut {
 
     pub fn send_unicode(&mut self, c: char) -> Result<(), io::Error> {
         let event = Self::make_event()?;
-        let mut arr: [u16; 2] = [0; 2];
-        c.encode_utf16(&mut arr);
-        event.set_string_from_utf16_unchecked(&arr);
+        let mut arr = [0u16; 2];
+        // Capture the slice containing the encoded UTF-16 code units.
+        let encoded = c.encode_utf16(&mut arr);
+        // Pass only the part of the array that was populated.
+        event.set_string_from_utf16_unchecked(encoded);
         event.set_type(CGEventType::KeyDown);
         event.post(CGEventTapLocation::AnnotatedSession);
         event.set_type(CGEventType::KeyUp);

--- a/src/tests/sim_tests/unicode_sim_tests.rs
+++ b/src/tests/sim_tests/unicode_sim_tests.rs
@@ -19,3 +19,20 @@ fn special_nop_keys() {
     .no_time();
     assert_eq!(r#"outU:( outU:) outU:" outU:( outU:)"#, result);
 }
+
+#[test]
+#[cfg(target_os = "macos")]
+fn macos_unicode_handling() {
+    let result = simulate(
+        r##"
+         (defcfg)
+         (defsrc a)
+         (deflayer base
+             (unicode "🎉")  ;; Test with an emoji that uses multi-unit UTF-16
+         )
+        "##,
+        "d:a t:100",
+    )
+    .no_time();
+    assert_eq!("outU:🎉", result);
+}


### PR DESCRIPTION
## Related issues
https://github.com/jtroo/kanata/issues/1546

## Description

Avoid sending trailing NUL byte in Unicode events

Previously, a fixed two-element array was used regardless of the actual
number of UTF-16 code units, causing an extra NUL byte to be passed to VSCode
when inserting Unicode characters. This change uses the slice returned by
`encode_utf16` to ensure only the valid code units are sent.

I have zero experience on rust but it fixed the issue

## Checklist

- Add documentation to docs/config.adoc
  - [] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [ ] Yes
