### PR TITLE
fix: broken --watch flag due to faulty ticks_since_idle logic

### DIFF
--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -2524,7 +2524,10 @@ fn live_reload_forced_after_1s_even_when_not_idle() {
     let mut k = match Kanata::new(&args) {
         Ok(k) => k,
         Err(e) => {
-            eprintln!("Skipping test: cannot create Kanata instance (likely CI environment): {}", e);
+            eprintln!(
+                "Skipping test: cannot create Kanata instance (likely CI environment): {}",
+                e
+            );
             return;
         }
     };


### PR DESCRIPTION
## Fix: --watch flag broken due to faulty ticks_since_idle logic

### Problem

The `--watch` flag appeared to work (file changes were detected and logged) but configuration updates were never actually applied. Users would see:

```
Config file changed: /path/to/config.kbd, triggering reload
Requested live reload of file: /path/to/config.kbd
```

But the reload would never complete - "Live reload successful" never appeared and key mappings remained unchanged until full restart.

### Root Cause

The reload mechanism relied on a broken 1-second fallback timer using `ticks_since_idle`:

```rust
// Broken logic
if self.live_reload_requested
    && ((self.prev_keys.is_empty() && self.cur_keys.is_empty())
        || self.ticks_since_idle > 1000)  // ← This never triggered
```

**The issue:** `ticks_since_idle` only increments when the system is **already idle**, but it gets reset to 0 whenever the system is **not idle**. This creates a catch-22 where the 1s fallback can never trigger if the keyboard state doesn't reach idle naturally.

### Solution

Replace the broken `ticks_since_idle` logic with a reliable wall-clock timestamp approach:

- Add `reload_requested_at: Option<web_time::Instant>` field
- Set timestamp on any reload request (`--watch`, TCP commands, manual shortcuts)
- Use wall-clock time for the 1s fallback: `t.elapsed() >= Duration::from_secs(1)`
- Preserve idle-first behavior for safety, but guarantee execution within 1 second

### Impact

**Fixes all live reload mechanisms:**
- ✅ `--watch` file monitoring (primary issue reported)
- ✅ TCP reload commands (`{"Reload": {}}`)
- ✅ Manual keyboard shortcuts (e.g., `lrld` action)

**Behavior:**
- **Preferred:** Immediate reload when keyboard is idle (unchanged)
- **Fallback:** Forced reload after exactly 1 second (now reliable)
- **Logging:** Clear indication when fallback is used

### Testing

Verified on macOS with `--watch`:
1. Start kanata with `--watch` flag
2. Modify config to add new key mapping (e.g., `1→2`)
3. **Before fix:** Change detected but mapping never applied
4. **After fix:** Mapping active within 1 second automatically

### Changes

- Add `reload_requested_at` field to `Kanata` struct
- Update all `request_live_reload*` methods to set timestamp
- Replace `ticks_since_idle > 1000` with `t.elapsed() >= 1000ms`
- Add test case for forced reload scenario
- Improve logging for reload state transitions

This is a targeted fix that resolves the fundamental timer bug while preserving existing behavior and safety guarantees.