### PR TITLE
fix(tcp): Add request_id echo support to Hello/HelloOk

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -4869,8 +4869,8 @@ When `wait` is `true`, the server blocks until the reload completes or times out
 |===
 | Command | Description
 
-| `{"Hello":{}}`
-| Request server version and capabilities. Server responds with `HelloOk`.
+| `{"Hello":{}}` or `{"Hello":{"request_id":123}}`
+| Request server version and capabilities. Server responds with `HelloOk`. If `request_id` is provided, it will be echoed in the response for correlation.
 |===
 
 ==== Server Messages
@@ -4915,8 +4915,8 @@ These are sent in response to client queries:
 | `{"CurrentLayerInfo":{"name":"base","cfg_text":"..."}}`
 | Response to `RequestCurrentLayerInfo`. Contains the layer name and its full configuration text.
 
-| `{"HelloOk":{"version":"1.11.0","protocol":1,"capabilities":[...]}}`
-| Response to `Hello`. Contains server version, protocol version, and supported capabilities.
+| `{"HelloOk":{"version":"1.11.0","protocol":1,"capabilities":[...],"request_id":123}}`
+| Response to `Hello`. Contains server version, protocol version, and supported capabilities. If the client sent a `request_id`, it is echoed back for response correlation.
 
 | `{"ReloadResult":{"ok":true}}`
 | Response to reload commands when `wait` was `true`. Indicates whether the config reload succeeded. If timed out, includes `timeout_ms`.

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -293,7 +293,7 @@ impl TcpServer {
                                                 }
                                             }
                                             // New command: Hello - capability detection
-                                            ClientMessage::Hello {} => {
+                                            ClientMessage::Hello { request_id } => {
                                                 let version = env!("CARGO_PKG_VERSION").to_string();
                                                 let capabilities = vec![
                                                     "reload".to_string(),
@@ -308,6 +308,7 @@ impl TcpServer {
                                                     version,
                                                     protocol: 1,
                                                     capabilities,
+                                                    request_id,
                                                 };
                                                 match stream.write_all(&msg.as_bytes()) {
                                                     Ok(_) => {


### PR DESCRIPTION
## Summary

Adds `request_id` echo support to the Hello/HelloOk handshake, enabling reliable response correlation when broadcast events may interleave with command responses.

## Problem

When a client sends `{"Hello":{}}`, broadcast events (LayerChange, ConfigFileReload, etc.) can arrive before the HelloOk response. Clients that use request_id correlation (like KeyPath) have no way to distinguish their HelloOk response from interleaved broadcasts without parsing every message type.

## Solution

Add optional `request_id` field to both Hello (client→server) and HelloOk (server→client):

**Before:**
```json
Client: {"Hello":{}}
Server: {"HelloOk":{"version":"1.11.0","protocol":1,"capabilities":[...]}}
```

**After:**
```json
Client: {"Hello":{"request_id":12345}}
Server: {"HelloOk":{"version":"1.11.0","protocol":1,"capabilities":[...],"request_id":12345}}
```

## Backwards Compatibility

Fully backwards compatible:
- Clients not sending `request_id` receive HelloOk without the field
- `skip_serializing_if = "Option::is_none"` ensures clean JSON for None values
- Existing clients continue to work unchanged

## Changes

- `tcp_protocol/src/lib.rs`: Add `request_id: Option<u64>` to Hello and HelloOk
- `src/tcp_server.rs`: Echo request_id from Hello to HelloOk
- `docs/config.adoc`: Document request_id usage
- Tests: Add serialization tests for request_id handling

## Testing

```
cargo test -p kanata-tcp-protocol
```

All 9 tests pass, including 4 new tests for request_id behavior.