### PR TITLE
feat(linux): add virtual to possible output bus type configuration

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -4471,7 +4471,7 @@ The default value is kanata.
 === Linux only: linux-output-device-bus-type
 
 Kanata on Linux needs to declare a "bus type" for its evdev output device.
-The options are `USB` and `I8042`, with the default as `I8042`.
+The options are `USB`, `I8042`, and `virtual`, with the default as `I8042`.
 Using USB can https://github.com/jtroo/kanata/pull/661[break disable-touchpad-while-typing on Wayland].
 But using I8042 appears to break https://github.com/jtroo/kanata/issues/1131[some other scenarios].
 Thus the output bus type is configurable.

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -61,6 +61,7 @@ impl Default for CfgLinuxOptions {
 pub enum LinuxCfgOutputBusType {
     BusUsb,
     BusI8042,
+    BusVirtual,
 }
 
 #[cfg(any(target_os = "macos", target_os = "unknown"))]
@@ -414,10 +415,10 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                     "linux-output-device-bus-type" => {
                         let bus_type = sexpr_to_str_or_err(val, label)?;
                         match bus_type {
-                            "USB" | "I8042" => {}
+                            "USB" | "I8042" | "virtual" => {}
                             _ => bail_expr!(
                                 val,
-                                "Invalid value for linux-output-device-bus-type.\nExpected one of: USB or I8042"
+                                "Invalid value for linux-output-device-bus-type.\nExpected one of: USB | I8042 | virtual"
                             ),
                         };
                         #[cfg(any(
@@ -429,6 +430,7 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                             let bus_type = match bus_type {
                                 "USB" => LinuxCfgOutputBusType::BusUsb,
                                 "I8042" => LinuxCfgOutputBusType::BusI8042,
+                                "virtual" => LinuxCfgOutputBusType::BusVirtual,
                                 _ => unreachable!("validated earlier"),
                             };
                             cfg.linux_opts.linux_output_bus_type = bus_type;

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -403,6 +403,7 @@ impl Kanata {
             match cfg.options.linux_opts.linux_output_bus_type {
                 LinuxCfgOutputBusType::BusUsb => evdev::BusType::BUS_USB,
                 LinuxCfgOutputBusType::BusI8042 => evdev::BusType::BUS_I8042,
+                LinuxCfgOutputBusType::BusVirtual => evdev::BusType::BUS_VIRTUAL,
             },
         ) {
             Ok(kbd_out) => kbd_out,
@@ -574,6 +575,7 @@ impl Kanata {
             match cfg.options.linux_opts.linux_output_bus_type {
                 LinuxCfgOutputBusType::BusUsb => evdev::BusType::BUS_USB,
                 LinuxCfgOutputBusType::BusI8042 => evdev::BusType::BUS_I8042,
+                LinuxCfgOutputBusType::BusVirtual => evdev::BusType::BUS_VIRTUAL,
             },
         ) {
             Ok(kbd_out) => kbd_out,


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add `virtual` as a possible bus type in the configuration. This doesn't necessarily fix anything that I have the ability to test on my machine, but I feel as though it makes sense to add it as an option. If it does fix something that would be nice though.

## Checklist

- Add documentation to docs/config.adoc
  - [X] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [X] Yes or N/A
- Added tests, or did manual testing
  - [X] Yes
