### PR TITLE
fix: deduplicate historical keys in chordsv1

### DIFF
--- a/keyberon/src/layout/contextual_execution.rs
+++ b/keyberon/src/layout/contextual_execution.rs
@@ -1,0 +1,26 @@
+//! Information about what state the keyberon layout is in
+//! and handling conditional execution based on state.
+
+use super::*;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ContextualExecution {
+    /// Known pause case:
+    /// - When replicating output keys during chordv1 activation.
+    pub(super) pause_historical_keys_updates: bool,
+}
+
+impl ContextualExecution {
+    pub(super) fn new() -> Self {
+        Self {
+            pause_historical_keys_updates: false,
+        }
+    }
+
+    /// Push into historical keys while checking the pause state.
+    pub(super) fn push_historical_key<T: Copy>(&self, h: &mut History<T>, e: T) {
+        if !self.pause_historical_keys_updates {
+            h.push_front(e);
+        }
+    }
+}

--- a/src/tests/sim_tests/chord_sim_tests.rs
+++ b/src/tests/sim_tests/chord_sim_tests.rs
@@ -452,3 +452,38 @@ u:t t:10
     .to_ascii();
     assert_eq!("dn:RShift t:11ms dn:T t:4ms up:RShift t:7ms up:T", result);
 }
+
+#[test]
+fn sim_chordsv1_key_history_updates_once() {
+    let result = simulate(
+        "
+(defsrc)
+(defchords iobspc 50
+  (i o) bspc
+)
+(deflayermap (base)
+  i (chord iobspc i)
+  o (chord iobspc o)
+  t (switch
+    ((key-history bspc 3)) a fallthrough
+    ((key-history bspc 2)) b fallthrough
+    ((key-history bspc 1)) c fallthrough
+  )
+)
+        ",
+        "
+d:i d:o t:10
+u:i u:o t:10
+d:t u:t t:10
+d:t u:t t:10
+",
+    )
+    .to_ascii();
+    // For first press of `t`, only position 1 should be filled.
+    // The key history should unpause, so on pressing `t` again,
+    // position 2 is now where bspc is because C was sent.
+    assert_eq!(
+        "t:1ms dn:BSpace t:10ms up:BSpace t:10ms dn:C t:1ms up:C t:9ms dn:B t:1ms up:B",
+        result
+    );
+}


### PR DESCRIPTION
Fix #1932 