### PR TITLE
fix tiny typo in config.adoc

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1570,7 +1570,7 @@ at a constant rate until a maximum is reached.
 | `$interval`
 | Number of milliseconds between move activations.
 
-| `$acceletaion-time`
+| `$acceleration-time`
 | Number of milliseconds until max distance per activation is reached.
 
 | `$min`


### PR DESCRIPTION
acceletaion ->  accele*rat*ion

## Describe your changes. Use imperative present tense.
Fix tiny typo in config.adoc.
acceletaion ->  accele**rat**ion

## Checklist

- Add documentation to docs/config.adoc
  - [N/A]
- Add example and basic docs to cfg_samples/kanata.kbd
  - [N/A
- Update error messages
  - [N/A]
- Added tests, or did manual testing
  - [N/A]
