### PR TITLE
fix!(sequences): prioritize vkey tap of seq completion

### DIFF
--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -1581,6 +1581,21 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
             self.dequeue(overflow);
         }
     }
+
+    /// Put a key event at the front instead of back.
+    /// These events will not participate in chordsv2.
+    pub fn event_to_front(&mut self, event: Event) {
+        if let Event::Press(x, y) = event {
+            self.historical_inputs.push_front((x, y));
+        }
+        if let Some(overflow) = self.queue.push_front(event.into()) {
+            for i in -1..(EXTRA_WAITING_LEN as i8) {
+                self.waiting_into_hold(i);
+            }
+            self.dequeue(overflow);
+        }
+    }
+
     /// Resolve coordinate to first non-Trans actions.
     /// Trans on base layer, resolves to key from defsrc.
     fn resolve_coord(

--- a/src/kanata/sequences.rs
+++ b/src/kanata/sequences.rs
@@ -345,8 +345,8 @@ pub(super) fn do_successful_sequence_termination(
             _ => true,
         });
     }
-    layout.event(Event::Press(i, j));
-    layout.event(Event::Release(i, j));
+    layout.event_to_front(Event::Release(i, j));
+    layout.event_to_front(Event::Press(i, j));
     Ok(())
 }
 

--- a/src/tests/sim_tests/seq_sim_tests.rs
+++ b/src/tests/sim_tests/seq_sim_tests.rs
@@ -236,3 +236,29 @@ fn noerase() {
         result,
     );
 }
+
+#[test]
+fn tap_hold_pending() {
+    let result = simulate(
+        "
+(defalias md     (tap-hold 200 200 s S-s))
+(defsrc s d j)
+(deflayer base @md d sldr)
+(deffakekeys _u  (unicode μ))
+(defseq _u     (s))
+        ",
+        "
+d:KeyJ t:50 u:KeyJ t:50
+d:KeyS t:50 u:KeyS t:50 d:KeyD t:50 u:KeyD t:5000
+
+d:KeyJ t:50 u:KeyJ t:50
+d:KeyS t:50 d:KeyD t:50 u:KeyS t:50 u:KeyD t:5000",
+    )
+    .no_time()
+    .no_releases()
+    .to_ascii();
+    assert_eq!(
+        "outU:μ dn:D outU:μ dn:D",
+        result,
+    );
+}

--- a/src/tests/sim_tests/seq_sim_tests.rs
+++ b/src/tests/sim_tests/seq_sim_tests.rs
@@ -248,17 +248,14 @@ fn tap_hold_pending() {
 (defseq _u     (s))
         ",
         "
-d:KeyJ t:50 u:KeyJ t:50
-d:KeyS t:50 u:KeyS t:50 d:KeyD t:50 u:KeyD t:5000
+d:KeyJ t:10 u:KeyJ t:10
+d:KeyS t:10 u:KeyS t:10 d:KeyD t:10 u:KeyD t:10
 
-d:KeyJ t:50 u:KeyJ t:50
-d:KeyS t:50 d:KeyD t:50 u:KeyS t:50 u:KeyD t:5000",
+d:KeyJ t:10 u:KeyJ t:10
+d:KeyS t:10 d:KeyD t:10 u:KeyS t:10 u:KeyD t:10",
     )
     .no_time()
     .no_releases()
     .to_ascii();
-    assert_eq!(
-        "outU:μ dn:D outU:μ dn:D",
-        result,
-    );
+    assert_eq!("outU:μ dn:D outU:μ dn:D", result,);
 }


### PR DESCRIPTION
Potentially breaking fix as this changes output order. However, I suspect this will not break anyone and would be a strict improvement, so I opt not to make it configurable. If someone reports a break, can add the configurability later.

Closes #1701 

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
