### PR TITLE
fix(macos): recover from DriverKit output loss instead of bricking keyboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,8 +853,7 @@ dependencies = [
 [[package]]
 name = "karabiner-driverkit"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000dc9189dc126ed5ec1ba477b3f524d88f1527260b423dbc79d23356c82165f"
+source = "git+https://github.com/malpern/driverkit.git?branch=fix%2Fexpose-sink-health#a1309eeb1429e0f9b1209fa94fe7c6fb6a729f4f"
 dependencies = [
  "cc",
  "os_info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ kanata-tcp-protocol = { path = "tcp_protocol", version = "0.190.0" }
 arboard = "3.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-karabiner-driverkit = "0.1.5"
+karabiner-driverkit = { git = "https://github.com/malpern/driverkit.git", branch = "fix/expose-sink-health" }
 objc = "0.2.7"
 core-graphics = "0.24.0"
 open = { version = "5", optional = true }

--- a/src/kanata/macos.rs
+++ b/src/kanata/macos.rs
@@ -1,5 +1,6 @@
 use super::*;
 use anyhow::{Result, anyhow, bail};
+use karabiner_driverkit::is_sink_ready;
 use log::info;
 use parking_lot::Mutex;
 use std::convert::TryFrom;
@@ -8,67 +9,128 @@ use std::sync::mpsc::SyncSender as Sender;
 
 impl Kanata {
     /// Enter an infinite loop that listens for OS key events and sends them to the processing thread.
+    ///
+    /// Contains an outer recovery loop: if the DriverKit output connection drops
+    /// (daemon crash, not installed, etc.), input devices are released so the
+    /// keyboard returns to normal operation. When the connection recovers,
+    /// devices are re-seized and remapping resumes.
     pub fn event_loop(kanata: Arc<Mutex<Self>>, tx: Sender<KeyEvent>) -> Result<()> {
         info!("entering the event loop");
 
         let k = kanata.lock();
         let allow_hardware_repeat = k.allow_hardware_repeat;
-        let mut kb = match KbdIn::new(k.include_names.clone(), k.exclude_names.clone()) {
-            Ok(kbd_in) => kbd_in,
-            Err(e) => bail!("failed to open keyboard device(s): {}", e),
-        };
+        let include_names = k.include_names.clone();
+        let exclude_names = k.exclude_names.clone();
         drop(k);
 
         loop {
-            let event = kb.read().map_err(|e| anyhow!("failed read: {}", e))?;
-
-            let mut key_event = match KeyEvent::try_from(event) {
-                Ok(ev) => ev,
-                _ => {
-                    // Pass-through unrecognized keys
-                    log::debug!("{event:?} is unrecognized!");
-                    let mut kanata = kanata.lock();
-                    kanata
-                        .kbd_out
-                        .write(event)
-                        .map_err(|e| anyhow!("failed write: {}", e))?;
-                    continue;
-                }
+            // --- (Re)create KbdIn and grab input devices ---
+            let mut kb = match KbdIn::new(include_names.clone(), exclude_names.clone()) {
+                Ok(kbd_in) => kbd_in,
+                Err(e) => bail!("failed to open keyboard device(s): {}", e),
             };
 
-            check_for_exit(&key_event);
+            info!("keyboard grabbed, entering event processing loop");
 
-            if key_event.value == KeyValue::Repeat && !allow_hardware_repeat {
-                continue;
-            }
-
-            if !MAPPED_KEYS.lock().contains(&key_event.code) {
-                log::debug!("{key_event:?} is not mapped");
-                let mut kanata = kanata.lock();
-                kanata
-                    .kbd_out
-                    .write(event)
-                    .map_err(|e| anyhow!("failed write: {}", e))?;
-                continue;
-            }
-
-            log::debug!("sending {key_event:?} to processing loop");
-
-            match key_event.value {
-                KeyValue::Release => {
-                    PRESSED_KEYS.lock().remove(&key_event.code);
+            // --- Inner event processing loop ---
+            let needs_recovery = loop {
+                // Check output health before blocking on input
+                if !is_sink_ready() {
+                    log::warn!("DriverKit output lost — releasing input devices");
+                    break true;
                 }
-                KeyValue::Press => {
-                    let mut pressed_keys = PRESSED_KEYS.lock();
-                    if pressed_keys.contains(&key_event.code) {
-                        key_event.value = KeyValue::Repeat;
-                    } else {
-                        pressed_keys.insert(key_event.code);
+
+                let event = match kb.read() {
+                    Ok(ev) => ev,
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                        // Pipe closed by release_input_only() — expected during recovery
+                        log::info!("input pipe EOF — devices were released");
+                        break true;
+                    }
+                    Err(e) => return Err(anyhow!("failed read: {}", e)),
+                };
+
+                let mut key_event = match KeyEvent::try_from(event) {
+                    Ok(ev) => ev,
+                    _ => {
+                        log::debug!("{event:?} is unrecognized!");
+                        let mut kanata = kanata.lock();
+                        match kanata.kbd_out.write(event) {
+                            Ok(()) => continue,
+                            Err(e) if e.kind() == std::io::ErrorKind::NotConnected => {
+                                log::warn!(
+                                    "DriverKit output lost during write — releasing input devices"
+                                );
+                                break true;
+                            }
+                            Err(e) => return Err(anyhow!("failed write: {}", e)),
+                        }
+                    }
+                };
+
+                check_for_exit(&key_event);
+
+                if key_event.value == KeyValue::Repeat && !allow_hardware_repeat {
+                    continue;
+                }
+
+                if !MAPPED_KEYS.lock().contains(&key_event.code) {
+                    log::debug!("{key_event:?} is not mapped");
+                    let mut kanata = kanata.lock();
+                    match kanata.kbd_out.write(event) {
+                        Ok(()) => continue,
+                        Err(e) if e.kind() == std::io::ErrorKind::NotConnected => {
+                            log::warn!(
+                                "DriverKit output lost during write — releasing input devices"
+                            );
+                            break true;
+                        }
+                        Err(e) => return Err(anyhow!("failed write: {}", e)),
                     }
                 }
-                _ => {}
+
+                log::debug!("sending {key_event:?} to processing loop");
+
+                match key_event.value {
+                    KeyValue::Release => {
+                        PRESSED_KEYS.lock().remove(&key_event.code);
+                    }
+                    KeyValue::Press => {
+                        let mut pressed_keys = PRESSED_KEYS.lock();
+                        if pressed_keys.contains(&key_event.code) {
+                            key_event.value = KeyValue::Repeat;
+                        } else {
+                            pressed_keys.insert(key_event.code);
+                        }
+                    }
+                    _ => {}
+                }
+                tx.try_send(key_event)?;
+            };
+
+            if !needs_recovery {
+                break Ok(());
             }
-            tx.try_send(key_event)?;
+
+            // --- Release input so the keyboard works normally (unseized) ---
+            kb.release_input();
+            drop(kb);
+
+            info!(
+                "Input devices released. Keyboard is usable (without remapping). \
+                 Waiting for DriverKit output to recover..."
+            );
+
+            // --- Wait for the pqrs client heartbeat to re-establish the connection ---
+            loop {
+                std::thread::sleep(std::time::Duration::from_millis(500));
+                if is_sink_ready() {
+                    info!("DriverKit output recovered — re-grabbing input devices");
+                    break;
+                }
+            }
+
+            // The outer loop will create a new KbdIn and resume remapping.
         }
     }
 

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -56,11 +56,15 @@ impl From<InputEvent> for DKEvent {
     }
 }
 
-pub struct KbdIn {}
+pub struct KbdIn {
+    grabbed: bool,
+}
 
 impl Drop for KbdIn {
     fn drop(&mut self) {
-        release();
+        if self.grabbed {
+            release();
+        }
     }
 }
 
@@ -129,7 +133,29 @@ impl KbdIn {
 
         if !device_names.is_empty() || register_device("") {
             if grab() {
-                Ok(Self {})
+                // Wait for the DriverKit virtual keyboard to become ready.
+                // The pqrs client connects asynchronously; give it time.
+                let mut ready = false;
+                for i in 0..100 {
+                    if is_sink_ready() {
+                        ready = true;
+                        break;
+                    }
+                    if i % 10 == 0 && i > 0 {
+                        log::info!(
+                            "Waiting for DriverKit virtual keyboard... ({:.1}s)",
+                            i as f64 * 0.1
+                        );
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+                if !ready {
+                    log::warn!(
+                        "DriverKit virtual keyboard not ready after 10s. \
+                         Key output may fail until the daemon connects."
+                    );
+                }
+                Ok(Self { grabbed: true })
             } else {
                 Err(anyhow!("grab failed"))
             }
@@ -148,9 +174,41 @@ impl KbdIn {
             code: 0,
         };
 
-        wait_key(&mut event);
+        let got_event = wait_key(&mut event);
+        if got_event == 0 {
+            // Pipe returned EOF — input was released via release_input_only()
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "input pipe closed (devices released)",
+            ));
+        }
 
         Ok(InputEvent::new(event))
+    }
+
+    /// Release seized input devices without tearing down the output connection.
+    /// After this call, `read()` will return `UnexpectedEof`.
+    pub fn release_input(&mut self) {
+        if self.grabbed {
+            release_input_only();
+            self.grabbed = false;
+        }
+    }
+
+    /// Re-seize input devices after a previous `release_input()`.
+    /// Returns true if at least one device was seized.
+    pub fn regrab_input(&mut self) -> bool {
+        if !self.grabbed {
+            let ok = karabiner_driverkit::regrab_input();
+            self.grabbed = ok;
+            ok
+        } else {
+            true
+        }
+    }
+
+    pub fn is_grabbed(&self) -> bool {
+        self.grabbed
     }
 }
 
@@ -253,7 +311,13 @@ impl KbdOut {
     pub fn write(&mut self, event: InputEvent) -> Result<(), io::Error> {
         let mut devent = event.into();
         log::debug!("Attempting to write {event:?} {devent:?}");
-        let _sent = send_key(&mut devent);
+        let rc = send_key(&mut devent);
+        if rc == 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "DriverKit virtual keyboard not ready (sink disconnected)",
+            ));
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Add recovery loop to the macOS event loop: on DriverKit output loss, release input devices so the keyboard works normally, then re-grab when the connection recovers
- `KbdOut::write()` now returns `NotConnected` when the virtual keyboard sink is unavailable (send_key returns error code 2)
- `KbdIn::read()` detects pipe EOF from `release_input_only()` to cleanly unblock the blocking read
- `KbdIn::new()` waits up to 10s for sink readiness after `grab()`, with progress logging

## Motivation

Fixes #1792.

When the Karabiner DriverKit daemon crashes or stops, kanata keeps input devices seized but can't emit keystrokes — bricking the keyboard. With `KeepAlive=true` the machine becomes completely unusable and requires SSH or power button to recover.

## How It Works

```
GRABBED (normal operation)
    │
    ├── write error (NotConnected) or !is_sink_ready()
    │
    ▼
RELEASING ── release_input_only() ── keyboard works normally (unseized)
    │
    ├── poll is_sink_ready() every 500ms
    │   (pqrs client heartbeat auto-reconnects)
    │
    ▼
RE-GRABBING ── new KbdIn ── back to GRABBED
```

The outer recovery loop in `event_loop()`:
1. **Inner loop**: Normal event processing. On write error (`NotConnected`) or pipe EOF, breaks out
2. **Release**: Calls `release_input()` to release seized devices while keeping the output connection alive
3. **Wait**: Polls `is_sink_ready()` every 500ms until the pqrs client's heartbeat re-establishes the connection
4. **Re-grab**: Creates a new `KbdIn` which calls `register_device()` + `grab()` to re-seize input

## Dependencies

Depends on [Psych3r/driverkit#11](https://github.com/psych3r/driverkit/pull/11) which exposes the connection health state from the pqrs client library. The `Cargo.toml` currently points to the branch; will be updated to a version number after that PR is merged and published.

## Files Changed

| File | Changes |
|------|---------|
| `src/oskbd/macos.rs` | `KbdIn.grabbed` field, `release_input()`/`regrab_input()`/`is_grabbed()` methods, `read()` EOF detection, `write()` health check, sink readiness wait in `new()` |
| `src/kanata/macos.rs` | Outer recovery loop around the event loop |
| `Cargo.toml` | Updated `karabiner-driverkit` dependency to fork branch |
| `Cargo.lock` | Updated lockfile |

## Test plan

- [ ] `cargo check` passes (verified)
- [ ] Start kanata, confirm normal remapping works
- [ ] Kill daemon: `sudo launchctl bootout system /Library/LaunchDaemons/org.pqrs.Karabiner.VirtualHIDDeviceManager.plist`
- [ ] **Before fix**: keyboard dead, unrecoverable without SSH/power button
- [ ] **After fix**: keyboard regains normal (unseized) function within ~3s, logs show "Releasing input devices"
- [ ] Restart daemon: `sudo launchctl bootstrap system /Library/LaunchDaemons/org.pqrs.Karabiner.VirtualHIDDeviceManager.plist`
- [ ] **After fix**: kanata re-seizes and resumes remapping within ~5s, logs show "DriverKit output recovered"

Note: @jtroo — I can test this on my macOS machine since you don't have one. Happy to provide logs and screen recordings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)