### PR TITLE
fix(macos): recover from DriverKit output loss instead of bricking keyboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "karabiner-driverkit"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7348953ebe65644771a0d921902e732bc7ca2f0efc6e6c4209904a538dd8ee7e"
+checksum = "c900441e9c078ba7c0ffb0a3537475e4ad094e7b6d2e14e2d7b65a7fcfc10ef0"
 dependencies = [
  "cc",
  "os_info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ kanata-tcp-protocol = { path = "tcp_protocol", version = "0.1110.0" }
 arboard = "3.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-karabiner-driverkit = "0.2.0"
+karabiner-driverkit = "0.2.1"
 objc = "0.2.7"
 core-graphics = "0.24.0"
 open = { version = "5", optional = true }

--- a/src/kanata/macos.rs
+++ b/src/kanata/macos.rs
@@ -1,5 +1,6 @@
 use super::*;
 use anyhow::{Result, anyhow, bail};
+use karabiner_driverkit::is_sink_ready;
 use log::info;
 use parking_lot::Mutex;
 use std::convert::TryFrom;
@@ -8,67 +9,128 @@ use std::sync::mpsc::SyncSender as Sender;
 
 impl Kanata {
     /// Enter an infinite loop that listens for OS key events and sends them to the processing thread.
+    ///
+    /// Contains an outer recovery loop: if the DriverKit output connection drops
+    /// (daemon crash, not installed, etc.), input devices are released so the
+    /// keyboard returns to normal operation. When the connection recovers,
+    /// devices are re-seized and remapping resumes.
     pub fn event_loop(kanata: Arc<Mutex<Self>>, tx: Sender<KeyEvent>) -> Result<()> {
         info!("entering the event loop");
 
         let k = kanata.lock();
         let allow_hardware_repeat = k.allow_hardware_repeat;
-        let mut kb = match KbdIn::new(k.include_names.clone(), k.exclude_names.clone()) {
-            Ok(kbd_in) => kbd_in,
-            Err(e) => bail!("failed to open keyboard device(s): {}", e),
-        };
+        let include_names = k.include_names.clone();
+        let exclude_names = k.exclude_names.clone();
         drop(k);
 
         loop {
-            let event = kb.read().map_err(|e| anyhow!("failed read: {}", e))?;
-
-            let mut key_event = match KeyEvent::try_from(event) {
-                Ok(ev) => ev,
-                _ => {
-                    // Pass-through unrecognized keys
-                    log::debug!("{event:?} is unrecognized!");
-                    let mut kanata = kanata.lock();
-                    kanata
-                        .kbd_out
-                        .write(event)
-                        .map_err(|e| anyhow!("failed write: {}", e))?;
-                    continue;
-                }
+            // --- (Re)create KbdIn and grab input devices ---
+            let mut kb = match KbdIn::new(include_names.clone(), exclude_names.clone()) {
+                Ok(kbd_in) => kbd_in,
+                Err(e) => bail!("failed to open keyboard device(s): {}", e),
             };
 
-            check_for_exit(&key_event);
+            info!("keyboard grabbed, entering event processing loop");
 
-            if key_event.value == KeyValue::Repeat && !allow_hardware_repeat {
-                continue;
-            }
-
-            if !MAPPED_KEYS.lock().contains(&key_event.code) {
-                log::debug!("{key_event:?} is not mapped");
-                let mut kanata = kanata.lock();
-                kanata
-                    .kbd_out
-                    .write(event)
-                    .map_err(|e| anyhow!("failed write: {}", e))?;
-                continue;
-            }
-
-            log::debug!("sending {key_event:?} to processing loop");
-
-            match key_event.value {
-                KeyValue::Release => {
-                    PRESSED_KEYS.lock().remove(&key_event.code);
+            // --- Inner event processing loop ---
+            let needs_recovery = loop {
+                // Check output health before blocking on input
+                if !is_sink_ready() {
+                    log::warn!("DriverKit output lost — releasing input devices");
+                    break true;
                 }
-                KeyValue::Press => {
-                    let mut pressed_keys = PRESSED_KEYS.lock();
-                    if pressed_keys.contains(&key_event.code) {
-                        key_event.value = KeyValue::Repeat;
-                    } else {
-                        pressed_keys.insert(key_event.code);
+
+                let event = match kb.read() {
+                    Ok(ev) => ev,
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                        // Pipe closed by release_input_only() — expected during recovery
+                        log::info!("input pipe EOF — devices were released");
+                        break true;
+                    }
+                    Err(e) => return Err(anyhow!("failed read: {}", e)),
+                };
+
+                let mut key_event = match KeyEvent::try_from(event) {
+                    Ok(ev) => ev,
+                    _ => {
+                        log::debug!("{event:?} is unrecognized!");
+                        let mut kanata = kanata.lock();
+                        match kanata.kbd_out.write(event) {
+                            Ok(()) => continue,
+                            Err(e) if e.kind() == std::io::ErrorKind::NotConnected => {
+                                log::warn!(
+                                    "DriverKit output lost during write — releasing input devices"
+                                );
+                                break true;
+                            }
+                            Err(e) => return Err(anyhow!("failed write: {}", e)),
+                        }
+                    }
+                };
+
+                check_for_exit(&key_event);
+
+                if key_event.value == KeyValue::Repeat && !allow_hardware_repeat {
+                    continue;
+                }
+
+                if !MAPPED_KEYS.lock().contains(&key_event.code) {
+                    log::debug!("{key_event:?} is not mapped");
+                    let mut kanata = kanata.lock();
+                    match kanata.kbd_out.write(event) {
+                        Ok(()) => continue,
+                        Err(e) if e.kind() == std::io::ErrorKind::NotConnected => {
+                            log::warn!(
+                                "DriverKit output lost during write — releasing input devices"
+                            );
+                            break true;
+                        }
+                        Err(e) => return Err(anyhow!("failed write: {}", e)),
                     }
                 }
-                _ => {}
+
+                log::debug!("sending {key_event:?} to processing loop");
+
+                match key_event.value {
+                    KeyValue::Release => {
+                        PRESSED_KEYS.lock().remove(&key_event.code);
+                    }
+                    KeyValue::Press => {
+                        let mut pressed_keys = PRESSED_KEYS.lock();
+                        if pressed_keys.contains(&key_event.code) {
+                            key_event.value = KeyValue::Repeat;
+                        } else {
+                            pressed_keys.insert(key_event.code);
+                        }
+                    }
+                    _ => {}
+                }
+                tx.try_send(key_event)?;
+            };
+
+            if !needs_recovery {
+                break Ok(());
             }
-            tx.try_send(key_event)?;
+
+            // --- Release input so the keyboard works normally (unseized) ---
+            kb.release_input();
+            drop(kb);
+
+            info!(
+                "Input devices released. Keyboard is usable (without remapping). \
+                 Waiting for DriverKit output to recover..."
+            );
+
+            // --- Wait for the pqrs client heartbeat to re-establish the connection ---
+            loop {
+                std::thread::sleep(std::time::Duration::from_millis(500));
+                if is_sink_ready() {
+                    info!("DriverKit output recovered — re-grabbing input devices");
+                    break;
+                }
+            }
+
+            // The outer loop will create a new KbdIn and resume remapping.
         }
     }
 

--- a/src/kanata/macos.rs
+++ b/src/kanata/macos.rs
@@ -10,10 +10,15 @@ use std::sync::mpsc::SyncSender as Sender;
 impl Kanata {
     /// Enter an infinite loop that listens for OS key events and sends them to the processing thread.
     ///
-    /// Contains an outer recovery loop: if the DriverKit output connection drops
+    /// Contains a recovery mechanism: if the DriverKit output connection drops
     /// (daemon crash, not installed, etc.), input devices are released so the
     /// keyboard returns to normal operation. When the connection recovers,
     /// devices are re-seized and remapping resumes.
+    ///
+    /// Recovery uses `regrab_input()` rather than recreating `KbdIn` to avoid
+    /// re-initializing the pqrs client (via `init_sink()`). A second client
+    /// causes duplicate connection callbacks that race with the IOHIDManager,
+    /// leading to "exclusive access" errors on the input device.
     pub fn event_loop(kanata: Arc<Mutex<Self>>, tx: Sender<KeyEvent>) -> Result<()> {
         info!("entering the event loop");
 
@@ -23,16 +28,15 @@ impl Kanata {
         let exclude_names = k.exclude_names.clone();
         drop(k);
 
+        let mut kb = match KbdIn::new(include_names, exclude_names) {
+            Ok(kbd_in) => kbd_in,
+            Err(e) => bail!("failed to open keyboard device(s): {}", e),
+        };
+
+        info!("keyboard grabbed, entering event processing loop");
+
         loop {
-            // --- (Re)create KbdIn and grab input devices ---
-            let mut kb = match KbdIn::new(include_names.clone(), exclude_names.clone()) {
-                Ok(kbd_in) => kbd_in,
-                Err(e) => bail!("failed to open keyboard device(s): {}", e),
-            };
-
-            info!("keyboard grabbed, entering event processing loop");
-
-            // --- Inner event processing loop ---
+            // --- Event processing loop ---
             let needs_recovery = loop {
                 // Check output health before blocking on input
                 if !is_sink_ready() {
@@ -114,23 +118,36 @@ impl Kanata {
 
             // --- Release input so the keyboard works normally (unseized) ---
             kb.release_input();
-            drop(kb);
 
             info!(
                 "Input devices released. Keyboard is usable (without remapping). \
                  Waiting for DriverKit output to recover..."
             );
 
-            // --- Wait for the pqrs client heartbeat to re-establish the connection ---
+            // --- Wait for the pqrs client to re-establish the connection ---
             loop {
                 std::thread::sleep(std::time::Duration::from_millis(500));
                 if is_sink_ready() {
+                    // Let the pqrs client's callback sequence finish before
+                    // we re-seize input devices. The client fires several
+                    // callbacks in quick succession (connected, driver_connected,
+                    // virtual_hid_keyboard_ready); seizing too early can race
+                    // with IOKit enumeration triggered by those callbacks.
+                    std::thread::sleep(std::time::Duration::from_secs(1));
                     info!("DriverKit output recovered — re-grabbing input devices");
                     break;
                 }
             }
 
-            // The outer loop will create a new KbdIn and resume remapping.
+            // Re-seize input devices using regrab_input() which creates a fresh
+            // pipe and listener thread without re-initializing the sink client.
+            if !kb.regrab_input() {
+                bail!("failed to re-grab keyboard devices after DriverKit recovery");
+            }
+
+            info!("keyboard grabbed, entering event processing loop");
+
+            // Back to the event processing loop.
         }
     }
 


### PR DESCRIPTION
## Summary

- Add recovery loop to the macOS event loop: on DriverKit output loss, release input devices so the keyboard works normally, then re-grab when the connection recovers
- `KbdOut::write()` now returns `NotConnected` when the virtual keyboard sink is unavailable (send_key returns error code 2)
- `KbdIn::read()` detects pipe EOF from `release_input_only()` to cleanly unblock the blocking read
- `KbdIn::new()` waits up to 10s for sink readiness after `grab()`, with progress logging

## Motivation

Fixes #1792.

When the Karabiner DriverKit daemon crashes or stops, kanata keeps input devices seized but can't emit keystrokes — bricking the keyboard. With `KeepAlive=true` the machine becomes completely unusable and requires SSH or power button to recover.

## How It Works

```
GRABBED (normal operation)
    │
    ├── write error (NotConnected) or !is_sink_ready()
    │
    ▼
RELEASING ── release_input_only() ── keyboard works normally (unseized)
    │
    ├── poll is_sink_ready() every 500ms
    │   (pqrs client heartbeat auto-reconnects)
    │
    ▼
RE-GRABBING ── new KbdIn ── back to GRABBED
```

The outer recovery loop in `event_loop()`:
1. **Inner loop**: Normal event processing. On write error (`NotConnected`) or pipe EOF, breaks out
2. **Release**: Calls `release_input()` to release seized devices while keeping the output connection alive
3. **Wait**: Polls `is_sink_ready()` every 500ms until the pqrs client's heartbeat re-establishes the connection
4. **Re-grab**: Creates a new `KbdIn` which calls `register_device()` + `grab()` to re-seize input

## Dependencies

Uses `karabiner-driverkit` v0.2.1 ([published today](https://crates.io/crates/karabiner-driverkit/0.2.1)) which exposes the connection health state from the pqrs client library. See [psych3r/driverkit#11](https://github.com/psych3r/driverkit/pull/11).

## Files Changed

| File | Changes |
|------|---------| 
| `Cargo.toml` | Bump `karabiner-driverkit` from `0.2.0` to `0.2.1` |
| `Cargo.lock` | Updated lockfile |
| `src/oskbd/macos.rs` | `KbdIn.grabbed` field, `release_input()`/`regrab_input()`/`is_grabbed()` methods, `read()` EOF detection, `write()` health check, sink readiness wait in `new()` |
| `src/kanata/macos.rs` | Outer recovery loop around the event loop |

## Thread Safety

| Shared State | Writer | Reader | Sync |
|---|---|---|---|
| `sink_ready` | pqrs dispatcher thread | Event loop thread | `std::atomic<bool>` acquire/release |
| `fd[2]` pipe | Listener thread | Event loop thread | POSIX pipe (inherently safe) |

## Test plan

- [ ] `cargo check` passes (verified)
- [ ] Start kanata, confirm normal remapping works
- [ ] Kill daemon: `sudo launchctl bootout system /Library/LaunchDaemons/org.pqrs.Karabiner.VirtualHIDDeviceManager.plist`
- [ ] **Before fix**: keyboard dead, unrecoverable without SSH/power button
- [ ] **After fix**: keyboard regains normal (unseized) function within ~3s, logs show "Releasing input devices"
- [ ] Restart daemon: `sudo launchctl bootstrap system /Library/LaunchDaemons/org.pqrs.Karabiner.VirtualHIDDeviceManager.plist`
- [ ] **After fix**: kanata re-seizes and resumes remapping within ~5s, logs show "DriverKit output recovered"

Note: @jtroo — I can test this on my macOS machine since you don't have one. Happy to provide logs and screen recordings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)