### PR TITLE
fix: evaluate switch transparency correctly

### DIFF
--- a/keyberon/src/chord.rs
+++ b/keyberon/src/chord.rs
@@ -185,11 +185,24 @@ impl<'a, T> ChordsV2<'a, T> {
             .find_map(|ach| match ach.status {
                 Unread => {
                     ach.status = Releasable;
-                    Some(Some(((0, ach.coordinate), ach.delay, ach.action)))
+                    // Note on LayerStack being default (empty):
+                    // A chordv2 is not allowed to use transparency,
+                    // so it does not need to handle this case.
+                    Some(Some((
+                        (0, ach.coordinate),
+                        ach.delay,
+                        ach.action,
+                        Default::default(),
+                    )))
                 }
                 UnreadReleased => {
                     ach.status = Released;
-                    Some(Some(((0, ach.coordinate), ach.delay, ach.action)))
+                    Some(Some((
+                        (0, ach.coordinate),
+                        ach.delay,
+                        ach.action,
+                        Default::default(),
+                    )))
                 }
                 Releasable | Released => None,
             })

--- a/src/tests/sim_tests/switch_sim_tests.rs
+++ b/src/tests/sim_tests/switch_sim_tests.rs
@@ -51,3 +51,21 @@ fn sim_switch_noop() {
     .no_time();
     assert_eq!("out:↓C out:↑C out:↓D out:↑D", result);
 }
+
+#[test]
+fn sim_switch_trans_not_top_layer() {
+    let result = simulate(
+        "
+        (defalias init (multi (layer-while-held l1) (layer-while-held l2) (layer-while-held l3) (layer-while-held l4)))
+        (defsrc a b)
+        (deflayer l0 c @init)
+        (deflayer l1 b @init)
+        (deflayer l2 (switch () _ break) @init)
+        (deflayer l3 _ @init)
+        (deflayer l4 _ @init)
+        ",
+        "d:b t:20 d:a t:10 u:a t:100 d:a t:10 u:a t:100",
+    )
+    .to_ascii();
+    assert_eq!("t:21ms dn:B t:9ms up:B t:101ms dn:B t:9ms up:B", result);
+}


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

* Fix #1884: make transparent action within switch forward its transparency resolution stack state.
* Fix another side-issue that caused confusion where the simulator differs in a code path from normal kanata in the parsing code. Deduplicated code to fix this bug.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes