### PR TITLE
feat: add TapActivated and HoldActivated TCP server events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ regex = { version = "1.10.4", optional = true }
 [features]
 default = ["tcp_server","win_sendinput_send_scancodes", "zippychord"]
 perf_logging = []
-tcp_server = ["dep:serde_json"]
+tcp_server = ["dep:serde_json", "kanata-keyberon/tap_hold_tracker"]
 win_sendinput_send_scancodes = ["kanata-parser/win_sendinput_send_scancodes"]
 win_llhook_read_scancodes = ["kanata-parser/win_llhook_read_scancodes"]
 winiov2 = ["win_llhook_read_scancodes","win_sendinput_send_scancodes"]

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -4940,6 +4940,12 @@ These are sent automatically when events occur:
 
 | `{"Error":{"msg":"error description"}}`
 | Sent when an error occurs processing a command.
+
+| `{"HoldActivated":{"key":"caps"}}`
+| Sent when a tap-hold key transitions to hold state. The `key` field is the physical key name.
+
+| `{"TapActivated":{"key":"a"}}`
+| Sent when a tap-hold key triggers its tap action. The `key` field is the physical key name.
 |===
 
 ===== Query Responses
@@ -4963,7 +4969,7 @@ These are sent in response to client queries:
 | Response to `RequestCurrentLayerInfo`. Contains the layer name and its full configuration text.
 
 | `{"HelloOk":{"version":"1.11.0","protocol":1,"capabilities":[...]}}`
-| Response to `Hello`. Contains server version, protocol version, and supported capabilities.
+| Response to `Hello`. Contains server version, protocol version, and supported capabilities. Includes `hold-activated` and `tap-activated`.
 
 | `{"ReloadResult":{"ok":true}}`
 | Response to reload commands when `wait` was `true`. Indicates whether the config reload succeeded. If timed out, includes `timeout_ms`.

--- a/keyberon/Cargo.toml
+++ b/keyberon/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["no-std"]
 license = "MIT"
 readme = "README.md"
 
+[features]
+tap_hold_tracker = []
+
 [dependencies]
 kanata-keyberon-macros = { version = "0.2.0" }
 heapless = "0.7.16"

--- a/keyberon/src/lib.rs
+++ b/keyberon/src/lib.rs
@@ -6,3 +6,4 @@ pub mod chord;
 pub mod key_code;
 pub mod layout;
 mod multikey_buffer;
+pub mod tap_hold_tracker;

--- a/keyberon/src/tap_hold_tracker.rs
+++ b/keyberon/src/tap_hold_tracker.rs
@@ -1,0 +1,119 @@
+//! Tracks tap-hold activation events for external consumers (e.g. TCP broadcast).
+//!
+//! When the `tap_hold_tracker` feature is enabled, this module stores the
+//! coordinate of the most recent hold/tap activation so that higher-level code
+//! can relay it over the network.  When the feature is disabled the tracker is
+//! a zero-sized no-op — all setters are empty and all getters return `None`.
+//!
+//! The `config` parameter on the setters accepts a `&WaitingConfig` reference;
+//! the `matches!` guard lives inside the method body so that the no-op stub's
+//! empty body causes the compiler to eliminate the call entirely.
+
+#[cfg(feature = "tap_hold_tracker")]
+mod inner {
+    use crate::layout::{KCoord, WaitingConfig};
+
+    /// Information about a tap-hold key that just transitioned to hold state.
+    #[derive(Debug, Clone, Copy)]
+    pub struct HoldActivatedInfo {
+        /// The key coordinate (row, column).
+        pub coord: KCoord,
+    }
+
+    /// Information about a tap-hold key that just triggered its tap action.
+    #[derive(Debug, Clone, Copy)]
+    pub struct TapActivatedInfo {
+        /// The key coordinate (row, column).
+        pub coord: KCoord,
+    }
+
+    /// Records the most recent tap-hold activation event.
+    #[derive(Debug, Default)]
+    pub struct TapHoldTracker {
+        hold_activated: Option<HoldActivatedInfo>,
+        tap_activated: Option<TapActivatedInfo>,
+    }
+
+    impl TapHoldTracker {
+        pub(crate) fn set_hold_activated<'a, T: std::fmt::Debug>(
+            &mut self,
+            coord: KCoord,
+            config: &WaitingConfig<'a, T>,
+        ) {
+            if matches!(config, WaitingConfig::HoldTap(..)) {
+                self.hold_activated = Some(HoldActivatedInfo { coord });
+            }
+        }
+
+        pub(crate) fn set_tap_activated<'a, T: std::fmt::Debug>(
+            &mut self,
+            coord: KCoord,
+            config: &WaitingConfig<'a, T>,
+        ) {
+            if matches!(config, WaitingConfig::HoldTap(..)) {
+                self.tap_activated = Some(TapActivatedInfo { coord });
+            }
+        }
+
+        pub fn take_hold_activated(&mut self) -> Option<HoldActivatedInfo> {
+            self.hold_activated.take()
+        }
+
+        pub fn take_tap_activated(&mut self) -> Option<TapActivatedInfo> {
+            self.tap_activated.take()
+        }
+    }
+}
+
+#[cfg(not(feature = "tap_hold_tracker"))]
+mod inner {
+    use crate::layout::{KCoord, WaitingConfig};
+
+    /// Stub: no coordinate data stored when the feature is disabled.
+    #[derive(Debug, Clone, Copy)]
+    pub struct HoldActivatedInfo {
+        /// The key coordinate (row, column).
+        pub coord: KCoord,
+    }
+
+    /// Stub: no coordinate data stored when the feature is disabled.
+    #[derive(Debug, Clone, Copy)]
+    pub struct TapActivatedInfo {
+        /// The key coordinate (row, column).
+        pub coord: KCoord,
+    }
+
+    /// Zero-sized no-op tracker when the feature is disabled.
+    #[derive(Debug, Default)]
+    pub struct TapHoldTracker;
+
+    impl TapHoldTracker {
+        #[inline(always)]
+        pub(crate) fn set_hold_activated<'a, T: std::fmt::Debug>(
+            &mut self,
+            _coord: KCoord,
+            _config: &WaitingConfig<'a, T>,
+        ) {
+        }
+
+        #[inline(always)]
+        pub(crate) fn set_tap_activated<'a, T: std::fmt::Debug>(
+            &mut self,
+            _coord: KCoord,
+            _config: &WaitingConfig<'a, T>,
+        ) {
+        }
+
+        #[inline(always)]
+        pub fn take_hold_activated(&mut self) -> Option<HoldActivatedInfo> {
+            None
+        }
+
+        #[inline(always)]
+        pub fn take_tap_activated(&mut self) -> Option<TapActivatedInfo> {
+            None
+        }
+    }
+}
+
+pub use inner::*;

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -316,6 +316,8 @@ impl TcpServer {
                                                     "layer-names".to_string(),
                                                     "fake-key-names".to_string(),
                                                     "layer-change".to_string(),
+                                                    "hold-activated".to_string(),
+                                                    "tap-activated".to_string(),
                                                     "current-layer-name".to_string(),
                                                     "current-layer-info".to_string(),
                                                     "fake-key".to_string(),

--- a/tcp_protocol/src/lib.rs
+++ b/tcp_protocol/src/lib.rs
@@ -48,6 +48,16 @@ pub enum ServerMessage {
         #[serde(skip_serializing_if = "Option::is_none")]
         timeout_ms: Option<u64>,
     },
+    /// Sent when a tap-hold key transitions to hold state.
+    /// The `key` field is the physical key name (e.g., `"caps"`, `"a"`).
+    HoldActivated {
+        key: String,
+    },
+    /// Sent when a tap-hold key triggers its tap action.
+    /// The `key` field is the physical key name (e.g., `"caps"`, `"a"`).
+    TapActivated {
+        key: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -251,5 +261,23 @@ mod tests {
         let msg = ServerMessage::FakeKeyNames { names: vec![] };
         let json = serde_json::to_string(&msg).unwrap();
         assert_eq!(json, r#"{"FakeKeyNames":{"names":[]}}"#);
+    }
+
+    #[test]
+    fn test_hold_activated_json_format() {
+        let msg = ServerMessage::HoldActivated {
+            key: "caps".to_string(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert_eq!(json, r#"{"HoldActivated":{"key":"caps"}}"#);
+    }
+
+    #[test]
+    fn test_tap_activated_json_format() {
+        let msg = ServerMessage::TapActivated {
+            key: "a".to_string(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert_eq!(json, r#"{"TapActivated":{"key":"a"}}"#);
     }
 }


### PR DESCRIPTION
I'm building a macOS keyboard overlay app that visualizes key behavior
in real time over TCP. Currently there's no way for a TCP client to
know whether a tap-hold key resolved as tap or hold — the client only
sees the resulting keycode, not which path the state machine took.

The existing `push-msg` action can partially work around this, but it
requires the user to manually annotate every tap-hold definition in
their config with custom messages, and the output is freeform JSON
with no consistent structure for clients to parse. These two events
provide automatic, structured notification without any config changes.

Add two new ServerMessage broadcast events sent to TCP clients when
tap-hold keys resolve their ambiguity:

- `HoldActivated { key }` — sent when a tap-hold key transitions to
  hold state (timeout expiry, PermissiveHold, or HoldOnOtherKeyPress)
- `TapActivated { key }` — sent when a tap-hold key triggers its tap
  action (quick press-release)

The `key` field contains the physical key name (e.g. `"caps"`, `"a"`),
matching the format used by other ServerMessage variants.

Both events are advertised in `HelloOk.capabilities` as
`hold-activated` and `tap-activated` for client feature detection.

**Scope:** These events fire exclusively for `HoldTap` actions on
physical keys. Chord, tap-dance, and fake-key activations are
explicitly excluded — all three keyberon resolution paths
(`waiting_into_hold`, `waiting_into_tap`, `waiting_into_timeout`) are
guarded with `matches!(w.config, WaitingConfig::HoldTap(..))`, and
emission filters on `NORMAL_KEY_ROW`.

**Use case:** Enables TCP clients (keyboard overlay visualizers,
accessibility tools) to show real-time tap/hold resolution state,
helping users understand and debug their tap-hold configurations.
Related: #1182.

**Future work:** If you're amenable, broader event coverage for chords,
tap-dance, and fake keys could follow in separate PRs using dedicated
event types (e.g. `ChordActivated`, `TapDanceActivated`) to keep the
API contract for these two events stable.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A — passive broadcast events, no config syntax changes
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes — 8 new tests: 4 positive (timeout hold, PermissiveHold,
    HoldOnOtherKeyPress, tap release), 2 negative (chord and tap-dance
    do not emit), 2 serialization format checks