### PR TITLE
fix: cross compilation for windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ strip-ansi-escapes = { version = "0.2.0", optional = true }
 open = { version = "5", features = ["shellexecute-on-windows"], optional = true}
 # shellexecute fix allows opening files already opened for writing, needs _detached mode
 
-[target.'cfg(target_os = "windows")'.build-dependencies]
+[build-dependencies]
 embed-resource = { version = "2.4.2", optional = true }
 indoc = { version = "2.0.4", optional = true }
 regex = { version = "1.10.4", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,12 @@
 fn main() -> std::io::Result<()> {
-    #[cfg(all(target_os = "windows", any(feature = "win_manifest", feature = "gui")))]
+    #[cfg(feature = "win_manifest")]
     {
         windows::build()?;
     }
     Ok(())
 }
 
-#[cfg(all(target_os = "windows", any(feature = "win_manifest", feature = "gui")))]
+#[cfg(feature = "win_manifest")]
 mod windows {
     use indoc::formatdoc;
     use regex::Regex;


### PR DESCRIPTION
Cross compilation for Windows is currently not possible because `target_os` deviates from its usual meaning when used for `build-dependencies` and inside `build.rs`. There, it refers to the `host` instead of the `target`.
As the `build-dependencies` are already marked optional and only enabled through the `win_manifest` feature, this PR simply removes the check for the `target_os`.
There does not seem to be a config based mechanism to only allow the `win_manifest` feature on a Windows target. If desired, such a check could however be included in the `build.rs` as a "runtime" check, i.e., at the time the buildscript is executed.

Additionally, this PR hides the features automatically generated for optional dependencies.

Best,
PhiPro

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [ ] Yes
