### PR TITLE
Only test zippychord when feature is enabled

### DIFF
--- a/src/tests/sim_tests/mod.rs
+++ b/src/tests/sim_tests/mod.rs
@@ -30,6 +30,7 @@ mod unicode_sim_tests;
 mod unmod_sim_tests;
 mod use_defsrc_sim_tests;
 mod vkey_sim_tests;
+#[cfg(feature = "zippychord")]
 mod zippychord_sim_tests;
 
 fn simulate<S: AsRef<str>>(cfg: S, sim: S) -> String {


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

One can activate a specific set of features so that the zippychord_sim_tests test is run without the zippychord feature being enabled. This leads to a runtime error saying that the zippychord feature was not enabled when trying to run the tests with this specific feature set.

Add an additional cfg feature gate in front of the zippychord_sim_tests module to prevent this failure.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] N/A
