### PR TITLE
fix: delayed tap-hold release can now tap

### DIFF
--- a/src/tests/sim_tests/chord_sim_tests.rs
+++ b/src/tests/sim_tests/chord_sim_tests.rs
@@ -232,11 +232,11 @@ static CHORD_INTO_TAP_HOLD_CFG: &str = "\
 fn sim_chord_into_tap_hold() {
     let result = simulate(
         CHORD_INTO_TAP_HOLD_CFG,
-        "d:a t:50 d:b t:149 u:a u:b t:5 \
-         d:a t:50 d:b t:148 u:a u:b t:1000",
+        "d:a t:50 d:b t:150 u:a u:b t:5 \
+         d:a t:50 d:b t:149 u:a u:b t:1000",
     );
     assert_eq!(
-        "t:199ms\nout:↓Y\nt:10ms\nout:↑Y\nt:193ms\nout:↓X\nt:10ms\nout:↑X",
+        "t:199ms\nout:↓Y\nt:10ms\nout:↑Y\nt:195ms\nout:↓X\nt:10ms\nout:↑X",
         result
     );
 }

--- a/src/tests/sim_tests/mod.rs
+++ b/src/tests/sim_tests/mod.rs
@@ -24,6 +24,7 @@ mod release_sim_tests;
 mod repeat_sim_tests;
 mod seq_sim_tests;
 mod switch_sim_tests;
+mod tap_hold_tests;
 mod template_sim_tests;
 mod timing_tests;
 mod unicode_sim_tests;

--- a/src/tests/sim_tests/tap_hold_tests.rs
+++ b/src/tests/sim_tests/tap_hold_tests.rs
@@ -1,0 +1,18 @@
+use super::*;
+
+#[test]
+fn nested_template() {
+    let result = simulate(
+        "
+        (defcfg concurrent-tap-hold yes )
+        (defsrc a j )
+        (deflayer base @a @j)
+        (defalias
+         a (tap-hold 200 1000 a lctl)
+         j (tap-hold 200 500 j lsft))
+        ",
+        "d:a t:100 d:j t:10 u:j t:1100 u:a t:50",
+    )
+    .to_ascii();
+    assert_eq!("t:999ms dn:LCtrl t:2ms dn:J t:6ms up:J t:203ms up:LCtrl", result);
+}


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Fixes #1674 

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
