### PR TITLE
fix(macos): map repeat to press in simulated output

### DIFF
--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -204,7 +204,7 @@ impl TryFrom<KeyEvent> for InputEvent {
     fn try_from(item: KeyEvent) -> Result<Self, Self::Error> {
         if let Ok(pagecode) = PageCode::try_from(item.code) {
             let val = match item.value {
-                KeyValue::Press => 1,
+                KeyValue::Press | KeyValue::Repeat => 1,
                 _ => 0,
             };
             Ok(InputEvent {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,7 +4,6 @@ use std::sync::Mutex;
 #[cfg(all(
     feature = "simulated_output",
     not(feature = "simulated_input"),
-    not(target_os = "macos"),
     not(feature = "interception_driver")
 ))]
 mod sim_tests;


### PR DESCRIPTION
## Description
This PR fixes macOS simulated output so `KeyValue::Repeat` is encoded as a press, matching Linux/Windows behavior and allowing the simulator test suite to run on macOS.

## Motivation
On macOS, repeat events were being converted to releases, which produced incorrect simulated output and caused multiple `sim_tests` failures. This made it impractical to run the simulator tests on macOS.

## Changes
- Treat `KeyValue::Repeat` as a press (`value = 1`) in macOS `KeyEvent` -> `InputEvent` conversion
- Remove the macOS gate for `sim_tests` when `simulated_output` is enabled

## Why this is correct
macOS `InputEvent` only supports down/up (1/0); there is no distinct repeat value. Autorepeat is represented as repeated key-down events, and Windows already maps Repeat to down. This change makes macOS consistent and avoids the incorrect release mapping.

## Mac verification
Ran on macOS with a fakekey + repeat sequence; output shows repeat as `↓` (press), and sim output behaves as expected. With this fix, the full `sim_tests` suite passes on macOS.

## Testing
```bash
cargo test -p kanata --features simulated_output
```