### PR TITLE
fix: add IntlRo and ro keys to wasm build

### DIFF
--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -331,7 +331,7 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         #[cfg(any(target_os = "macos", target_os = "unknown"))]
         "Lang2" | "eisu" => OsCode::KEY_HANJA,
 
-        #[cfg(any(target_os = "windows", target_os = "macos"))]
+        #[cfg(any(target_os = "windows", target_os = "macos", target_os = "unknown"))]
         "IntlRo" | "ro" => OsCode::KEY_RO,
 
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "unknown"))]


### PR DESCRIPTION
`IntlRo` and `ro` keys were mistakenly removed from wasm build in 9c5ccb7. This PR re-adds them.

## Describe your changes. Use imperative present tense.

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [ ] Yes
