### PR TITLE
fix: omit mouse activity from process-unmapped-keys

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1197,6 +1197,14 @@ fn parse_defsrc(
     if defcfg.process_unmapped_keys {
         for osc in 0..KEYS_IN_ROW as u16 {
             if let Some(osc) = OsCode::from_u16(osc) {
+                if osc.is_mouse_code() {
+                    // Bugfix #1879:
+                    // Auto-including mouse activity in mapped keys
+                    // seems strictly incorrect to do, so never do it.
+                    // Users can still choose to opt in if they want.
+                    // Auto-including mouse activity breaks many scenarios.
+                    continue;
+                }
                 match KeyCode::from(osc) {
                     KeyCode::No => {}
                     _ => {

--- a/parser/src/cfg/tests/defcfg.rs
+++ b/parser/src/cfg/tests/defcfg.rs
@@ -62,6 +62,9 @@ fn unmapped_except_keys_respects_deflocalkeys() {
                 KeyCode::No | KeyCode::K555 => {
                     assert!(!cfg.mapped_keys.contains(&osc));
                 }
+                _ if osc.is_mouse_code() => {
+                    assert!(!cfg.mapped_keys.contains(&osc));
+                }
                 _ => {
                     assert!(cfg.mapped_keys.contains(&osc));
                 }
@@ -74,7 +77,7 @@ fn unmapped_except_keys_respects_deflocalkeys() {
 fn unmapped_except_keys_is_removed_from_mapping() {
     let source = "
 (defcfg process-unmapped-keys (all-except 1 2 3))
-(defsrc)
+(defsrc mlft mmid)
 (deflayermap (name) 0 0)
 ";
     let cfg = parse_cfg(source)
@@ -90,6 +93,13 @@ fn unmapped_except_keys_is_removed_from_mapping() {
         if let Some(osc) = OsCode::from_u16(osc) {
             match KeyCode::from(osc) {
                 KeyCode::No | KeyCode::Kb1 | KeyCode::Kb2 | KeyCode::Kb3 => {
+                    assert!(!cfg.mapped_keys.contains(&osc));
+                }
+                // mlft, mmid
+                KeyCode::K272 | KeyCode::K274 => {
+                    assert!(cfg.mapped_keys.contains(&osc));
+                }
+                _ if osc.is_mouse_code() => {
                     assert!(!cfg.mapped_keys.contains(&osc));
                 }
                 _ => {

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -325,7 +325,7 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "unknown"))]
         "katakana" => OsCode::KEY_KATAKANA,
         "cnv" | "conv" | "henk" | "hnk" | "henkan" => OsCode::KEY_HENKAN,
-        "ncnv" | "mhnk" | "muhenkan" => OsCode::KEY_MUHENKAN,       
+        "ncnv" | "mhnk" | "muhenkan" => OsCode::KEY_MUHENKAN,
         #[cfg(target_os = "macos")]
         "Lang1" | "kana" => OsCode::KEY_HANGEUL,
         #[cfg(any(target_os = "macos", target_os = "unknown"))]
@@ -339,7 +339,6 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         #[cfg(target_os = "windows")]
         "PrintScreen" | "prtsc" | "prnt" | "⎙" => OsCode::KEY_PRINT,
 
-        // NOTE: these are linux and interception-only due to missing implementation for LLHOOK.
         "mlft" | "mouseleft" | "🖰1" | "‹🖰" => OsCode::BTN_LEFT,
         "mrgt" | "mouseright" | "🖰2" | "🖰›" => OsCode::BTN_RIGHT,
         "mmid" | "mousemid" | "🖰3" => OsCode::BTN_MIDDLE,
@@ -1173,6 +1172,24 @@ pub enum OsCode {
     KEY_766 = 766, // aliased to mvmt as a dummy input for use with mouse-movement-key
 
     KEY_MAX = 767,
+}
+
+impl OsCode {
+    pub fn is_mouse_code(&self) -> bool {
+        use OsCode::*;
+        matches!(
+            self,
+            BTN_LEFT
+                | BTN_RIGHT
+                | BTN_MIDDLE
+                | BTN_SIDE
+                | BTN_EXTRA
+                | MouseWheelUp
+                | MouseWheelDown
+                | MouseWheelLeft
+                | MouseWheelRight
+        )
+    }
 }
 
 use core::fmt;


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Fix #1879

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes