### PR TITLE
feat: add TCP commands for live configuration reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 CLAUDE.md
 .DS_Store
 PLAN.md
+
+# Manual testing files
+test_*.kbd
+manual_test/
+*.test.kbd

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -4550,6 +4550,18 @@ https://github.com/jtroo/kanata/blob/main/tcp_protocol/src/lib.rs[TCP protocol c
 You may also be interested in the
 https://github.com/jtroo/kanata/blob/main/example_tcp_client/src/main.rs[example client].
 
+==== TCP Configuration Reload Commands
+
+The TCP server supports live configuration reloading through the following commands:
+
+- `{"Reload":{}}` - Reload the current configuration file (equivalent to `lrld` keyboard action)
+- `{"ReloadNext":{}}` - Reload the next configuration file (equivalent to `lrnx` keyboard action)  
+- `{"ReloadPrev":{}}` - Reload the previous configuration file (equivalent to `lrpv` keyboard action)
+- `{"ReloadNum":{"index":N}}` - Reload configuration file at index N (equivalent to `lrld-num N` keyboard action)
+- `{"ReloadFile":{"path":"/path/to/config.kbd"}}` - Reload a specific configuration file (equivalent to `lrld-file` keyboard action)
+
+These commands mirror the existing keyboard live reload actions and allow external tools to trigger configuration reloads via TCP.
+
 [[args-quiet]]
 === Disable logs other than errors: `-q`, `--quiet`
 

--- a/example_tcp_client/src/main.rs
+++ b/example_tcp_client/src/main.rs
@@ -58,6 +58,17 @@ fn print_usage() {
 \n\
     Requests to change kanata's layer look like:\n\
     {}
+\n\
+    Configuration reload commands:\n\
+    - reload: {}\n\
+    - reload next: {}\n\
+    - reload previous: {}\n\
+    - reload specific index: {}\n\
+    - reload specific file: {}
+\n\
+    Server responses for commands look like:\n\
+    - Success: {}\n\
+    - Error: {}
     ",
         serde_json::to_string(&ServerMessage::LayerChange {
             new: "newly-changed-to-layer".into()
@@ -65,6 +76,19 @@ fn print_usage() {
         .expect("deserializable"),
         serde_json::to_string(&ClientMessage::ChangeLayer {
             new: "requested-layer".into()
+        })
+        .expect("deserializable"),
+        serde_json::to_string(&ClientMessage::Reload {}).expect("deserializable"),
+        serde_json::to_string(&ClientMessage::ReloadNext {}).expect("deserializable"),
+        serde_json::to_string(&ClientMessage::ReloadPrev {}).expect("deserializable"),
+        serde_json::to_string(&ClientMessage::ReloadNum { index: 1 }).expect("deserializable"),
+        serde_json::to_string(&ClientMessage::ReloadFile {
+            path: "/path/to/config.kbd".to_string()
+        })
+        .expect("deserializable"),
+        serde_json::to_string(&ServerResponse::Ok).expect("deserializable"),
+        serde_json::to_string(&ServerResponse::Error {
+            msg: "Invalid config index: 5. Only 2 configs are available (0-1).".to_string()
         })
         .expect("deserializable"),
     )
@@ -95,28 +119,62 @@ fn init_logger(args: &Args) {
 
 fn write_to_kanata(mut s: TcpStream) {
     log::info!("writer starting");
-    log::info!("writer: type layer name then press enter to send a change layer request to kanata");
-    let mut layer = String::new();
+    log::info!("writer: enter commands to send to kanata:");
+    log::info!("  - layer name: change to that layer");
+    log::info!("  - fk:KEYNAME: tap fake key");
+    log::info!("  - reload: reload current config");
+    log::info!("  - reload-next: reload next config");
+    log::info!("  - reload-prev: reload previous config");
+    log::info!("  - reload-num:N: reload config at index N");
+    log::info!("  - reload-file:PATH: reload config file at PATH");
+    let mut input = String::new();
     loop {
-        stdin().read_line(&mut layer).expect("stdin is readable");
-        let new = layer.trim_end().to_owned();
-        if new.starts_with("fk:") {
-            let fkname = new.trim_start_matches("fk:").into();
+        stdin().read_line(&mut input).expect("stdin is readable");
+        let command = input.trim_end().to_owned();
+
+        let msg = if command.starts_with("fk:") {
+            let fkname = command.trim_start_matches("fk:").into();
             log::info!("writer: telling kanata to tap fake key \"{fkname}\"");
-            let msg = serde_json::to_string(&ClientMessage::ActOnFakeKey {
+            serde_json::to_string(&ClientMessage::ActOnFakeKey {
                 name: fkname,
                 action: FakeKeyActionMessage::Tap,
             })
-            .expect("deserializable");
-            s.write_all(msg.as_bytes()).expect("stream writable");
-            layer.clear();
-            continue;
-        }
-        log::info!("writer: telling kanata to change layer to \"{new}\"");
-        let msg =
-            serde_json::to_string(&ClientMessage::ChangeLayer { new }).expect("deserializable");
+            .expect("deserializable")
+        } else if command == "reload" {
+            log::info!("writer: telling kanata to reload current config");
+            serde_json::to_string(&ClientMessage::Reload {}).expect("deserializable")
+        } else if command == "reload-next" {
+            log::info!("writer: telling kanata to reload next config");
+            serde_json::to_string(&ClientMessage::ReloadNext {}).expect("deserializable")
+        } else if command == "reload-prev" {
+            log::info!("writer: telling kanata to reload previous config");
+            serde_json::to_string(&ClientMessage::ReloadPrev {}).expect("deserializable")
+        } else if command.starts_with("reload-num:") {
+            let index_str = command.trim_start_matches("reload-num:");
+            match index_str.parse::<usize>() {
+                Ok(index) => {
+                    log::info!("writer: telling kanata to reload config at index {index}");
+                    serde_json::to_string(&ClientMessage::ReloadNum { index })
+                        .expect("deserializable")
+                }
+                Err(_) => {
+                    log::error!("Invalid number format for reload-num: {index_str}");
+                    input.clear();
+                    continue;
+                }
+            }
+        } else if command.starts_with("reload-file:") {
+            let path = command.trim_start_matches("reload-file:").to_string();
+            log::info!("writer: telling kanata to reload config file \"{path}\"");
+            serde_json::to_string(&ClientMessage::ReloadFile { path }).expect("deserializable")
+        } else {
+            log::info!("writer: telling kanata to change layer to \"{command}\"");
+            serde_json::to_string(&ClientMessage::ChangeLayer { new: command })
+                .expect("deserializable")
+        };
+
         s.write_all(msg.as_bytes()).expect("stream writable");
-        layer.clear();
+        input.clear();
     }
 }
 
@@ -127,6 +185,21 @@ fn read_from_kanata(s: TcpStream) {
     loop {
         msg.clear();
         reader.read_line(&mut msg).expect("stream readable");
+
+        // Try to parse as ServerResponse first (for command responses)
+        if let Ok(response) = serde_json::from_str::<ServerResponse>(&msg) {
+            match response {
+                ServerResponse::Ok => {
+                    log::info!("✓ Command executed successfully");
+                }
+                ServerResponse::Error { msg } => {
+                    log::error!("✗ Command failed: {}", msg);
+                }
+            }
+            continue;
+        }
+
+        // Fall back to parsing as ServerMessage (for notifications)
         let parsed_msg: ServerMessage = match serde_json::from_str(&msg) {
             Ok(msg) => msg,
             Err(e) => {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1706,33 +1706,39 @@ impl Kanata {
 
                 // Process reload actions after releasing the layout borrow
                 if let Some(action) = reload_action {
-                    match action {
+                    let reload_succeeded = match action {
                         ReloadAction::Reload => {
                             self.request_live_reload();
-                            live_reload_requested = true;
+                            true
                         }
                         ReloadAction::ReloadNext => {
                             self.request_live_reload_next();
-                            live_reload_requested = true;
+                            true
                         }
                         ReloadAction::ReloadPrev => {
                             self.request_live_reload_prev();
-                            live_reload_requested = true;
+                            true
                         }
                         ReloadAction::ReloadNum(n) => {
                             if let Err(e) = self.request_live_reload_num(n) {
                                 log::error!("{}", e);
+                                false
                             } else {
-                                live_reload_requested = true;
+                                true
                             }
                         }
                         ReloadAction::ReloadFile(path) => {
                             if let Err(e) = self.request_live_reload_file(path) {
                                 log::error!("{}", e);
+                                false
                             } else {
-                                live_reload_requested = true;
+                                true
                             }
                         }
+                    };
+
+                    if reload_succeeded {
+                        live_reload_requested = true;
                     }
                 }
             }

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1703,7 +1703,7 @@ impl Kanata {
                 }
                 #[cfg(feature = "cmd")]
                 run_multi_cmd(cmds);
-                
+
                 // Process reload actions after releasing the layout borrow
                 if let Some(action) = reload_action {
                     match action {

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -27,6 +27,21 @@ pub type Connections = ();
 use kanata_parser::custom_action::FakeKeyAction;
 
 #[cfg(feature = "tcp_server")]
+fn send_response(
+    stream: &mut TcpStream,
+    response: ServerResponse,
+    connections: &Connections,
+    addr: &str,
+) -> bool {
+    if let Err(write_err) = stream.write_all(&response.as_bytes()) {
+        log::error!("stream write error: {write_err}");
+        connections.lock().remove(addr);
+        return false;
+    }
+    true
+}
+
+#[cfg(feature = "tcp_server")]
 fn to_action(val: FakeKeyActionMessage) -> FakeKeyAction {
     match val {
         FakeKeyActionMessage::Press => FakeKeyAction::Press,
@@ -117,6 +132,7 @@ impl TcpServer {
                             for v in reader {
                                 match v {
                                     Ok(event) => {
+                                        log::debug!("tcp server received command: {:?}", event);
                                         match event {
                                             ClientMessage::ChangeLayer { new } => {
                                                 kanata.lock().change_layer(new);
@@ -220,6 +236,40 @@ impl TcpServer {
                                                 ),
                                             }
                                             }
+                                            // Handle reload commands with unified response protocol
+                                            reload_cmd @ (ClientMessage::Reload {}
+                                            | ClientMessage::ReloadNext {}
+                                            | ClientMessage::ReloadPrev {}
+                                            | ClientMessage::ReloadNum { .. }
+                                            | ClientMessage::ReloadFile { .. }) => {
+                                                // Log specific action type
+                                                match &reload_cmd {
+                                                    ClientMessage::Reload {} => log::info!("tcp server Reload action"),
+                                                    ClientMessage::ReloadNext {} => log::info!("tcp server ReloadNext action"),
+                                                    ClientMessage::ReloadPrev {} => log::info!("tcp server ReloadPrev action"),
+                                                    ClientMessage::ReloadNum { index } => log::info!("tcp server ReloadNum action: index {index}"),
+                                                    ClientMessage::ReloadFile { path } => log::info!("tcp server ReloadFile action: path {path}"),
+                                                    _ => unreachable!(),
+                                                }
+
+                                                let response = match kanata
+                                                    .lock()
+                                                    .handle_client_command(reload_cmd)
+                                                {
+                                                    Ok(_) => ServerResponse::Ok,
+                                                    Err(e) => ServerResponse::Error {
+                                                        msg: format!("{e}"),
+                                                    },
+                                                };
+                                                if !send_response(
+                                                    &mut stream,
+                                                    response,
+                                                    &connections,
+                                                    &addr,
+                                                ) {
+                                                    break;
+                                                }
+                                            }
                                         }
                                         use kanata_parser::keys::*;
                                         wakeup_channel
@@ -233,15 +283,11 @@ impl TcpServer {
                                         log::warn!(
                                         "client sent an invalid message, disconnecting them. Err: {e:?}"
                                     );
-                                        // Ignore write result because we're about to disconnect
-                                        // the client anyway.
-                                        let _ = stream.write_all(
-                                            &ServerMessage::Error {
-                                                msg: "disconnecting - you sent an invalid message"
-                                                    .into(),
-                                            }
-                                            .as_bytes(),
-                                        );
+                                        // Send proper error response for malformed JSON
+                                        let response = ServerResponse::Error {
+                                            msg: format!("Failed to deserialize command: {e}"),
+                                        };
+                                        let _ = stream.write_all(&response.as_bytes());
                                         connections.lock().remove(&addr);
                                         break;
                                     }


### PR DESCRIPTION
## feat: Add TCP commands for live configuration reload

### Summary

This PR adds comprehensive TCP reload commands that mirror existing keyboard live reload actions, enabling external tools to programmatically trigger configuration reloads with proper error handling and user feedback.

### New TCP Commands

- `{"Reload":{}}` - Reload current config (equivalent to `lrld`)
- `{"ReloadNext":{}}` - Reload next config (equivalent to `lrnx`)  
- `{"ReloadPrev":{}}` - Reload previous config (equivalent to `lrpv`)
- `{"ReloadNum":{"index":N}}` - Reload config at index N (equivalent to `lrld-num N`)
- `{"ReloadFile":{"path":"/path/to/config.kbd"}}` - Reload specific file (equivalent to `lrld-file`)

### Key Architecture Change: Request/Response Protocol

**Before**: Fire-and-forget commands with no client feedback  
**After**: Request/response protocol with standardized feedback

This shift enables robust client implementations by providing:
```json
{"status":"Ok"}                                    // Success confirmation
{"status":"Error","msg":"Config file not found"}   // Actionable error details
```

**Why this matters**: External tools can now provide meaningful user feedback, handle errors gracefully, and build reliable automation workflows instead of guessing whether commands succeeded.

### Implementation Details

- **ServerResponse enum**: Standardized Ok/Error responses for all reload commands
- **Centralized validation**: `handle_client_command` method consolidates error handling logic  
- **Enhanced example client**: Shows ✓/✗ status and demonstrates all reload commands
- **Focused testing**: 2 tests covering API contract and newline termination behavior (validated against testing best practices)

### Project Convention Compliance

Following feedback from previous PRs, this implementation prioritizes:

- **Meaningful tests only**: 2 focused tests that validate our behavior (API contract, newline logic) rather than testing language features
- **Kanata conventions**: Uses existing patterns (`#[cfg(feature = "tcp_server")]`, `request_live_reload_*` naming, `bail\!()` error handling)
- **Concise documentation**: 12-line addition to config.adoc that's user-focused and explains what commands do, not how they work
- **Proper project structure**: Integrates with existing TCP infrastructure without creating unnecessary files or directories

### Use Cases

This enables external automation tools to:
- Reload configs in response to file system events with confidence
- Switch between different configuration sets programmatically with error handling
- Integrate kanata config management into broader automation workflows
- Provide users with clear success/failure feedback

### Testing

- ✅ Compiles successfully with `--features tcp_server`
- ✅ All tests pass (focused on actual behavior, not language features)
- ✅ Example client demonstrates functionality with user feedback
- ✅ Backward compatible with existing TCP commands

🤖 Generated with [Claude Code](https://claude.ai/code)