### PR TITLE
Added EjectKey in MacOS keyboards

### DIFF
--- a/parser/src/cfg/is_a_button.rs
+++ b/parser/src/cfg/is_a_button.rs
@@ -134,6 +134,7 @@ fn standard_keys_are_not_considered_buttons() {
         KEY_MUTE,
         KEY_VOLUMEDOWN,
         KEY_VOLUMEUP,
+        KEY_EJECTCD,
         KEY_PAUSE,
         KEY_LEFTMETA,
         KEY_RIGHTMETA,

--- a/parser/src/keys/macos.rs
+++ b/parser/src/keys/macos.rs
@@ -510,6 +510,10 @@ impl TryFrom<OsCode> for PageCode {
                 page: 0x0C,
                 code: 0xEA,
             }), // 0x0781
+            OsCode::KEY_EJECTCD => Ok(PageCode {
+                page: 0x0C,
+                code: 0xB8,
+            }), // 0x0781
             //KeyboardLockingCapsLock   => 82, todo
             //KeyboardLockingNumLock    => 83, todo
             //KeyboardLockingScrollLock => 84, todo
@@ -1179,6 +1183,10 @@ impl TryFrom<PageCode> for OsCode {
                 page: 0x0C,
                 code: 0xEA,
             } => Ok(OsCode::KEY_VOLUMEDOWN),
+            PageCode {
+                page: 0x0C,
+                code: 0xB8,
+            } => Ok(OsCode::KEY_EJECTCD),
             PageCode {
                 page: 0x07,
                 code: 0x85,

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -280,6 +280,7 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "VolumeMute" | "mute"  | "🔇" | "🔈⓪" | "🔈⓿" | "🔈₀" => OsCode::KEY_MUTE,
         "VolumeUp" | "volu" | "🔊" | "🔈+" | "🔈➕" | "🔈₊" | "🔈⊕" => OsCode::KEY_VOLUMEUP,
         "VolumeDown" | "voldwn" | "vold" | "🔉" | "🔈−" | "🔈➖" | "🔈₋" | "🔈⊖" => OsCode::KEY_VOLUMEDOWN,
+        "EjectCD" | "eject" => OsCode::KEY_EJECTCD,
         "brup" | "bru" | "🔆" => OsCode::KEY_BRIGHTNESSUP,
         "brdown" | "brdwn" | "brdn" | "🔅" => OsCode::KEY_BRIGHTNESSDOWN,
         "blup" | "⌨💡+" | "⌨💡➕" | "⌨💡₊" | "⌨💡⊕" => OsCode::KEY_KBDILLUMUP,


### PR DESCRIPTION
MacOS keyboards have an eject key to the right of the F12

This patch allows the use of the Eject key as another key using the predefined EjectCD

It defines two strings for this key: "EjectCD" and "eject"

## Checklist

- Add documentation to docs/config.adoc
  - Keys do not seem to be documented 
- Add example and basic docs to cfg_samples/kanata.kbd
  - Key seems to be too obscure to add to examples, but I will add it if desired
- Update error messages
  - N/A
- Added tests, or did manual testing
  - Did manual testing. If needed I can add tests, but I need guidance on how to do it.
