### PR TITLE
ci: Add windows x64 build action

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,33 @@
+name: windows-build
+
+on:
+  workflow_dispatch:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "persist-cross-job"
+      - name: Build x64
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          cargo build --release --target x86_64-pc-windows-msvc
+          move target\release\kanata.exe artifacts\kanata_windows_x64.exe
+          cargo build --release --features cmd --target x86_64-pc-windows-msvc
+          move target\release\kanata.exe artifacts\kanata_windows_cmd_allowed_x64.exe
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-binaries-x64
+          path: |
+            artifacts/kanata_windows_x64.exe
+            artifacts/kanata_windows_cmd_allowed_x64.exe


### PR DESCRIPTION
## Adds windows build action to github workflows

Closes #1599

## Checklist

- Add documentation to docs/config.adoc
  - [N/A ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ N/A] Yes or N/A
- Update error messages
  - [N/A ] Yes or N/A
- Added tests, or did manual testing
  - [Yes] Yes
