### PR TITLE
feat: add --no-wait flag to skip exit prompt

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -4831,6 +4831,16 @@ Your final desired `defcfg` could be to have logging of layer changes as false.
 However, for testing purposes you may want to temporarily log the layers.
 This configuration forces logging to happen for this use case.
 
+[[args-no-wait]]
+=== Skip exit prompt: `--no-wait`
+
+By default, kanata displays "Press enter to exit" and waits for user input
+before exiting. This flag skips that prompt and exits immediately.
+
+This is useful when running kanata as a background service (e.g., systemd)
+where you want automatic restart on failure. Without this flag,
+the service would hang waiting for stdin input that never comes.
+
 [[args-linux-dev-symlink]]
 === Linux only - Device symlink path: `-s`, `--symlink-path`
 

--- a/docs/setup-linux.md
+++ b/docs/setup-linux.md
@@ -84,12 +84,16 @@ Environment=PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin
 # IOSchedulingClass=realtime
 # Nice=-20
 Type=simple
-ExecStart=/usr/bin/sh -c 'exec $$(which kanata) --cfg $${HOME}/.config/kanata/config.kbd'
-Restart=no
+ExecStart=/usr/bin/sh -c 'exec $$(which kanata) --cfg $${HOME}/.config/kanata/config.kbd --no-wait'
+Restart=on-failure
+RestartSec=3
 
 [Install]
 WantedBy=default.target
 ```
+
+Note: The `--no-wait` flag is required for `Restart=on-failure` to work.
+Without it, kanata waits for user input on exit, which blocks automatic restart.
 
 Make sure to update the executable location for sh in the snippet above.
 This would be the line starting with `ExecStart=/usr/bin/sh -c`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,12 +209,16 @@ mod cli {
 
 #[cfg(not(feature = "gui"))]
 pub fn main() -> Result<()> {
+    let args = Args::parse();
+    let no_wait = args.no_wait;
     let ret = cli::main_impl();
     if let Err(ref e) = ret {
         log::error!("{e}\n");
     }
-    eprintln!("\nPress enter to exit");
-    let _ = std::io::stdin().read_line(&mut String::new());
+    if !no_wait {
+        eprintln!("\nPress enter to exit");
+        let _ = std::io::stdin().read_line(&mut String::new());
+    }
     ret
 }
 

--- a/src/main_lib/args.rs
+++ b/src/main_lib/args.rs
@@ -105,4 +105,35 @@ kanata.kbd in the current working directory and
     /// configuration but want to default to no logging.
     #[arg(long, verbatim_doc_comment)]
     pub log_layer_changes: bool,
+
+    /// Skip the "Press enter to exit" prompt and exit immediately.
+    /// Useful for running kanata as a background service (e.g., systemd)
+    /// where automatic restart on failure is desired.
+    #[arg(long, verbatim_doc_comment)]
+    pub no_wait: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_wait_flag_default_false() {
+        let args = Args::try_parse_from(["kanata"]).unwrap();
+        assert!(!args.no_wait);
+    }
+
+    #[test]
+    fn no_wait_flag_enabled() {
+        let args = Args::try_parse_from(["kanata", "--no-wait"]).unwrap();
+        assert!(args.no_wait);
+    }
+
+    #[test]
+    fn no_wait_with_other_flags() {
+        let args =
+            Args::try_parse_from(["kanata", "--no-wait", "--nodelay", "-c", "test.kbd"]).unwrap();
+        assert!(args.no_wait);
+        assert!(args.nodelay);
+    }
 }


### PR DESCRIPTION
Closes #1610

## Describe your changes. Use imperative present tense.

Add CLI flag to exit immediately without waiting for Enter key press. This enables proper systemd service restart on failure, as the service no longer hangs waiting for stdin input.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
