### PR TITLE
fix(windows): intercept now expects correct OsCode for `kana`

### DIFF
--- a/src/oskbd/windows/interception_convert.rs
+++ b/src/oskbd/windows/interception_convert.rs
@@ -311,7 +311,7 @@ impl TryFrom<OsCodeWrapper> for Stroke {
             OsCode::KEY_F22 => (ScanCode::F22, KeyState::empty()),
             OsCode::KEY_F23 => (ScanCode::F23, KeyState::empty()),
             OsCode::KEY_F24 => (ScanCode::F24, KeyState::empty()),
-            OsCode::KEY_KATAKANA => (ScanCode::Katakana, KeyState::empty()),
+            OsCode::KEY_HANGEUL => (ScanCode::Katakana, KeyState::empty()),
             // Note: the OEM keys below don't seem to correspond to the same VK OEM
             // mappings as the LLHOOK codes.
             // ScanCode::Oem1 = 0x5A, /* VK_OEM_WSCTRL */


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

This patch fixes `OsCodeWrapper` for interception module expecting `KEY_KATAKANA` instead of `KEY_HANGEUL`, which is the correct OsCode for `0x70` (`kana` / `katakana` / `katakanahiragana`) on Windows. (See #1753)

## Checklist

- Add documentation to docs/config.adoc
  - [ ] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] N/A
- Update error messages
  - [ ] N/A
- Added tests, or did manual testing
  - [X] Yes
