### PR TITLE
fix(tcp): Handle peer_addr() failures gracefully to prevent panics

### DIFF
--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -109,10 +109,13 @@ impl TcpServer {
                             }
                         }
 
-                        let addr = stream
-                            .peer_addr()
-                            .expect("incoming conn has known address")
-                            .to_string();
+                        let addr = match stream.peer_addr() {
+                            Ok(addr) => addr.to_string(),
+                            Err(e) => {
+                                log::warn!("failed to get peer address, using fallback: {e:?}");
+                                format!("unknown_{}", std::ptr::addr_of!(stream) as usize)
+                            }
+                        };
 
                         connections.lock().insert(
                             addr.clone(),


### PR DESCRIPTION
### What's the issue?
The TCP server crashes whenever `peer_addr()` fails on incoming connections. This happens when clients disconnect suddenly or during TCP resets, causing the whole app to panic with `.expect()`. Not great for stability!

### The fix
Instead of panicking, we now handle the error gracefully:
- Catch `peer_addr()` failures with a proper match statement
- Fall back to a unique identifier using the stream's memory address
- Log a warning so you can still see what happened

### What changed
- **src/tcp_server.rs**: Swapped out the panic-happy `.expect("incoming conn has known address")` with error handling that creates a fallback ID like `unknown_12345678`

### Context
I originally contributed the TCP server code and ran into this crash while testing locally when network conditions got rough.

### Tested
- ✅ All tests still pass 
- ✅ Clippy is happy
- ✅ Code formatted properly

### Why this matters
- TCP server won't crash when network gets flaky
- You'll still see warnings in logs when connections fail
- Everything else works exactly the same

Small change, but makes kanata way more robust when dealing with real-world network conditions. No more crashes from connection resets!

---

**This is ready to go!** Simple fix that prevents actual crashes without breaking anything.