### PR TITLE
feat: added smart-rpt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,15 @@
 [workspace]
 members = [
-    "./",
-    "parser",
-    "keyberon",
-    "example_tcp_client",
-    "tcp_protocol",
-    "windows_key_tester",
-    "simulated_input",
-    "simulated_passthru",
+  "./",
+  "parser",
+  "keyberon",
+  "example_tcp_client",
+  "tcp_protocol",
+  "windows_key_tester",
+  "simulated_input",
+  "simulated_passthru",
 ]
-exclude = [
-    "interception",
-    "key-sort-add",
-    "wasm",
-]
+exclude = ["interception", "key-sort-add", "wasm"]
 resolver = "2"
 
 [package]
@@ -40,7 +36,12 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-clap = { version = "4", features = [ "std", "derive", "help", "suggestions" ], default-features = false }
+clap = { version = "4", features = [
+  "std",
+  "derive",
+  "help",
+  "suggestions",
+], default-features = false }
 dirs = "5.0.1"
 indoc = { version = "2.0.4", optional = true }
 log = { version = "0.4.8", default-features = false }
@@ -50,12 +51,14 @@ parking_lot = "0.12"
 radix_trie = "0.2"
 rustc-hash = "1.1.0"
 simplelog = "0.12.0"
-serde_json = { version = "1", features = ["std"], default-features = false, optional = true }
+serde_json = { version = "1", features = [
+  "std",
+], default-features = false, optional = true }
 time = "0.3.36"
 web-time = "1.1.0"
 
 kanata-keyberon = { path = "keyberon", version = "0.190.0" }
-kanata-parser =   { path = "parser", version = "0.190.0" }
+kanata-parser = { path = "parser", version = "0.190.0" }
 kanata-tcp-protocol = { path = "tcp_protocol", version = "0.190.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -81,37 +84,39 @@ sd-notify = "0.4.1"
 [target.'cfg(target_os = "windows")'.dependencies]
 encode_unicode = "0.3.6"
 winapi = { version = "0.3.9", features = [
-    "wincon",
-    "timeapi",
-    "mmsystem",
-    "winuser",
-    "windef",
-    "minwindef",
+  "wincon",
+  "timeapi",
+  "mmsystem",
+  "winuser",
+  "windef",
+  "minwindef",
 ] }
 windows-sys = { version = "0.52.0", features = [
-    "Win32_Devices_DeviceAndDriverInstallation",
-    "Win32_Devices_Usb",
-    "Win32_Foundation",
-    "Win32_Graphics_Gdi",
-    "Win32_Security",
-    "Win32_System_Diagnostics_Debug",
-    "Win32_System_Registry",
-    "Win32_System_Threading",
-    "Win32_UI_Controls",
-    "Win32_UI_Shell",
-    "Win32_UI_HiDpi",
-    "Win32_UI_WindowsAndMessaging",
-    "Win32_System_SystemInformation",
-    "Wdk",
-    "Wdk_System",
-    "Wdk_System_SystemServices",
-], optional=true }
-native-windows-gui = { version = "1.0.13", default-features = false}
+  "Win32_Devices_DeviceAndDriverInstallation",
+  "Win32_Devices_Usb",
+  "Win32_Foundation",
+  "Win32_Graphics_Gdi",
+  "Win32_Security",
+  "Win32_System_Diagnostics_Debug",
+  "Win32_System_Registry",
+  "Win32_System_Threading",
+  "Win32_UI_Controls",
+  "Win32_UI_Shell",
+  "Win32_UI_HiDpi",
+  "Win32_UI_WindowsAndMessaging",
+  "Win32_System_SystemInformation",
+  "Wdk",
+  "Wdk_System",
+  "Wdk_System_SystemServices",
+], optional = true }
+native-windows-gui = { version = "1.0.13", default-features = false }
 regex = { version = "1.10.4", optional = true }
 kanata-interception = { version = "0.3.0", optional = true }
 muldiv = { version = "1.0.1", optional = true }
 strip-ansi-escapes = { version = "0.2.0", optional = true }
-open = { version = "5", features = ["shellexecute-on-windows"], optional = true}
+open = { version = "5", features = [
+  "shellexecute-on-windows",
+], optional = true }
 # shellexecute fix allows opening files already opened for writing, needs _detached mode
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
@@ -120,23 +125,39 @@ indoc = { version = "2.0.4", optional = true }
 regex = { version = "1.10.4", optional = true }
 
 [features]
-default = ["tcp_server","win_sendinput_send_scancodes", "zippychord"]
+default = ["tcp_server", "win_sendinput_send_scancodes", "zippychord"]
 perf_logging = []
 tcp_server = ["serde_json"]
 win_sendinput_send_scancodes = ["kanata-parser/win_sendinput_send_scancodes"]
 win_llhook_read_scancodes = ["kanata-parser/win_llhook_read_scancodes"]
 win_manifest = ["embed-resource", "indoc", "regex"]
 cmd = ["kanata-parser/cmd"]
-interception_driver = ["kanata-interception", "kanata-parser/interception_driver"]
+interception_driver = [
+  "kanata-interception",
+  "kanata-parser/interception_driver",
+]
 simulated_output = ["indoc"]
 simulated_input = ["indoc"]
-passthru_ahk = ["simulated_input","simulated_output"]
-gui = ["win_manifest","kanata-parser/gui",
-  "win_sendinput_send_scancodes","win_llhook_read_scancodes",
-  "muldiv","strip-ansi-escapes","open",
+passthru_ahk = ["simulated_input", "simulated_output"]
+gui = [
+  "win_manifest",
+  "kanata-parser/gui",
+  "win_sendinput_send_scancodes",
+  "win_llhook_read_scancodes",
+  "muldiv",
+  "strip-ansi-escapes",
+  "open",
   "dep:windows-sys",
   "winapi/processthreadsapi",
-  "native-windows-gui/tray-notification","native-windows-gui/message-window","native-windows-gui/menu","native-windows-gui/cursor","native-windows-gui/high-dpi","native-windows-gui/embed-resource","native-windows-gui/image-decoder","native-windows-gui/notice","native-windows-gui/animation-timer",
+  "native-windows-gui/tray-notification",
+  "native-windows-gui/message-window",
+  "native-windows-gui/menu",
+  "native-windows-gui/cursor",
+  "native-windows-gui/high-dpi",
+  "native-windows-gui/embed-resource",
+  "native-windows-gui/image-decoder",
+  "native-windows-gui/notice",
+  "native-windows-gui/animation-timer",
 ]
 zippychord = ["kanata-parser/zippychord"]
 

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1160,6 +1160,9 @@ The output chord prefix strings are:
 
 | `rpt-any`
 | String action that outputs the most-recently outputted action.
+
+| `rpt-exclude-bspace`
+| String action that outputs the single most-recently typed key, ignoring backspace.
 |===
 
 **Description**
@@ -1186,11 +1189,23 @@ There is a variant `rpt-any`
 which will repeat any previous action
 and would output `ctrl+c` in the example case.
 
+.Example:
+[source]
 ----
 (deflayer has-repeat-any
   rpt-any a s d f
 )
 ----
+
+The `rpt-exclude-bspace` action repeats the last key output that isn't backspace. Note that this does not output chords, so `ctrl+c bspace` will output `c`.
+
+.Example:
+[source]
+---
+(deflayer has-repeat-skip-bspace
+  rpt-skip-bspace a s d f
+)
+---
 
 [[release-a-key-or-layer]]
 === Release a key or layer
@@ -4519,7 +4534,7 @@ https://github.com/jtroo/kanata/blob/main/example_tcp_client/src/main.rs[example
 The TCP server supports live configuration reloading through the following commands:
 
 - `{"Reload":{}}` - Reload the current configuration file (equivalent to `lrld` keyboard action)
-- `{"ReloadNext":{}}` - Reload the next configuration file (equivalent to `lrnx` keyboard action)  
+- `{"ReloadNext":{}}` - Reload the next configuration file (equivalent to `lrnx` keyboard action)
 - `{"ReloadPrev":{}}` - Reload the previous configuration file (equivalent to `lrpv` keyboard action)
 - `{"ReloadNum":{"index":N}}` - Reload configuration file at index N (equivalent to `lrld-num N` keyboard action)
 - `{"ReloadFile":{"path":"/path/to/config.kbd"}}` - Reload a specific configuration file (equivalent to `lrld-file` keyboard action)

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -1161,8 +1161,8 @@ The output chord prefix strings are:
 | `rpt-any`
 | String action that outputs the most-recently outputted action.
 
-| `rpt-exclude-bspace`
-| String action that outputs the single most-recently typed key, ignoring backspace.
+| `smart-rpt`
+| String action that outputs the most-recently typed key and goes one key back in history after backspace.
 |===
 
 **Description**
@@ -1197,13 +1197,13 @@ and would output `ctrl+c` in the example case.
 )
 ----
 
-The `rpt-exclude-bspace` action repeats the last key output that isn't backspace. Note that this does not output chords, so `ctrl+c bspace` will output `c`.
+The `smart-rpt` action repeats the most recently input key but goes back at most one additional key on backspace. For example, the sequence `<H> <e> <l> <o> <smart-rpt> <bspace> <bspace> <smart-rpt> <o>` outputs `Hello`, while replacing `smart-rpt` with `rpt` outputs `Heo`.
 
 .Example:
 [source]
 ---
 (deflayer has-repeat-skip-bspace
-  rpt-skip-bspace a s d f
+  smart-rpt a s d f
 )
 ---
 

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1702,7 +1702,7 @@ fn parse_action_atom(ac_span: &Spanned<String>, s: &ParserState) -> Result<&'sta
             );
         }
         "rpt" | "repeat" | "rpt-key" => return custom(CustomAction::Repeat, &s.a),
-        "rpt-exclude-bspace" => return custom(CustomAction::RepeatExcludeBSpace, &s.a),
+        "smart-rpt" => return custom(CustomAction::SmartRepeat, &s.a),
         "rpt-any" => return Ok(s.a.sref(Action::Repeat)),
         "dynamic-macro-record-stop" => {
             return custom(CustomAction::DynamicMacroRecordStop(0), &s.a);

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1702,6 +1702,7 @@ fn parse_action_atom(ac_span: &Spanned<String>, s: &ParserState) -> Result<&'sta
             );
         }
         "rpt" | "repeat" | "rpt-key" => return custom(CustomAction::Repeat, &s.a),
+        "rpt-exclude-bspace" => return custom(CustomAction::RepeatExcludeBSpace, &s.a),
         "rpt-any" => return Ok(s.a.sref(Action::Repeat)),
         "dynamic-macro-record-stop" => {
             return custom(CustomAction::DynamicMacroRecordStop(0), &s.a);

--- a/parser/src/custom_action.rs
+++ b/parser/src/custom_action.rs
@@ -71,6 +71,7 @@ pub enum CustomAction {
     LiveReloadNum(u16),
     LiveReloadFile(String),
     Repeat,
+    RepeatExcludeBSpace,
     CancelMacroOnRelease,
     CancelMacroOnNextPress(u32),
     DynamicMacroRecord(u16),

--- a/parser/src/custom_action.rs
+++ b/parser/src/custom_action.rs
@@ -71,7 +71,7 @@ pub enum CustomAction {
     LiveReloadNum(u16),
     LiveReloadFile(String),
     Repeat,
-    RepeatExcludeBSpace,
+    SmartRepeat,
     CancelMacroOnRelease,
     CancelMacroOnNextPress(u32),
     DynamicMacroRecord(u16),

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -240,6 +240,7 @@ pub struct Kanata {
     last_pressed_key: KeyCode,
     /// Keep track of last pressed non-backspace key for [`CustomAction::SmartRepeat`]
     last_last_pressed_key: KeyCode,
+    /// Keep track of how many non-backspace repeats have been used in a row for [`CustomAction::SmartRepeat`]
     repeat_count: i8,
     #[cfg(feature = "tcp_server")]
     /// Names of fake keys mapped to their index in the fake keys row
@@ -1607,8 +1608,6 @@ impl Kanata {
                             }
                         }
                         CustomAction::Repeat | CustomAction::SmartRepeat => {
-                          let n = self.repeat_count;
-                          log::error!("{n}");
                           let keycode = match (custact, self.repeat_count) {
                               (CustomAction::SmartRepeat, -1) => self.last_last_pressed_key,
                               (CustomAction::SmartRepeat, _) => {


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Add `smart-rpt`, which functions as outlined in #1595.

## Checklist

- Add documentation to docs/config.adoc
  - Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - Yes
- Update error messages
  - N/A
- Added tests, or did manual testing
  - Yes
