### PR TITLE
feat(linux): add virtual device output name configuration

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -139,6 +139,14 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;;
   ;;   linux-unicode-termination space
 
+  ;; Kanata on Linux creates an evdev output device named "kanata".
+  ;; This name can be changed with this linux-output-device-name.
+  ;;
+  ;; Examples:
+  ;;
+  ;;   linux-output-device-name kanata_laptop
+  ;;   linux-output-device-name "kanata output device"
+
   ;; Kanata on Linux needs to declare a "bus type" for its evdev output device.
   ;; The options are USB and I8042. The default is I8042.
   ;; Using USB can break disable-touchpad-while-typing on Wayland.

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -4110,6 +4110,20 @@ changing their behavior as well.
 )
 ----
 
+[[linux-only-linux-output-device-name]]
+=== Linux only: linux-output-device-name
+
+This option defines the name of the evdev output device.
+The default value is kanata.
+
+.Example:
+[source]
+----
+(defcfg
+   linux-output-device-name "kanata output"
+)
+----
+
 [[linux-only-linux-output-device-bus-type]]
 === Linux only: linux-output-device-bus-type
 

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -32,6 +32,7 @@ pub struct CfgLinuxOptions {
     pub linux_unicode_termination: UnicodeTermination,
     pub linux_x11_repeat_delay_rate: Option<KeyRepeatSettings>,
     pub linux_use_trackpoint_property: bool,
+    pub linux_output_name: String,
     pub linux_output_bus_type: LinuxCfgOutputBusType,
     pub linux_device_detect_mode: Option<DeviceDetectMode>,
 }
@@ -49,6 +50,7 @@ impl Default for CfgLinuxOptions {
             linux_unicode_termination: UnicodeTermination::Enter,
             linux_x11_repeat_delay_rate: None,
             linux_use_trackpoint_property: false,
+            linux_output_name: "kanata".to_owned(),
             linux_output_bus_type: LinuxCfgOutputBusType::BusI8042,
             linux_device_detect_mode: None,
         }
@@ -358,6 +360,17 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                         {
                             cfg.linux_opts.linux_use_trackpoint_property =
                                 parse_defcfg_val_bool(val, label)?
+                        }
+                    }
+                    "linux-output-device-name" => {
+                        #[cfg(any(target_os = "linux", target_os = "unknown"))]
+                        {
+                            let device_name = sexpr_to_str_or_err(val, label)?;
+                            if device_name.is_empty() {
+                                log::warn!("linux-output-device-name is empty, using kanata as default value");
+                            } else {
+                                cfg.linux_opts.linux_output_name = device_name.to_owned();
+                            }
                         }
                     }
                     "linux-output-device-bus-type" => {

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1400,6 +1400,7 @@ fn parse_all_defcfg() {
   linux-unicode-termination space
   linux-x11-repeat-delay-rate 400,50
   linux-use-trackpoint-property yes
+  linux-output-device-name "Kanata Test"
   linux-output-device-bus-type USB
   tray-icon symbols.ico
   icon-match-layer-name no

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -320,6 +320,8 @@ impl Kanata {
             #[cfg(target_os = "linux")]
             cfg.options.linux_opts.linux_use_trackpoint_property,
             #[cfg(target_os = "linux")]
+            &cfg.options.linux_opts.linux_output_name,
+            #[cfg(target_os = "linux")]
             match cfg.options.linux_opts.linux_output_bus_type {
                 LinuxCfgOutputBusType::BusUsb => evdev::BusType::BUS_USB,
                 LinuxCfgOutputBusType::BusI8042 => evdev::BusType::BUS_I8042,
@@ -483,6 +485,8 @@ impl Kanata {
             &None,
             #[cfg(target_os = "linux")]
             cfg.options.linux_opts.linux_use_trackpoint_property,
+            #[cfg(target_os = "linux")]
+            &cfg.options.linux_opts.linux_output_name,
             #[cfg(target_os = "linux")]
             match cfg.options.linux_opts.linux_output_bus_type {
                 LinuxCfgOutputBusType::BusUsb => evdev::BusType::BUS_USB,

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -377,6 +377,7 @@ impl KbdOut {
     pub fn new(
         symlink_path: &Option<String>,
         trackpoint: bool,
+        name: &str,
         bus_type: BusType,
     ) -> Result<Self, io::Error> {
         // Support pretty much every feature of a Keyboard or a Mouse in a VirtualDevice so that no event from the original input devices gets lost
@@ -400,7 +401,7 @@ impl KbdOut {
         ]);
 
         let device = uinput::VirtualDeviceBuilder::new()?
-            .name("kanata")
+            .name(&name)
             // libinput's "disable while typing" feature don't work when bus_type
             // is set to BUS_USB, but appears to work when it's set to BUS_I8042.
             .input_id(evdev::InputId::new(bus_type, 1, 1, 1))

--- a/src/oskbd/sim_passthru.rs
+++ b/src/oskbd/sim_passthru.rs
@@ -37,6 +37,7 @@ impl KbdOut {
     pub fn new(
         _s: &Option<String>,
         _tp: bool,
+        _name: &str,
         _bustype: evdev::BusType,
     ) -> Result<Self, io::Error> {
         Ok(Self { tx_kout: None })

--- a/src/oskbd/simulated.rs
+++ b/src/oskbd/simulated.rs
@@ -356,6 +356,7 @@ impl KbdOut {
     pub fn new(
         _s: &Option<String>,
         _tp: bool,
+        _name: &str,
         _bustype: evdev::BusType,
     ) -> Result<Self, io::Error> {
         Self::new_actual()


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Provide a configuration option to set the name of the virtual device on linux.

## Checklist

- Add documentation to docs/config.adoc
  - [X] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [X] Yes or N/A
- Update error messages
  - [X] Yes or N/A
- Added tests, or did manual testing
  - [X] Yes
