### PR TITLE
fix(macOS): emit the correct OsCode for `compose`

### DIFF
--- a/parser/src/keys/macos.rs
+++ b/parser/src/keys/macos.rs
@@ -400,7 +400,10 @@ impl TryFrom<OsCode> for PageCode {
                 page: 0x07,
                 code: 0x64,
             }), //KeyboardNonUSBackslash
-            // KeyboardApplication               => 0x0765, todo
+            OsCode::KEY_COMPOSE => Ok(PageCode {
+                page: 0x07,
+                code: 0x65,
+            }),
             OsCode::KEY_POWER => Ok(PageCode {
                 page: 0x07,
                 code: 0x66,


### PR DESCRIPTION

## Describe your changes. Use imperative present tense.
This patch fixes the `todo` for KeyboardApplication, which is actually the `menu`/`compose` key.

This prevents a panic when emitting the `menu` key on macOS.

## Checklist

- Add documentation to docs/config.adoc
  - N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  - N/A
- Added tests, or did manual testing
  - [X] Yes