### PR TITLE
Linux key press debounce setting

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -149,6 +149,11 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;;   linux-output-device-bus-type USB
   ;;   linux-output-device-bus-type I8042
 
+  ;; On Linux, it is possible to configure the debounce duration for key press events in milliseconds.
+  ;; This is useful in the case of keyboard 'chatter' or 'double taps' due to faulty hardware.
+  ;; Example: Set debounce duration to 50ms.
+  ;;   linux-debounce-duration 50
+
   ;; There is an optional configuration entry for Windows to help mitigate strange
   ;; behaviour of AltGr if your layout uses that. Uncomment one of the items below
   ;; to change what kanata does with the key.

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -4066,6 +4066,24 @@ Thus the output bus type is configurable.
 )
 ----
 
+[[linux-only-linux-debounce-duration]]
+=== Linux only: linux-debounce-duration
+
+This option allows you to configure the debounce duration for key press events in milliseconds.
+Debouncing prevents rapid repeated key presses from being processed too quickly.
+This can be handy in the case of 'chatter' or 'double taps',
+where a single press of the keyboard results in multiple key press events because of faulty hardware.
+
+This option only limits the key press events. All other events are not debounced and passed through immediately.
+
+.Example:
+[source]
+----
+(defcfg
+  linux-debounce-duration 50 ;; Set debounce duration to 50ms
+)
+----
+
 [[macos-only-macos-dev-names-include]]
 === macOS only: macos-dev-names-include
 

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -34,6 +34,7 @@ pub struct CfgLinuxOptions {
     pub linux_use_trackpoint_property: bool,
     pub linux_output_bus_type: LinuxCfgOutputBusType,
     pub linux_device_detect_mode: Option<DeviceDetectMode>,
+    pub linux_debounce_duration_ms: u64,
 }
 #[cfg(any(target_os = "linux", target_os = "unknown"))]
 impl Default for CfgLinuxOptions {
@@ -51,6 +52,7 @@ impl Default for CfgLinuxOptions {
             linux_use_trackpoint_property: false,
             linux_output_bus_type: LinuxCfgOutputBusType::BusI8042,
             linux_device_detect_mode: None,
+            linux_debounce_duration_ms: 0,
         }
     }
 }
@@ -379,6 +381,13 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                                 _ => unreachable!("validated earlier"),
                             });
                             cfg.linux_opts.linux_device_detect_mode = detect_mode;
+                        }
+                    }
+                    "linux-debounce-duration" => {
+                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+                        {
+                            cfg.linux_opts.linux_debounce_duration_ms =
+                                parse_cfg_val_u64(val, label)?;
                         }
                     }
                     "windows-altgr" => {
@@ -915,6 +924,19 @@ pub fn parse_dev(val: &SExpr) -> Result<Vec<String>> {
             r?
         }
     })
+}
+
+fn parse_cfg_val_u64(expr: &SExpr, label: &str) -> Result<u64> {
+    match &expr {
+        SExpr::Atom(v) => Ok(str::parse::<u64>(v.t.trim_atom_quotes())
+            .map_err(|_| anyhow_expr!(expr, "{label} must be 0-18446744073709551615"))?),
+        SExpr::List(_) => {
+            bail_expr!(
+                expr,
+                "The value for {label} cannot be a list, it must be a number 0-18446744073709551615",
+            )
+        }
+    }
 }
 
 fn sexpr_to_str_or_err<'a>(expr: &'a SExpr, label: &str) -> Result<&'a str> {

--- a/src/kanata/linux.rs
+++ b/src/kanata/linux.rs
@@ -10,6 +10,8 @@ use parking_lot::Mutex;
 use std::convert::TryFrom;
 use std::sync::mpsc::SyncSender as Sender;
 use std::sync::Arc;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 use super::*;
 
@@ -18,7 +20,10 @@ impl Kanata {
     /// thread.
     pub fn event_loop(kanata: Arc<Mutex<Self>>, tx: Sender<KeyEvent>) -> Result<()> {
         info!("entering the event loop");
-
+    
+        let (preprocess_tx, preprocess_rx) = std::sync::mpsc::sync_channel(100);
+        start_event_preprocessor(preprocess_rx, tx);
+    
         let k = kanata.lock();
         let allow_hardware_repeat = k.allow_hardware_repeat;
         let mut kbd_in = match KbdIn::new(
@@ -84,8 +89,8 @@ impl Kanata {
                     };
                 }
 
-                // Send key events to the processing loop
-                if let Err(e) = tx.try_send(key_event) {
+                // Send key events to the preprocessing loop instead of directly to the processing loop
+                if let Err(e) = preprocess_tx.try_send(key_event) {
                     bail!("failed to send on channel: {}", e)
                 }
             }
@@ -190,5 +195,59 @@ fn handle_scroll(
             }
         }
         _ => unreachable!("expect to be handling a wheel event"),
+    }
+}
+
+fn start_event_preprocessor(preprocess_rx: Receiver<KeyEvent>, process_tx: Sender<KeyEvent>) {
+    let debounce_duration = Duration::from_millis(50); // Set debounce duration here
+    let mut last_key_event_time: HashMap<OsCode, Instant> = HashMap::new();
+
+    std::thread::spawn(move || {
+        loop {
+            match preprocess_rx.try_recv() {
+                Ok(kev) => {
+                    let now = Instant::now();
+                    let oscode = kev.code;
+
+                    match kev.value {
+                        KeyValue::Release => {
+                            // Always allow key releases to pass through
+                            try_send_panic(&process_tx, kev);
+                        }
+                        KeyValue::Press => {
+                            // Check if the key press is within the debounce duration
+                            if let Some(&last_time) = last_key_event_time.get(&oscode) {
+                                if now.duration_since(last_time) < debounce_duration {
+                                    log::debug!("Debounced key press: {:?}", kev);
+                                    continue; // Skip processing this event
+                                }
+                            }
+
+                            // Update the last processed time for the key press
+                            last_key_event_time.insert(oscode, now);
+
+                            // Forward the key press event
+                            try_send_panic(&process_tx, kev);
+                        }
+                        _ => {
+                            // Forward other key events (e.g., Repeat, Tap) without debouncing
+                            try_send_panic(&process_tx, kev);
+                        }
+                    }
+                }
+                Err(TryRecvError::Empty) => {
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                Err(TryRecvError::Disconnected) => {
+                    panic!("channel disconnected");
+                }
+            }
+        }
+    });
+}
+
+fn try_send_panic(tx: &Sender<KeyEvent>, kev: KeyEvent) {
+    if let Err(e) = tx.try_send(kev) {
+        panic!("failed to send on channel: {e:?}");
     }
 }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -242,6 +242,8 @@ pub struct Kanata {
     pub macro_on_press_cancel_duration: u32,
     /// Stores user's saved clipboard contents.
     pub saved_clipboard_content: SavedClipboardData,
+    #[cfg(target_os = "linux")]
+    pub linux_debounce_duration: u64,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -446,6 +448,8 @@ impl Kanata {
             allow_hardware_repeat: cfg.options.allow_hardware_repeat,
             macro_on_press_cancel_duration: 0,
             saved_clipboard_content: Default::default(),
+            #[cfg(target_os = "linux")]
+            linux_debounce_duration: cfg.options.linux_opts.linux_debounce_duration_ms,
         })
     }
 
@@ -582,6 +586,8 @@ impl Kanata {
             allow_hardware_repeat: cfg.options.allow_hardware_repeat,
             macro_on_press_cancel_duration: 0,
             saved_clipboard_content: Default::default(),
+            #[cfg(target_os = "linux")]
+            linux_debounce_duration: cfg.options.linux_opts.linux_debounce_duration_ms,
         })
     }
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Faulty or dirty keyboard hardware often results in 'chatter' or 'double taps'. Where a single physical press on the key results in multiple key press events in rapid succession.

This PR adds support for configuring a debounce duration on Linux to mitigate keyboard chatter or double taps.
Only key press events are debounced, other events are passed through.

Based on @jtroo 's comment from a while back, advising to create an event loop like in the Windows specific code:
https://github.com/jtroo/kanata/discussions/408

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [ ] N/A. Let me know if I need to add error messages.
- Added tests, or did manual testing
  - [x] Yes, manual testing on NixOS Linux.

This is my first work in rust ever, so please bear with me. Any feedback is welcome.