### PR TITLE
doc: add kanata-switcher to application-aware layer switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Some directories are exceptions:
    - [nata (Linux)](https://github.com/mdSlash/nata)
    - [kanata-vk-agent (macOS)](https://github.com/devsunb/kanata-vk-agent)
    - [hyprkan (Linux)](https://github.com/mdSlash/hyprkan)
+   - [kanata-switcher (Linux, all DEs)](https://github.com/7mind/kanata-switcher)
 
 ## What does the name mean?
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add [kanata-switcher](https://github.com/7mind/kanata-switcher) to layer switcher section

Note: I just had to add the `all DEs` qualifier - sorry! All the other listed Linux switchers support only tiling WMs or X11, while kanata-switcher is (for now) the only tool that supports Wayland DEs: GNOME/KDE/COSMIC/wlroots & X11 all in one.