### PR TITLE
refactor: Renames references for tap-timeout to tap-repress-timeout

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -444,9 +444,9 @@ If you need help, please feel welcome to ask in the GitHub discussions.
 
 ;; defvar can be used to declare commonly-used values
 (defvar
-  tap-timeout   100
-  hold-timeout  200
-  tt $tap-timeout
+  tap-repress-timeout   100
+  hold-timeout          200
+  tt $tap-repress-timeout
   ht $hold-timeout
 
   ;; A list value in defvar that begins with concat behaves in a special manner
@@ -492,7 +492,7 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;; For full context, see https://github.com/jtroo/kanata/discussions/422
   ;;
   ;; tap-hold parameter order:
-  ;; 1. tap timeout
+  ;; 1. tap repress timeout
   ;; 2. hold timeout
   ;; 3. tap action
   ;; 4. hold action
@@ -500,11 +500,11 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;; The hold timeout is the number of milliseconds after which the hold action
   ;; will activate.
   ;;
-  ;; The tap timeout is best explained in a roundabout way. When you press and
+  ;; The tap repress timeout is best explained in a roundabout way. When you press and
   ;; hold a standard key on your keyboard (e.g. 'a'), your operating system will
   ;; read that and keep sending 'a' to the active application. To be able to
   ;; replicate this behaviour with a tap-hold key, you must press-release-press
-  ;; the key within the tap timeout window (number is milliseconds). Simply
+  ;; the key within the tap repress timeout window (number is milliseconds). Simply
   ;; holding the key results in the hold action activating, which is why you
   ;; need to double-press for the tap action to stay pressed.
   ;;

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -703,9 +703,9 @@ Variables are referred to by prefixing their name with `$`.
 [source]
 ----
 (defvar
-  tap-timeout   100
+  tap-repress-timeout   100
   hold-timeout  200
-  tt $tap-timeout
+  tt $tap-repress-timeout
   ht $hold-timeout
 )
 
@@ -1887,12 +1887,12 @@ depending it a key is tapped or held.
 .Syntax:
 [source]
 ----
-(tap-hold $tap-timeout $hold-timeout $tap-action $hold-action)
+(tap-hold $tap-repress-timeout $hold-timeout $tap-action $hold-action)
 ----
 
 [cols="1,4"]
 |===
-| `$tap-timeout`
+| `$tap-repress-timeout`
 | Number of milliseconds for the window that a tap into re-press with hold
 results in the `$tap-action` being held.
 
@@ -1910,12 +1910,12 @@ results in `$tap-action` activating.
 
 .Variants:
 ----
-(tap-hold-press $tap-timeout $hold-timeout $tap-action $hold-action)
-(tap-hold-release $tap-timeout $hold-timeout $tap-action $hold-action)
-(tap-hold-press-timeout $tap-timeout $hold-timeout $tap-action $hold-action $timeout-action)
-(tap-hold-release-timeout $tap-timeout $hold-timeout $tap-action $hold-action $timeout-action)
-(tap-hold-release-keys $tap-timeout $hold-timeout $tap-action $hold-action $tap-keys)
-(tap-hold-except-keys $tap-timeout $hold-timeout $tap-action $hold-action $tap-keys)
+(tap-hold-press $tap-repress-timeout $hold-timeout $tap-action $hold-action)
+(tap-hold-release $tap-repress-timeout $hold-timeout $tap-action $hold-action)
+(tap-hold-press-timeout $tap-repress-timeout $hold-timeout $tap-action $hold-action $timeout-action)
+(tap-hold-release-timeout $tap-repress-timeout $hold-timeout $tap-action $hold-action $timeout-action)
+(tap-hold-release-keys $tap-repress-timeout $hold-timeout $tap-action $hold-action $tap-keys)
+(tap-hold-except-keys $tap-repress-timeout $hold-timeout $tap-action $hold-action $tap-keys)
 ----
 
 [cols="1,2"]
@@ -1955,23 +1955,23 @@ key whereas a hold is a long press.
 
 The action takes 4 parameters in the listed order:
 
-. tap timeout (unit: ms)
+. tap repress timeout (unit: ms)
 . hold timeout (unit: ms)
 . tap action
 . hold action
 
-The tap timeout is the number of milliseconds within which a rapid
+The tap repress timeout is the number of milliseconds within which a rapid
 press+release+press of a key will result in the tap action being held instead
 of the hold action activating.
 
-.Tap timeout in more detail
+.Tap repress timeout in more detail
 [%collapsible,indent=4]
 ====
-The way a `tap-hold` action works with respect to the tap timeout
+The way a `tap-hold` action works with respect to the tap repress timeout
 is often unclear to newcomers.
 To make it concrete, the output event sequence of the `tap-hold` action
-`(tap-hold $tap-timeout 200 a lctl)`
-for varying values of `$tap-timeout`
+`(tap-hold $tap-repress-timeout 200 a lctl)`
+for varying values of `$tap-repress-timeout`
 with a fixed input event sequence will be described.
 
 The input event sequence is:
@@ -1984,7 +1984,7 @@ The input event sequence is:
 - 300 ms elapses
 - release
 
-With `(defvar $tap-timeout 0)`, the output event sequence is:
+With `(defvar $tap-repress-timeout 0)`, the output event sequence is:
 
 - 50 ms elapses
 - press `a`
@@ -1994,10 +1994,10 @@ With `(defvar $tap-timeout 0)`, the output event sequence is:
 - 100 ms elapses
 - release `lctl`
 
-The above output sequence is the same for all `$tap-timeout` values
+The above output sequence is the same for all `$tap-repress-timeout` values
 between and including `0` and `99`.
 
-For a value of `100` or greater for `$tap-timeout`,
+For a value of `100` or greater for `$tap-repress-timeout`,
 the output event sequence is instead:
 
 - 50 ms elapses

--- a/docs/simulated_output/sim.kbd
+++ b/docs/simulated_output/sim.kbd
@@ -3,10 +3,10 @@
   log-layer-changes    	yes	;;|no| overhead
 )
 (defvar ;; declare commonly-used values. prefix with $ to call them. They are refered with `$<var name>`
-  tap-timeout 	1000 ;;|500|
-  hold-timeout	1500 ;;|500|
-  🕐↕          	$tap-timeout
-  🕐🠿          	$hold-timeout
+  tap-repress-timeout 	1000 ;;|500|
+  hold-timeout	        1500 ;;|500|
+  🕐↕          	        $tap-repress-timeout
+  🕐🠿          	        $hold-timeout
 )
 (defalias
   ;; home row mods ↕tap 🠿hold

--- a/docs/simulated_passthru_ahk/kanata_dll.kbd
+++ b/docs/simulated_passthru_ahk/kanata_dll.kbd
@@ -5,7 +5,7 @@
 )
 
 (defvar
-  🕐↕	1000 ;;|500| tap-timeout
+  🕐↕	1000 ;;|500| tap-repress-timeout
   🕐🠿	1500 ;;|500| hold-timeout
   )
 (defalias	;;      timeout→ 	tap	  hold   ¦	 tap	 hold ←action

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -2121,7 +2121,7 @@ mod test {
     }
 
     #[test]
-    fn basic_hold_tap_timeout() {
+    fn basic_hold_tap_repress_timeout() {
         static LAYERS: Layers<2, 1> = &[
             [[
                 HoldTap(&HoldTapAction {

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1958,11 +1958,11 @@ fn parse_tap_hold(
         bail!(
             r"tap-hold expects 4 items after it, got {}.
 Params in order:
-<tap-timeout> <hold-timeout> <tap-action> <hold-action>",
+<tap-repress-timeout> <hold-timeout> <tap-action> <hold-action>",
             ac_params.len(),
         )
     }
-    let tap_timeout = parse_u16(&ac_params[0], s, "tap timeout")?;
+    let tap_repress_timeout = parse_u16(&ac_params[0], s, "tap repress timeout")?;
     let hold_timeout = parse_non_zero_u16(&ac_params[1], s, "hold timeout")?;
     let tap_action = parse_action(&ac_params[2], s)?;
     let hold_action = parse_action(&ac_params[3], s)?;
@@ -1971,7 +1971,7 @@ Params in order:
     }
     Ok(s.a.sref(Action::HoldTap(s.a.sref(HoldTapAction {
         config,
-        tap_hold_interval: tap_timeout,
+        tap_hold_interval: tap_repress_timeout,
         timeout: hold_timeout,
         tap: *tap_action,
         hold: *hold_action,
@@ -1988,11 +1988,11 @@ fn parse_tap_hold_timeout(
         bail!(
             r"tap-hold-(press|release)-timeout expects 5 items after it, got {}.
 Params in order:
-<tap-timeout> <hold-timeout> <tap-action> <hold-action> <timeout-action>",
+<tap-repress-timeout> <hold-timeout> <tap-action> <hold-action> <timeout-action>",
             ac_params.len(),
         )
     }
-    let tap_timeout = parse_u16(&ac_params[0], s, "tap timeout")?;
+    let tap_repress_timeout = parse_u16(&ac_params[0], s, "tap repress timeout")?;
     let hold_timeout = parse_non_zero_u16(&ac_params[1], s, "hold timeout")?;
     let tap_action = parse_action(&ac_params[2], s)?;
     let hold_action = parse_action(&ac_params[3], s)?;
@@ -2002,7 +2002,7 @@ Params in order:
     }
     Ok(s.a.sref(Action::HoldTap(s.a.sref(HoldTapAction {
         config,
-        tap_hold_interval: tap_timeout,
+        tap_hold_interval: tap_repress_timeout,
         timeout: hold_timeout,
         tap: *tap_action,
         hold: *hold_action,
@@ -2020,12 +2020,12 @@ fn parse_tap_hold_keys(
         bail!(
             r"tap-hold-{}-keys expects 5 items after it, got {}.
 Params in order:
-<tap-timeout> <hold-timeout> <tap-action> <hold-action> <tap-trigger-keys>",
+<tap-repress-timeout> <hold-timeout> <tap-action> <hold-action> <tap-trigger-keys>",
             custom_name,
             ac_params.len(),
         )
     }
-    let tap_timeout = parse_u16(&ac_params[0], s, "tap timeout")?;
+    let tap_repress_timeout = parse_u16(&ac_params[0], s, "tap repress timeout")?;
     let hold_timeout = parse_non_zero_u16(&ac_params[1], s, "hold timeout")?;
     let tap_action = parse_action(&ac_params[2], s)?;
     let hold_action = parse_action(&ac_params[3], s)?;
@@ -2035,7 +2035,7 @@ Params in order:
     }
     Ok(s.a.sref(Action::HoldTap(s.a.sref(HoldTapAction {
         config: HoldTapConfig::Custom(custom_func(&tap_trigger_keys, &s.a)),
-        tap_hold_interval: tap_timeout,
+        tap_hold_interval: tap_repress_timeout,
         timeout: hold_timeout,
         tap: *tap_action,
         hold: *hold_action,


### PR DESCRIPTION
## Changes instances of `tap-timeout` for `tap-repress-timeout`

Closes #1428

## Checklist

- Add documentation to docs/config.adoc
  - [N/A] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ N/A] Yes or N/A
- Update error messages
  - [ N/A] Yes or N/A
- Added tests, or did manual testing
  - [ N/A] Yes
