### PR TITLE
feature: add Lang1/Lang2 keys of Japanese Mac keyboard

### DIFF
--- a/cfg_samples/japanese_mac_eisu_kana.kbd
+++ b/cfg_samples/japanese_mac_eisu_kana.kbd
@@ -1,0 +1,27 @@
+#|
+  Using meta keys as japanese eisu and kana on Mac with US keyboard.
+
+  | Source  | Tap          | Hold |
+  | ------- | ------------ | ---- |
+  | lmet    | lang2 (eisu) | lmet |
+  | rmet    | lang1 (kana) | rmet |
+
+|#
+
+(defcfg
+  process-unmapped-keys yes
+)
+
+(defsrc
+  lmet  rmet
+)
+
+(deflayer default
+  @lmet @rmet
+)
+
+(defalias
+  lmet (tap-hold-press 200 200 eisu lmet)
+  rmet (tap-hold-press 200 200 kana rmet)
+)
+

--- a/parser/src/keys/macos.rs
+++ b/parser/src/keys/macos.rs
@@ -517,6 +517,14 @@ impl TryFrom<OsCode> for PageCode {
                 page: 0x07,
                 code: 0x85,
             }),
+            OsCode::KEY_HANGEUL => Ok(PageCode {
+                page: 0x07,
+                code: 0x90,
+            }),
+            OsCode::KEY_HANJA => Ok(PageCode {
+                page: 0x07,
+                code: 0x91,
+            }),
             OsCode::KEY_ALTERASE => Ok(PageCode {
                 page: 0x07,
                 code: 0x99,
@@ -1175,6 +1183,14 @@ impl TryFrom<PageCode> for OsCode {
                 page: 0x07,
                 code: 0x85,
             } => Ok(OsCode::KEY_KPCOMMA),
+            PageCode {
+                page: 0x07,
+                code: 0x90,
+            } => Ok(OsCode::KEY_HANGEUL),
+            PageCode {
+                page: 0x07,
+                code: 0x91,
+            } => Ok(OsCode::KEY_HANJA),
             PageCode {
                 page: 0x07,
                 code: 0x99,

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -324,6 +324,10 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "cnv" | "conv" | "henk" | "hnk" | "henkan" => OsCode::KEY_HENKAN,
         "ncnv" | "mhnk" | "muhenkan" => OsCode::KEY_MUHENKAN,
         "IntlRo" | "ro" => OsCode::KEY_RO,
+        #[cfg(any(target_os = "macos", target_os = "unknown"))]
+        "Lang1" | "kana" => OsCode::KEY_HANGEUL,
+        #[cfg(any(target_os = "macos", target_os = "unknown"))]
+        "Lang2" | "eisu" => OsCode::KEY_HANJA,
 
         #[cfg(any(target_os = "linux", target_os = "unknown"))]
         "PrintScreen" | "prtsc" | "prnt" | "⎙" => OsCode::KEY_SYSRQ,


### PR DESCRIPTION
- Lang1: Japanese Mac keyboard (kana)
- Lang2: Japanese Mac keyboard (eisu)

## Describe your changes. Use imperative present tense.

## Checklist

- Add documentation to docs/config.adoc
  - [N/A] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [Yes] Yes or N/A
- Update error messages
  - [N/A] Yes or N/A
- Added tests, or did manual testing
  - [Yes] Yes
