### PR TITLE
fix: delayed timedout tap-hold cannot hold

### DIFF
--- a/src/tests/sim_tests/tap_hold_tests.rs
+++ b/src/tests/sim_tests/tap_hold_tests.rs
@@ -5,19 +5,38 @@ fn delayed_timedout_released_taphold_can_still_tap() {
     let result = simulate(
         "
         (defcfg concurrent-tap-hold yes )
-        (defsrc a j )
-        (deflayer base @a @j)
+        (defsrc a b j)
+        (deflayer base @a @b @j)
         (defalias
          a (tap-hold 200 1000 a lctl)
+         b (tap-hold-tap-keys 0 100 b c (j))
          j (tap-hold 200 500 j lsft))
         ",
-        "d:a t:100 d:j t:10 u:j t:1100 u:a t:50",
+        "d:a t:50 d:b t:50 d:j t:10 u:j t:100 u:b t:100 u:a t:50",
     )
     .to_ascii();
     assert_eq!(
-        "t:999ms dn:LCtrl t:2ms dn:J t:6ms up:J t:203ms up:LCtrl",
+        "t:310ms dn:A t:7ms dn:B t:7ms dn:J t:6ms up:J t:1ms up:B t:1ms up:A",
         result
     );
+}
+
+#[test]
+fn delayed_timedout_released_taphold_can_hold() {
+    let result = simulate(
+        "
+        (defcfg concurrent-tap-hold yes)
+        (defsrc a b)
+        (deflayer base @a @b)
+        (defalias
+          a (tap-hold 0 300 a b)
+          b (tap-hold 0 100 c d)
+        )
+        ",
+        "d:a t:50 d:b t:150 u:b t:50 u:a t:50",
+    )
+    .to_ascii();
+    assert_eq!("t:250ms dn:A t:7ms dn:D t:1ms up:D t:1ms up:A", result);
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/jtroo/kanata/issues/1889.

In comparison to https://github.com/jtroo/kanata/pull/1681, this PR skips at most `timeout - 1` ticks on a timedout concurrent `tap-hold`, instead of the full `delay`. This prevents `timeout` from becoming negative, or rather `saturating_sub` to clamp to 0, so that `original_timeout` is now equal to `ticks + timeout` and hence obsolete.

The strict inequality `self.timeout > gap_between_press_and_release` is changed to `>=`. If the strict version is desired, this line should be changed to `self.timeout + since_release > self.delay`.

The additional `(tap-hold-tap-keys 0 100 b c (j))` in the `delayed_timedout_released_taphold_can_still_tap` test ensures that additional checks that may resolve a timedout `tap-hold` are still performed, even if the key was already released.

As a side remark, it is currently not checked whether such actions that resolve a timedout `tap-hold` actually would have fallen within the `timeout`. For example, changing the simulation input for `delayed_timedout_released_taphold_can_still_tap` to <code>d:a t:50 d:b t:<b>150</b> d:j t:10 u:j t:100 u:b t:100 u:a t:50</code> should, in my opinion, resolve the `tap-hold` on `b` to a hold, and thus output `c` instead of `b`. That is because `j` was only pressed after the timeout would have expired.
However, this falls outside the scope of this PR.

Best,
PhiPro


## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
