### PR TITLE
fix(windows,llhook): only clear stale PRESSED_KEYS entries on long-idle wake

### DIFF
--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -80,8 +80,12 @@ type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 /// State of pressed keys on the physical keyboard.
 ///
 /// Notably this is not what keys kanata is outputting as pressed.
+#[cfg(not(all(target_os = "windows", not(feature = "interception_driver"))))]
 pub(crate) static PRESSED_KEYS: Lazy<Mutex<HashSet<OsCode>>> =
     Lazy::new(|| Mutex::new(HashSet::default()));
+#[cfg(all(target_os = "windows", not(feature = "interception_driver")))]
+pub(crate) static PRESSED_KEYS: Lazy<Mutex<HashMap<OsCode, web_time::Instant>>> =
+    Lazy::new(|| Mutex::new(HashMap::default()));
 
 pub struct Kanata {
     /// Handle to some OS keyboard output mechanism.

--- a/src/kanata/windows/llhook.rs
+++ b/src/kanata/windows/llhook.rs
@@ -54,10 +54,12 @@ impl Kanata {
                 }
                 KeyValue::Press => {
                     let mut pressed_keys = PRESSED_KEYS.lock();
-                    if pressed_keys.contains(&key_event.code) {
-                        key_event.value = KeyValue::Repeat;
+                    if let std::collections::hash_map::Entry::Vacant(e) =
+                        pressed_keys.entry(key_event.code)
+                    {
+                        e.insert(web_time::Instant::now());
                     } else {
-                        pressed_keys.insert(key_event.code);
+                        key_event.value = KeyValue::Repeat;
                     }
                 }
                 _ => {}

--- a/src/kanata/windows/mod.rs
+++ b/src/kanata/windows/mod.rs
@@ -195,6 +195,9 @@ pub fn clear_states_from_inactivity(
         log::debug!("clearing keyberon normal key states due to inactivity");
         let layout = k.layout.bm();
         release_normalkey_states(layout);
-        PRESSED_KEYS.lock().clear();
+        let now = web_time::Instant::now();
+        PRESSED_KEYS
+            .lock()
+            .retain(|_, v| now - *v < std::time::Duration::from_secs(5));
     }
 }

--- a/src/tests/sim_tests/mod.rs
+++ b/src/tests/sim_tests/mod.rs
@@ -68,7 +68,12 @@ fn simulate_with_file_content<S: AsRef<str>>(
                         value: KeyValue::Press,
                     })
                     .expect("input handles fine");
+                    #[cfg(not(all(target_os = "windows", not(feature = "interception_driver"))))]
                     crate::PRESSED_KEYS.lock().insert(key_code);
+                    #[cfg(all(target_os = "windows", not(feature = "interception_driver")))]
+                    crate::PRESSED_KEYS
+                        .lock()
+                        .insert(key_code, web_time::Instant::now());
                 }
                 "u" => {
                     let key_code = str_to_oscode(val).expect("valid keycode");


### PR DESCRIPTION
Fixes https://github.com/jtroo/kanata/issues/1776 hopefully. Currently untested.