### PR TITLE
Improve documentation on transparent keys

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -911,12 +911,12 @@ inaccurate with regards to its meaning.
 
 **Description**
 
-Kanata maintains a layer stack consisting of:
+Kanata maintains a layer stack consisting in order of:
 
-* `defsrc`
-* if `delegate-to-first-layer` is enabled: the first layer defined by `deflayer` or `deflayermap`
-* the base layer, manipulated by `layer-switch`
 * a stack of temporary layers, where each `layer-while-held` adds one layer on top
+* the base layer, manipulated by `layer-switch`
+* if `delegate-to-first-layer` is enabled: the first layer defined by `deflayer` or `deflayermap`
+* `defsrc`
 
 A single underscore `+_+` acts as a "transparent" key in the current layer.
 It will invoke the action assigned to the same key position on the next layer in the stack.


### PR DESCRIPTION
A proper layer stack was implemented in #752.
However, the documentation was not updated to reflect these changes; I just learned about them by coincidence.

Best,
PhiPro

## Checklist

- Add documentation to docs/config.adoc
  - [X] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [ ] Yes
