### PR TITLE
feat: add string mappings for keypad parenthesis keys

### DIFF
--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -246,6 +246,8 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "NumpadSubtract" | "kp-" | "🔢₋" => OsCode::KEY_KPMINUS,
         "NumpadDecimal" | "kp." | "🔢．" => OsCode::KEY_KPDOT,
         "NumpadComma" | "kp," | "🔢⸴" =>OsCode::KEY_KPCOMMA,
+        "NumpadLeftParen" | "leftparen" | "lpar" | "kp(" | "🔢₍" => OsCode::KEY_KPLEFTPAREN,
+        "NumpadRightParen" | "rightparen" | "rpar" | "kp)" | "🔢₎" => OsCode::KEY_KPRIGHTPAREN,
         "ssrq" | "sys" => OsCode::KEY_SYSRQ,
         // Typically the Non-US backslash, near the left shift key
         "IntlBackslash" | "102d" | "lsgt" | "nubs" | "nonusbslash" | "﹨" | "<" => OsCode::KEY_102ND,


### PR DESCRIPTION
Closes #1742

## Describe your changes. Use imperative present tense.

Add defsrc mappings for KEY_KPLEFTPAREN and KEY_KPRIGHTPAREN:
- NumpadLeftParen, leftparen, lpar, kp(, 🔢₍
- NumpadRightParen, rightparen, rpar, kp), 🔢₎

## Checklist

- Add documentation to docs/config.adoc
  - [ ] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] N/A
- Update error messages
  - [ ] N/A
- Added tests, or did manual testing
  - [x] Yes
