### PR TITLE
Fix typo in chord.rs

### DIFF
--- a/parser/src/cfg/chord.rs
+++ b/parser/src/cfg/chord.rs
@@ -83,7 +83,7 @@ pub(crate) fn parse_defchordv2(
         bail_expr!(
             rem.last().unwrap(),
             "Incomplete chord entry. Each chord entry must have 5 items:\n\
-        particpating-keys, action, timeout, release-type, disabled-layers"
+        participating-keys, action, timeout, release-type, disabled-layers"
         );
     }
     Ok(chords_container)


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
- Fix typo in error message in `parser/src/cfg/chord.rs`.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes

## Manual testing

### Setup
`~/test.cfg`:
```
(defsrc a)
(deflayer test a)

(defcfg
    process-unmapped-keys yes
)

(defchordsv2
  (a s)
)
```

### Before
```bash
$ cargo run -- -c ~/test.cfg
   Compiling kanata-parser v0.190.0 (/home/tarik/code/kanata/parser)
   Compiling kanata v1.9.0 (/home/tarik/code/kanata)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.57s
     Running `target/debug/kanata -c /home/tarik/test.cfg`
18:47:27.6827 [INFO] kanata v1.9.0 starting
18:47:27.6830 [INFO] process unmapped keys: true
18:47:27.6831 [INFO] NOTE: kanata was compiled to never allow cmd
18:47:27.6833 [ERROR]   × Error in configuration
    ╭─[/home/tarik/test.cfg:8:1]
  8 │ (defchordsv2
  9 │   (a s)
    ·   ──┬──
    ·     ╰── Error here
 10 │ )
    ╰────
  help: Incomplete chord entry. Each chord entry must have 5 items:
        particpating-keys, action, timeout, release-type, disabled-layers
        
        For more info, see the configuration guide:
        https://github.com/jtroo/kanata/blob/main/docs/config.adoc

18:47:27.6835 [ERROR] failed to parse file


Press enter to exit
```

### After
```bash
$ cargo run -- -c ~/test.cfg
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/kanata -c /home/tarik/test.cfg`
18:46:08.6256 [INFO] kanata v1.9.0 starting
18:46:08.6258 [INFO] process unmapped keys: true
18:46:08.6260 [INFO] NOTE: kanata was compiled to never allow cmd
18:46:08.6262 [ERROR]   × Error in configuration
    ╭─[/home/tarik/test.cfg:8:1]
  8 │ (defchordsv2
  9 │   (a s)
    ·   ──┬──
    ·     ╰── Error here
 10 │ )
    ╰────
  help: Incomplete chord entry. Each chord entry must have 5 items:
        participating-keys, action, timeout, release-type, disabled-layers
        
        For more info, see the configuration guide:
        https://github.com/jtroo/kanata/blob/main/docs/config.adoc

18:46:08.6264 [ERROR] failed to parse file


Press enter to exit
```