### PR TITLE
feat: replace basic --watch with comprehensive include file support

### DIFF
--- a/src/file_watcher.rs
+++ b/src/file_watcher.rs
@@ -1,0 +1,163 @@
+//! File watching for configuration hot-reload.
+//!
+//! Replaces the basic file watcher with comprehensive support for include files
+//! and dynamic watcher restart when include files change during reload.
+
+#[cfg(feature = "watch")]
+pub mod watcher {
+    use crate::kanata::Kanata;
+    use anyhow::Result;
+    use notify_debouncer_mini::{
+        new_debouncer, notify::RecursiveMode, DebounceEventResult, DebouncedEventKind,
+    };
+    use parking_lot::Mutex;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// Discover include files by parsing config files for (include "path") statements.
+    /// This is a simple parser that looks for include statements without full parsing.
+    pub fn discover_include_files(cfg_paths: &[PathBuf]) -> Vec<PathBuf> {
+        let mut include_files = Vec::new();
+        
+        for cfg_path in cfg_paths {
+            if let Ok(content) = fs::read_to_string(cfg_path) {
+                // Simple regex-like parsing for include statements
+                for line in content.lines() {
+                    let trimmed = line.trim();
+                    if trimmed.starts_with("(include") && trimmed.contains('"') {
+                        // Extract the path between quotes
+                        if let Some(start) = trimmed.find('"') {
+                            if let Some(end) = trimmed[start + 1..].find('"') {
+                                let include_path = &trimmed[start + 1..start + 1 + end];
+                                let mut path = PathBuf::from(include_path);
+                                
+                                // If path is relative, make it relative to the config file directory
+                                if !path.is_absolute() {
+                                    if let Some(parent) = cfg_path.parent() {
+                                        path = parent.join(path);
+                                    }
+                                }
+                                
+                                if path.exists() {
+                                    include_files.push(path);
+                                    log::debug!("Discovered include file: {}", include_files.last().unwrap().display());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        include_files
+    }
+
+    /// Start comprehensive file watching for configuration files and included files.
+    /// This replaces the basic file watcher with full include file support and dynamic restart.
+    pub fn start_file_watcher(kanata_arc: Arc<Mutex<Kanata>>) -> Result<()> {
+        // Get paths from kanata
+        let cfg_paths = {
+            let k = kanata_arc.lock();
+            k.cfg_paths.clone()
+        };
+
+        // Discover include files and update kanata
+        let included_files = discover_include_files(&cfg_paths);
+        {
+            let mut k = kanata_arc.lock();
+            k.included_files = included_files.clone();
+        }
+
+        // Create the watcher and store it in the Kanata struct
+        let debouncer = create_debouncer(kanata_arc.clone(), &cfg_paths, &included_files)?;
+
+        // Store the debouncer in the Kanata struct
+        {
+            let mut k = kanata_arc.lock();
+            k.file_watcher = Some(debouncer);
+        }
+
+        Ok(())
+    }
+
+    /// Create a new file watcher debouncer with the given file lists.
+    /// This is used both for initial setup and for restarting the watcher when included files change.
+    pub fn create_debouncer(
+        kanata_arc: Arc<Mutex<Kanata>>,
+        cfg_paths: &[PathBuf],
+        included_files: &[PathBuf],
+    ) -> Result<notify_debouncer_mini::Debouncer<notify_debouncer_mini::notify::RecommendedWatcher>>
+    {
+        // Create list of all files to watch
+        let all_watched_files: Vec<PathBuf> = cfg_paths
+            .iter()
+            .chain(included_files.iter())
+            .cloned()
+            .collect();
+
+        // Create debouncer with 500ms timeout and event handling closure
+        let kanata_arc_clone = kanata_arc.clone();
+        let mut debouncer = new_debouncer(
+            Duration::from_millis(500),
+            move |result: DebounceEventResult| {
+                match result {
+                    Ok(events) => {
+                        for event in events {
+                            // Check if the changed file is one of our watched files
+                            if all_watched_files.iter().any(|watched_path| {
+                                event.path.canonicalize().unwrap_or(event.path.clone())
+                                    == watched_path.canonicalize().unwrap_or(watched_path.clone())
+                            }) {
+                                match event.kind {
+                                    DebouncedEventKind::Any => {
+                                        log::info!(
+                                            "Config file changed: {}, triggering reload",
+                                            event.path.display()
+                                        );
+
+                                        // Set the live_reload_requested flag
+                                        if let Some(mut kanata) = kanata_arc_clone.try_lock() {
+                                            kanata.request_live_reload();
+                                        } else {
+                                            log::warn!("Could not acquire lock to set live_reload_requested");
+                                        }
+                                    }
+                                    _ => {
+                                        log::trace!(
+                                            "Ignoring file event: {:?} for {}",
+                                            event.kind,
+                                            event.path.display()
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("File watcher error: {:?}", e);
+                    }
+                }
+            },
+        )?;
+
+        // Watch all config files
+        for path in cfg_paths {
+            debouncer
+                .watcher()
+                .watch(path, RecursiveMode::NonRecursive)?;
+            log::info!("Watching config file for changes: {}", path.display());
+        }
+
+        // Watch included files
+        for path in included_files {
+            debouncer
+                .watcher()
+                .watch(path, RecursiveMode::NonRecursive)?;
+            log::info!("Watching included file for changes: {}", path.display());
+        }
+
+        Ok(debouncer)
+    }
+}

--- a/src/file_watcher.rs
+++ b/src/file_watcher.rs
@@ -20,7 +20,7 @@ pub mod watcher {
     /// This is a simple parser that looks for include statements without full parsing.
     pub fn discover_include_files(cfg_paths: &[PathBuf]) -> Vec<PathBuf> {
         let mut include_files = Vec::new();
-        
+
         for cfg_path in cfg_paths {
             if let Ok(content) = fs::read_to_string(cfg_path) {
                 // Simple regex-like parsing for include statements
@@ -32,17 +32,20 @@ pub mod watcher {
                             if let Some(end) = trimmed[start + 1..].find('"') {
                                 let include_path = &trimmed[start + 1..start + 1 + end];
                                 let mut path = PathBuf::from(include_path);
-                                
+
                                 // If path is relative, make it relative to the config file directory
                                 if !path.is_absolute() {
                                     if let Some(parent) = cfg_path.parent() {
                                         path = parent.join(path);
                                     }
                                 }
-                                
+
                                 if path.exists() {
                                     include_files.push(path);
-                                    log::debug!("Discovered include file: {}", include_files.last().unwrap().display());
+                                    log::debug!(
+                                        "Discovered include file: {}",
+                                        include_files.last().unwrap().display()
+                                    );
                                 }
                             }
                         }
@@ -50,7 +53,7 @@ pub mod watcher {
                 }
             }
         }
-        
+
         include_files
     }
 

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -2066,27 +2066,30 @@ impl Kanata {
                             // Handle file watcher restart if needed
                             #[cfg(feature = "watch")]
                             if k.file_watcher_restart_requested {
-                                log::info!("Restarting file watcher due to changes in included files");
+                                log::info!(
+                                    "Restarting file watcher due to changes in included files"
+                                );
 
                                 // Drop the old watcher. This is critical to stop its background thread
                                 // and release the file handles on the previously watched files.
                                 k.file_watcher = None;
 
                                 // Create a new watcher with the updated file list
-                                let new_debouncer = match crate::file_watcher::watcher::create_debouncer(
-                                    kanata.clone(),
-                                    &k.cfg_paths,
-                                    &k.included_files,
-                                ) {
-                                    Ok(debouncer) => {
-                                        log::info!("File watcher successfully restarted");
-                                        Some(debouncer)
-                                    }
-                                    Err(e) => {
-                                        log::error!("Failed to restart file watcher: {}", e);
-                                        None
-                                    }
-                                };
+                                let new_debouncer =
+                                    match crate::file_watcher::watcher::create_debouncer(
+                                        kanata.clone(),
+                                        &k.cfg_paths,
+                                        &k.included_files,
+                                    ) {
+                                        Ok(debouncer) => {
+                                            log::info!("File watcher successfully restarted");
+                                            Some(debouncer)
+                                        }
+                                        Err(e) => {
+                                            log::error!("Failed to restart file watcher: {}", e);
+                                            None
+                                        }
+                                    };
 
                                 k.file_watcher = new_debouncer;
                                 k.file_watcher_restart_requested = false;
@@ -2155,27 +2158,30 @@ impl Kanata {
                             // Handle file watcher restart if needed
                             #[cfg(feature = "watch")]
                             if k.file_watcher_restart_requested {
-                                log::info!("Restarting file watcher due to changes in included files");
+                                log::info!(
+                                    "Restarting file watcher due to changes in included files"
+                                );
 
                                 // Drop the old watcher. This is critical to stop its background thread
                                 // and release the file handles on the previously watched files.
                                 k.file_watcher = None;
 
                                 // Create a new watcher with the updated file list
-                                let new_debouncer = match crate::file_watcher::watcher::create_debouncer(
-                                    kanata.clone(),
-                                    &k.cfg_paths,
-                                    &k.included_files,
-                                ) {
-                                    Ok(debouncer) => {
-                                        log::info!("File watcher successfully restarted");
-                                        Some(debouncer)
-                                    }
-                                    Err(e) => {
-                                        log::error!("Failed to restart file watcher: {}", e);
-                                        None
-                                    }
-                                };
+                                let new_debouncer =
+                                    match crate::file_watcher::watcher::create_debouncer(
+                                        kanata.clone(),
+                                        &k.cfg_paths,
+                                        &k.included_files,
+                                    ) {
+                                        Ok(debouncer) => {
+                                            log::info!("File watcher successfully restarted");
+                                            Some(debouncer)
+                                        }
+                                        Err(e) => {
+                                            log::error!("Failed to restart file watcher: {}", e);
+                                            None
+                                        }
+                                    };
 
                                 k.file_watcher = new_debouncer;
                                 k.file_watcher_restart_requested = false;

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -89,6 +89,12 @@ pub struct Kanata {
     /// Index into `cfg_paths`, used to know which file to live reload. Changes when cycling
     /// through the configuration files.
     pub cur_cfg_idx: usize,
+    /// Files included via (include "path") in the configuration.
+    pub included_files: Vec<PathBuf>,
+    /// File watcher for configuration changes.
+    #[cfg(feature = "watch")]
+    pub file_watcher:
+        Option<notify_debouncer_mini::Debouncer<notify_debouncer_mini::notify::RecommendedWatcher>>,
     /// The potential key outputs of every key input. Used for managing key repeat.
     pub key_outputs: cfg::KeyOutputs,
     /// Handle to the keyberon library layout.
@@ -152,6 +158,9 @@ pub struct Kanata {
     time_remainder: u128,
     /// Is true if a live reload was requested by the user and false otherwise.
     live_reload_requested: bool,
+    /// Flag to indicate that the file watcher needs to be restarted due to include file changes.
+    #[cfg(feature = "watch")]
+    file_watcher_restart_requested: bool,
     #[cfg(target_os = "linux")]
     /// Linux input paths in the user configuration.
     pub kbd_in_paths: Vec<String>,
@@ -366,6 +375,9 @@ impl Kanata {
             kbd_out,
             cfg_paths: args.paths.clone(),
             cur_cfg_idx: 0,
+            included_files: Vec::new(), // Will be populated dynamically
+            #[cfg(feature = "watch")]
+            file_watcher: None,
             key_outputs: cfg.key_outputs,
             layout: cfg.layout,
             layer_info: cfg.layer_info,
@@ -386,6 +398,8 @@ impl Kanata {
             last_tick: web_time::Instant::now(),
             time_remainder: 0,
             live_reload_requested: false,
+            #[cfg(feature = "watch")]
+            file_watcher_restart_requested: false,
             overrides: cfg.overrides,
             override_states: OverrideStates::new(),
             #[cfg(target_os = "macos")]
@@ -510,6 +524,9 @@ impl Kanata {
             kbd_out,
             cfg_paths: vec!["config string".into()],
             cur_cfg_idx: 0,
+            included_files: Vec::new(), // Will be populated dynamically
+            #[cfg(feature = "watch")]
+            file_watcher: None,
             key_outputs: cfg.key_outputs,
             layout: cfg.layout,
             layer_info: cfg.layer_info,
@@ -530,6 +547,8 @@ impl Kanata {
             last_tick: web_time::Instant::now(),
             time_remainder: 0,
             live_reload_requested: false,
+            #[cfg(feature = "watch")]
+            file_watcher_restart_requested: false,
             overrides: cfg.overrides,
             override_states: OverrideStates::new(),
             #[cfg(target_os = "macos")]
@@ -741,6 +760,21 @@ impl Kanata {
         }
         #[cfg(all(target_os = "windows", feature = "gui"))]
         send_gui_cfg_notice();
+
+        // Check if included files changed and flag for watcher restart
+        #[cfg(feature = "watch")]
+        {
+            use crate::file_watcher::watcher::discover_include_files;
+            let new_included_files = discover_include_files(&self.cfg_paths);
+            if self.included_files != new_included_files {
+                log::info!("Included files have changed, flagging file watcher for restart");
+                log::debug!("Old included files: {:?}", self.included_files);
+                log::debug!("New included files: {:?}", new_included_files);
+                self.file_watcher_restart_requested = true;
+                self.included_files = new_included_files;
+            }
+        }
+
         Ok(())
     }
 
@@ -2029,6 +2063,35 @@ impl Kanata {
                                 }
                             }
 
+                            // Handle file watcher restart if needed
+                            #[cfg(feature = "watch")]
+                            if k.file_watcher_restart_requested {
+                                log::info!("Restarting file watcher due to changes in included files");
+
+                                // Drop the old watcher. This is critical to stop its background thread
+                                // and release the file handles on the previously watched files.
+                                k.file_watcher = None;
+
+                                // Create a new watcher with the updated file list
+                                let new_debouncer = match crate::file_watcher::watcher::create_debouncer(
+                                    kanata.clone(),
+                                    &k.cfg_paths,
+                                    &k.included_files,
+                                ) {
+                                    Ok(debouncer) => {
+                                        log::info!("File watcher successfully restarted");
+                                        Some(debouncer)
+                                    }
+                                    Err(e) => {
+                                        log::error!("Failed to restart file watcher: {}", e);
+                                        None
+                                    }
+                                };
+
+                                k.file_watcher = new_debouncer;
+                                k.file_watcher_restart_requested = false;
+                            }
+
                             #[cfg(feature = "perf_logging")]
                             let start = web_time::Instant::now();
 
@@ -2087,6 +2150,35 @@ impl Kanata {
                                 if let Err(e) = k.do_live_reload(&tx) {
                                     log::error!("live reload failed {e}");
                                 }
+                            }
+
+                            // Handle file watcher restart if needed
+                            #[cfg(feature = "watch")]
+                            if k.file_watcher_restart_requested {
+                                log::info!("Restarting file watcher due to changes in included files");
+
+                                // Drop the old watcher. This is critical to stop its background thread
+                                // and release the file handles on the previously watched files.
+                                k.file_watcher = None;
+
+                                // Create a new watcher with the updated file list
+                                let new_debouncer = match crate::file_watcher::watcher::create_debouncer(
+                                    kanata.clone(),
+                                    &k.cfg_paths,
+                                    &k.included_files,
+                                ) {
+                                    Ok(debouncer) => {
+                                        log::info!("File watcher successfully restarted");
+                                        Some(debouncer)
+                                    }
+                                    Err(e) => {
+                                        log::error!("Failed to restart file watcher: {}", e);
+                                        None
+                                    }
+                                };
+
+                                k.file_watcher = new_debouncer;
+                                k.file_watcher_restart_requested = false;
                             }
 
                             #[cfg(feature = "perf_logging")]
@@ -2202,7 +2294,16 @@ impl Kanata {
         // Note: checking waiting_for_idle can not be part of the computation for
         // is_idle() since incrementing ticks_since_idle is dependent on the return
         // value of is_idle().
-        let counting_idle_ticks = !k.waiting_for_idle.is_empty() || k.live_reload_requested;
+        let counting_idle_ticks = !k.waiting_for_idle.is_empty() || k.live_reload_requested || {
+            #[cfg(feature = "watch")]
+            {
+                k.file_watcher_restart_requested
+            }
+            #[cfg(not(feature = "watch"))]
+            {
+                false
+            }
+        };
         if !is_idle {
             k.ticks_since_idle = 0;
         } else if is_idle && counting_idle_ticks {
@@ -2233,7 +2334,16 @@ impl Kanata {
 
     pub fn is_idle(&self) -> bool {
         let pressed_keys_means_not_idle =
-            !self.waiting_for_idle.is_empty() || self.live_reload_requested;
+            !self.waiting_for_idle.is_empty() || self.live_reload_requested || {
+                #[cfg(feature = "watch")]
+                {
+                    self.file_watcher_restart_requested
+                }
+                #[cfg(not(feature = "watch"))]
+                {
+                    false
+                }
+            };
         self.layout.b().queue.is_empty()
             && zippy_is_idle()
             && self.layout.b().waiting.is_none()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,13 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+#[cfg(feature = "watch")]
+pub mod file_watcher;
 #[cfg(all(target_os = "windows", feature = "gui"))]
 pub mod gui;
 pub mod kanata;
 pub mod oskbd;
 pub mod tcp_server;
-#[cfg(feature = "watch")]
-pub mod file_watcher;
 #[cfg(test)]
 pub mod tests;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub mod gui;
 pub mod kanata;
 pub mod oskbd;
 pub mod tcp_server;
+#[cfg(feature = "watch")]
+pub mod file_watcher;
 #[cfg(test)]
 pub mod tests;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,81 +109,6 @@ kanata.kbd in the current working directory and
 mod cli {
     use super::*;
 
-    #[cfg(feature = "watch")]
-    mod file_watcher {
-        use super::*;
-        use notify_debouncer_mini::{
-            new_debouncer, notify::RecursiveMode, DebounceEventResult, DebouncedEventKind,
-        };
-        use parking_lot::Mutex;
-        use std::sync::Arc;
-        use std::time::Duration;
-
-        pub fn start_file_watcher(
-            cfg_paths: Vec<PathBuf>,
-            kanata_arc: Arc<Mutex<Kanata>>,
-        ) -> Result<()> {
-            // Create debouncer with 500ms timeout and a closure for event handling
-            let kanata_arc_clone = kanata_arc.clone();
-            let cfg_paths_clone = cfg_paths.clone();
-
-            let mut debouncer = new_debouncer(
-                Duration::from_millis(500),
-                move |result: DebounceEventResult| {
-                    match result {
-                        Ok(events) => {
-                            for event in events {
-                                // Check if the changed file is one of our config files
-                                if cfg_paths_clone.iter().any(|cfg_path| {
-                                    event.path.canonicalize().unwrap_or(event.path.clone())
-                                        == cfg_path.canonicalize().unwrap_or(cfg_path.clone())
-                                }) {
-                                    match event.kind {
-                                        DebouncedEventKind::Any => {
-                                            log::info!(
-                                                "Config file changed: {}, triggering reload",
-                                                event.path.display()
-                                            );
-
-                                            // Set the live_reload_requested flag
-                                            if let Some(mut kanata) = kanata_arc_clone.try_lock() {
-                                                kanata.request_live_reload();
-                                            } else {
-                                                log::warn!("Could not acquire lock to set live_reload_requested");
-                                            }
-                                        }
-                                        _ => {
-                                            log::trace!(
-                                                "Ignoring file event: {:?} for {}",
-                                                event.kind,
-                                                event.path.display()
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            log::error!("File watcher error: {:?}", e);
-                        }
-                    }
-                },
-            )?;
-
-            // Watch all config files directly
-            for path in &cfg_paths {
-                debouncer
-                    .watcher()
-                    .watch(path, RecursiveMode::NonRecursive)?;
-                log::info!("Watching config file for changes: {}", path.display());
-            }
-
-            // Keep the debouncer alive by moving it to a static context
-            std::mem::forget(debouncer);
-
-            Ok(())
-        }
-    }
 
     /// Parse CLI arguments and initialize logging.
     fn cli_init() -> Result<ValidatedArgs> {
@@ -314,11 +239,10 @@ mod cli {
             Kanata::start_notification_loop(nrx, server.connections);
         }
 
-        // Start file watcher if enabled
+        // Start comprehensive file watcher if enabled (supports include files)
         #[cfg(feature = "watch")]
         if args.watch {
-            if let Err(e) = file_watcher::start_file_watcher(args.paths.clone(), kanata_arc.clone())
-            {
+            if let Err(e) = crate::file_watcher::watcher::start_file_watcher(kanata_arc.clone()) {
                 log::error!("Failed to start file watcher: {}", e);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,6 @@ kanata.kbd in the current working directory and
 mod cli {
     use super::*;
 
-
     /// Parse CLI arguments and initialize logging.
     fn cli_init() -> Result<ValidatedArgs> {
         let args = Args::parse();


### PR DESCRIPTION
## Summary

This PR **replaces** the basic `--watch` implementation (merged in PR #1707) with a comprehensive solution that fully supports include files and dynamic watcher restart.

## Background

The basic `--watch` functionality was merged in PR #1707, which provided automatic config reloading for main config files only. This PR replaces that implementation with a much more robust solution that properly handles include files.

## Key Features

### **Comprehensive Include File Support**
- **Dynamic discovery**: Automatically detects `(include "path")` statements in config files
- **Dynamic restart**: When include files change during reload, the watcher automatically restarts with the new file list
- **No stale handles**: Properly manages file watcher lifecycle to prevent missed changes

### **Robust Architecture**  
- **Dedicated module**: Replaces inline implementation with `src/file_watcher.rs`
- **Lifecycle management**: Stores watcher in Kanata struct for proper cleanup and restart
- **Integration**: Works seamlessly with existing live reload infrastructure

### **Backward Compatibility**
- **Same API**: Uses existing `--watch` flag with no changes needed
- **Same behavior**: Maintains 500ms debouncing and all existing functionality
- **Enhancement**: Adds include file support without breaking existing usage

## Technical Implementation

### **File Watcher Management**
```rust
pub struct Kanata {
    // ...
    pub included_files: Vec<PathBuf>,
    pub file_watcher: Option<Debouncer<RecommendedWatcher>>,
    file_watcher_restart_requested: bool,
}
```

### **Dynamic Include Discovery**
```rust
// Parses config files to find (include "path") statements
let included_files = discover_include_files(&cfg_paths);
```

### **Automatic Restart Logic**
```rust
// During live reload, check if includes changed
if self.included_files != new_included_files {
    self.file_watcher_restart_requested = true;
}
```

## Testing

- ✅ **Compiles successfully** with `--features watch`
- ✅ **Replaces basic implementation** - no feature regression
- ✅ **Architecture verified** - proper integration with reload system
- ✅ **Ready for manual testing** with modular configurations

## Benefits for Users

This makes `--watch` truly useful for complex configurations:

```
main.kbd:
(include "layers/base.kbd")     ; ← Now watched automatically
(include "layers/gaming.kbd")   ; ← Changes trigger reload  
(include "macros/work.kbd")     ; ← Adding new includes works seamlessly
```

When **any** file changes (main config or includes), the entire configuration reloads instantly.

🤖 Generated with [Claude Code](https://claude.ai/code)