### PR TITLE
feat(linux): add VID/PID to --list output

### DIFF
--- a/src/main_lib/mod.rs
+++ b/src/main_lib/mod.rs
@@ -87,8 +87,17 @@ pub(crate) fn list_devices_linux() {
     println!("Found {} keyboard device(s):\n", devices.len());
 
     for (i, (device, path)) in devices.iter().enumerate() {
-        println!("  {}. \"{}\"", i + 1, device.name().unwrap_or("Unknown"));
+        let name = device.name().unwrap_or("Unknown");
+        let input_id = device.input_id();
+        println!("  {}. \"{}\"", i + 1, name);
         println!("     Path: {path}");
+        println!(
+            "     Vendor ID: {} (0x{:04X}), Product ID: {} (0x{:04X})",
+            input_id.vendor(),
+            input_id.vendor(),
+            input_id.product(),
+            input_id.product()
+        );
         println!();
     }
 
@@ -107,7 +116,6 @@ pub(crate) fn list_devices_linux() {
     feature = "interception_driver",
     not(feature = "gui")
 ))]
-#[allow(dead_code)]
 struct WindowsDeviceInfo {
     display_name: String,        // For user display
     raw_wide_bytes: Vec<u8>,     // For kanata configuration (original wide string bytes)
@@ -119,7 +127,6 @@ struct WindowsDeviceInfo {
     feature = "interception_driver",
     not(feature = "gui")
 ))]
-#[allow(dead_code)]
 fn get_device_info(device_handle: winapi::um::winnt::HANDLE) -> Option<WindowsDeviceInfo> {
     use std::ffi::OsString;
     use std::os::windows::ffi::OsStringExt;
@@ -185,7 +192,6 @@ fn get_device_info(device_handle: winapi::um::winnt::HANDLE) -> Option<WindowsDe
     feature = "interception_driver",
     not(feature = "gui")
 ))]
-#[allow(dead_code)]
 pub(crate) fn list_devices_windows() {
     use std::ptr::null_mut;
     use winapi::shared::minwindef::{PUINT, UINT};
@@ -291,7 +297,6 @@ pub(crate) fn list_devices_windows() {
     feature = "interception_driver",
     not(feature = "gui")
 ))]
-#[allow(dead_code)]
 fn extract_hardware_id(device_name: &str) -> Option<String> {
     // Windows device names typically look like:
     // \\?\HID#VID_046D&PID_C52B&MI_01#7&1234abcd&0&0000#{884b96c3-56ef-11d1-bc8c-00a0c91405dd}


### PR DESCRIPTION
## Summary

- Add Vendor ID and Product ID display to Linux `--list` output using evdev's `input_id()` method
- Remove unnecessary `#[allow(dead_code)]` annotations from Windows device listing functions

## Details

This PR completes VID/PID support across all platforms in `kanata --list`:

| Platform | Status |
|----------|--------|
| macOS | ✅ Already supported via karabiner-driverkit v0.2.0 |
| Windows | ✅ Already supported via hardware ID parsing |
| Linux | ✅ **Now supported** via evdev `InputId` |

### Linux output now shows:
```
  1. "Device Name"
     Path: /dev/input/event0
     Vendor ID: 1234 (0x04D2), Product ID: 5678 (0x162E)
```

### Code cleanup:
Removed `#[allow(dead_code)]` from Windows functions (`WindowsDeviceInfo`, `get_device_info`, `list_devices_windows`, `extract_hardware_id`) as they are actively used.

## Context

This is a follow-up to #1717 (cross-platform `--list` support) and completes the work originally proposed in #1723 (which was closed). The macOS VID/PID support was completed via [driverkit PR psych3r/driverkit#7](https://github.com/psych3r/driverkit/pull/7) and integrated in #1813.

## Test plan

- [x] macOS: `cargo check` and `cargo clippy` pass locally
- [x] Linux/Windows: Relying on GitHub CI to verify builds pass on these platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)