### PR TITLE
fix dead link for keys list

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Sample configuration files are found in [cfg_samples](./cfg_samples). The
 that is hopefully easy to understand but does not contain all features. The
 `kanata.kbd` contains an example of all features with documentation. The
 release assets also have a `kanata.kbd` file that is tested to work with that
-release. All key names can be found in the [keys module](./src/keys/mod.rs),
+release. All key names can be found in the [keys module](./parser/src/keys/mod.rs),
 and you can also define your own key names.
 
 </details>


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Updates the readme's link to the key names list, it's been dead for a little bit
## Checklist

- Add documentation to docs/config.adoc
  - [N/A]
- Add example and basic docs to cfg_samples/kanata.kbd
  - [N/A]
- Update error messages
  - [N/A]
- Added tests, or did manual testing
  - [N/A]
