### PR TITLE
refactor: replace instant dep with web-time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
@@ -628,18 +628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "interception-sys"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,10 +707,11 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -740,7 +729,6 @@ dependencies = [
  "evdev",
  "indoc",
  "inotify",
- "instant",
  "kanata-interception",
  "kanata-keyberon",
  "kanata-parser",
@@ -767,6 +755,7 @@ dependencies = [
  "simplelog",
  "strip-ansi-escapes",
  "time",
+ "web-time",
  "winapi",
  "windows-sys 0.52.0",
 ]
@@ -1882,9 +1871,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1893,13 +1882,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1908,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1918,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1931,15 +1919,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
-name = "web-sys"
-version = "0.3.72"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ anyhow = "1"
 clap = { version = "4", features = [ "std", "derive", "help", "suggestions" ], default-features = false }
 dirs = "5.0.1"
 indoc = { version = "2.0.4", optional = true }
-instant = { version = "0.1.12", default-features = false }
 log = { version = "0.4.8", default-features = false }
 miette = { version = "5.7.0", features = ["fancy"] }
 once_cell = "1"
@@ -53,6 +52,7 @@ rustc-hash = "1.1.0"
 simplelog = "0.12.0"
 serde_json = { version = "1", features = ["std"], default-features = false, optional = true }
 time = "0.3.36"
+web-time = "1.1.0"
 
 kanata-keyberon = { path = "keyberon", version = "0.180.2" }
 kanata-parser =   { path = "parser", version = "0.180.2" }
@@ -128,7 +128,6 @@ interception_driver = ["kanata-interception", "kanata-parser/interception_driver
 simulated_output = ["indoc"]
 simulated_input = ["indoc"]
 passthru_ahk = ["simulated_input","simulated_output"]
-wasm = [ "instant/wasm-bindgen" ]
 gui = ["win_manifest","kanata-parser/gui",
   "win_sendinput_send_scancodes","win_llhook_read_scancodes",
   "muldiv","strip-ansi-escapes","open",

--- a/src/kanata/millisecond_counting.rs
+++ b/src/kanata/millisecond_counting.rs
@@ -1,12 +1,14 @@
+use web_time::Instant;
+
 pub struct MillisecondCountResult {
-    pub last_tick: instant::Instant,
+    pub last_tick: Instant,
     pub ms_elapsed: u128,
     pub ms_remainder_in_ns: u128,
 }
 
 pub fn count_ms_elapsed(
-    last_tick: instant::Instant,
-    now: instant::Instant,
+    last_tick: Instant,
+    now: Instant,
     prev_ms_remainder_in_ns: u128,
 ) -> MillisecondCountResult {
     const NS_IN_MS: u128 = 1_000_000;
@@ -29,7 +31,7 @@ pub fn count_ms_elapsed(
 #[test]
 fn ms_counts_0_elapsed_correctly() {
     use std::time::Duration;
-    let last_tick = instant::Instant::now();
+    let last_tick = Instant::now();
     let now = last_tick + Duration::from_nanos(999999);
     let result = count_ms_elapsed(last_tick, now, 0);
     assert_eq!(0, result.ms_elapsed);
@@ -40,7 +42,7 @@ fn ms_counts_0_elapsed_correctly() {
 #[test]
 fn ms_counts_1_elapsed_correctly() {
     use std::time::Duration;
-    let last_tick = instant::Instant::now();
+    let last_tick = Instant::now();
     let now = last_tick + Duration::from_nanos(1234567);
     let result = count_ms_elapsed(last_tick, now, 0);
     assert_eq!(1, result.ms_elapsed);
@@ -51,7 +53,7 @@ fn ms_counts_1_elapsed_correctly() {
 #[test]
 fn ms_counts_1_then_2_elapsed_correctly() {
     use std::time::Duration;
-    let last_tick = instant::Instant::now();
+    let last_tick = Instant::now();
     let now = last_tick + Duration::from_micros(1750);
     let result = count_ms_elapsed(last_tick, now, 0);
     assert_eq!(1, result.ms_elapsed);

--- a/src/tests/sim_tests/timing_tests.rs
+++ b/src/tests/sim_tests/timing_tests.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use crate::Kanata;
 
-use instant::Instant;
+use web_time::Instant;
 
 #[test]
 fn one_second_is_roughly_1000_counted_ticks() {


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

The instant crate is no longer maintained since a year. Its upstream author recommends [1] to switch to the web-time crate [2], which this commit does.

[1] https://github.com/sebcrozet/instant/commit/d94bebae9fa470869dda4c1c916ac3686c7bc9bd
[2] https://crates.io/crates/web-time

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] N/A
