### PR TITLE
feat: add tap-hold-require-prior-idle defcfg option

### DIFF
--- a/cfg_samples/home-row-mod-prior-idle.kbd
+++ b/cfg_samples/home-row-mod-prior-idle.kbd
@@ -1,0 +1,52 @@
+;; Home row mods with tap-hold-require-prior-idle.
+;;
+;; This replaces the layer-switching workaround in home-row-mod-advanced.kbd
+;; with two native features:
+;;
+;;   tap-hold-require-prior-idle  — during fast typing, tap-hold keys resolve as tap
+;;                         immediately (no waiting state, no accidental holds)
+;;
+;;   tap-hold-opposite-hand — hold activates only when the next key is on
+;;                            the opposite hand; same-hand rolls always tap
+;;
+;; The result: no nomods layer, no fakekeys, no multi wrappers.
+;;
+;; Configuration guide:
+;;   https://github.com/jtroo/kanata/blob/main/docs/config.adoc#tap-hold-require-prior-idle
+;;   https://github.com/jtroo/kanata/blob/main/docs/config.adoc#tap-hold
+
+(defcfg
+  process-unmapped-keys yes
+  ;; If any key was pressed within 150ms, resolve tap-hold as tap immediately.
+  ;; Prevents accidental modifier activation during fast typing.
+  tap-hold-require-prior-idle 150
+)
+
+(defsrc
+  a   s   d   f   j   k   l   ;
+)
+
+;; Declare which keys belong to each hand.
+;; tap-hold-opposite-hand uses this to decide hold vs tap.
+(defhands
+  (left  q w e r t a s d f g z x c v b)
+  (right y u i o p h j k l ; n m , . /)
+)
+
+(deflayer base
+  @a  @s  @d  @f  @j  @k  @l  @;
+)
+
+(defalias
+  ;; Note: consider using different time values for your different fingers.
+  ;; For example, your pinkies might be slower to release keys and index
+  ;; fingers faster.
+  a (tap-hold-opposite-hand 150 a lmet)
+  s (tap-hold-opposite-hand 150 s lalt)
+  d (tap-hold-opposite-hand 150 d lctl)
+  f (tap-hold-opposite-hand 150 f lsft)
+  j (tap-hold-opposite-hand 150 j rsft)
+  k (tap-hold-opposite-hand 150 k rctl)
+  l (tap-hold-opposite-hand 150 l ralt)
+  ; (tap-hold-opposite-hand 150 ; rmet)
+)

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -4128,6 +4128,36 @@ The default (and minimum) value is `5` and the unit is milliseconds.
 )
 ----
 
+[[tap-hold-require-prior-idle]]
+=== tap-hold-require-prior-idle
+
+This configuration applies to all `tap-hold` variants.
+When a different physical key was pressed within the configured number of
+milliseconds before a `tap-hold` key is pressed, the `tap-hold` key will
+immediately resolve as its tap action without entering the waiting state.
+This prevents accidental modifier activations during fast typing.
+The concept is equivalent to ZMK's `require-prior-idle-ms`.
+
+NOTE: For more info, see <<tap-hold>>.
+
+The default value is `0` (disabled) and the unit is milliseconds.
+
+.Example:
+[source]
+----
+(defcfg
+  tap-hold-require-prior-idle 150
+)
+----
+
+- If you type a normal key and then press a `tap-hold` key within the threshold,
+  the `tap-hold` key immediately outputs its tap action.
+- If the keyboard is idle for longer than the threshold before pressing a `tap-hold` key,
+  normal `tap-hold` behavior applies (waiting state, hold on timeout, etc.).
+- When `tap-hold-require-prior-idle` triggers, the tap action is chosen before any other
+  `tap-hold` configuration (e.g., `tap-hold-opposite-hand`, `concurrent-tap-hold`)
+  is consulted.
+
 [[override-release-on-activation]]
 === override-release-on-activation
 

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -116,6 +116,9 @@ where
     pub historical_keys: History<KeyCode>,
     pub historical_inputs: History<KCoord>,
     pub quick_tap_hold_timeout: bool,
+    /// If a different key was pressed within this many ticks before a HoldTap key,
+    /// immediately resolve as tap (typing streak detection). 0 = disabled.
+    pub require_prior_idle: u16,
     pub chords_v2: Option<ChordsV2<'a, T>>,
     rpt_multikey_key_buffer: MultiKeyBuffer<'a, T>,
     trans_resolution_behavior_v2: bool,
@@ -1174,6 +1177,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
             historical_inputs: History::new(),
             rpt_multikey_key_buffer: unsafe { MultiKeyBuffer::new() },
             quick_tap_hold_timeout: false,
+            require_prior_idle: 0,
             trans_resolution_behavior_v2: true,
             delegate_to_first_layer: false,
             chords_v2: None,
@@ -1826,6 +1830,22 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
                 tap_hold_interval,
                 on_press_reset_timeout_to,
             }) => {
+                // Typing streak detection: if a different physical key was pressed
+                // recently, resolve as tap immediately without entering WaitingState.
+                if self.require_prior_idle > 0 {
+                    let prior_idle_tap = self
+                        .historical_inputs
+                        .iter_hevents()
+                        .find(|prior| prior.event.0 == REAL_KEY_ROW && prior.event != coord)
+                        .is_some_and(|prior| {
+                            prior.ticks_since_occurrence <= self.require_prior_idle
+                        });
+                    if prior_idle_tap {
+                        let custom = self.do_action(tap, coord, delay, is_oneshot, layer_stack);
+                        self.last_press_tracker.update_coord(coord);
+                        return custom;
+                    }
+                }
                 let mut custom = CustomEvent::NoEvent;
                 if *tap_hold_interval == 0
                     || coord != self.last_press_tracker.coord

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -118,7 +118,7 @@ where
     pub quick_tap_hold_timeout: bool,
     /// If a different key was pressed within this many ticks before a HoldTap key,
     /// immediately resolve as tap (typing streak detection). 0 = disabled.
-    pub require_prior_idle: u16,
+    pub tap_hold_require_prior_idle: u16,
     pub chords_v2: Option<ChordsV2<'a, T>>,
     rpt_multikey_key_buffer: MultiKeyBuffer<'a, T>,
     trans_resolution_behavior_v2: bool,
@@ -1177,7 +1177,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
             historical_inputs: History::new(),
             rpt_multikey_key_buffer: unsafe { MultiKeyBuffer::new() },
             quick_tap_hold_timeout: false,
-            require_prior_idle: 0,
+            tap_hold_require_prior_idle: 0,
             trans_resolution_behavior_v2: true,
             delegate_to_first_layer: false,
             chords_v2: None,
@@ -1832,13 +1832,13 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
             }) => {
                 // Typing streak detection: if a different physical key was pressed
                 // recently, resolve as tap immediately without entering WaitingState.
-                if self.require_prior_idle > 0 {
+                if self.tap_hold_require_prior_idle > 0 {
                     let prior_idle_tap = self
                         .historical_inputs
                         .iter_hevents()
                         .find(|prior| prior.event.0 == REAL_KEY_ROW && prior.event != coord)
                         .is_some_and(|prior| {
-                            prior.ticks_since_occurrence <= self.require_prior_idle
+                            prior.ticks_since_occurrence <= self.tap_hold_require_prior_idle
                         });
                     if prior_idle_tap {
                         let custom = self.do_action(tap, coord, delay, is_oneshot, layer_stack);

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -155,7 +155,7 @@ pub struct CfgOptions {
     pub rapid_event_delay: u16,
     pub trans_resolution_behavior_v2: bool,
     pub chords_v2_min_idle: u16,
-    pub require_prior_idle: u16,
+    pub tap_hold_require_prior_idle: u16,
     #[cfg(any(
         all(target_os = "windows", feature = "interception_driver"),
         target_os = "linux",
@@ -202,7 +202,7 @@ impl Default for CfgOptions {
             rapid_event_delay: 5,
             trans_resolution_behavior_v2: true,
             chords_v2_min_idle: 5,
-            require_prior_idle: 0,
+            tap_hold_require_prior_idle: 0,
             #[cfg(any(
                 all(target_os = "windows", feature = "interception_driver"),
                 target_os = "linux",
@@ -899,7 +899,7 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                         cfg.chords_v2_min_idle = min_idle;
                     }
                     "tap-hold-require-prior-idle" => {
-                        cfg.require_prior_idle = parse_cfg_val_u16(val, label, false)?;
+                        cfg.tap_hold_require_prior_idle = parse_cfg_val_u16(val, label, false)?;
                     }
                     "mouse-movement-key" => {
                         #[cfg(any(

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -155,6 +155,7 @@ pub struct CfgOptions {
     pub rapid_event_delay: u16,
     pub trans_resolution_behavior_v2: bool,
     pub chords_v2_min_idle: u16,
+    pub require_prior_idle: u16,
     #[cfg(any(
         all(target_os = "windows", feature = "interception_driver"),
         target_os = "linux",
@@ -201,6 +202,7 @@ impl Default for CfgOptions {
             rapid_event_delay: 5,
             trans_resolution_behavior_v2: true,
             chords_v2_min_idle: 5,
+            require_prior_idle: 0,
             #[cfg(any(
                 all(target_os = "windows", feature = "interception_driver"),
                 target_os = "linux",
@@ -895,6 +897,9 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                             bail_expr!(val, "{label} must be 5-65535");
                         }
                         cfg.chords_v2_min_idle = min_idle;
+                    }
+                    "tap-hold-require-prior-idle" => {
+                        cfg.require_prior_idle = parse_cfg_val_u16(val, label, false)?;
                     }
                     "mouse-movement-key" => {
                         #[cfg(any(

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -336,7 +336,7 @@ fn populate_cfg_with_icfg(icfg: IntermediateCfg, s: ParserState) -> Cfg {
     );
     layout.bm().chords_v2 = icfg.chords_v2;
     layout.bm().quick_tap_hold_timeout = icfg.options.concurrent_tap_hold;
-    layout.bm().require_prior_idle = icfg.options.require_prior_idle;
+    layout.bm().tap_hold_require_prior_idle = icfg.options.tap_hold_require_prior_idle;
     layout.bm().oneshot.pause_input_processing_delay = icfg.options.rapid_event_delay;
     if let Some(s) = icfg.start_action {
         layout

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -336,6 +336,7 @@ fn populate_cfg_with_icfg(icfg: IntermediateCfg, s: ParserState) -> Cfg {
     );
     layout.bm().chords_v2 = icfg.chords_v2;
     layout.bm().quick_tap_hold_timeout = icfg.options.concurrent_tap_hold;
+    layout.bm().require_prior_idle = icfg.options.require_prior_idle;
     layout.bm().oneshot.pause_input_processing_delay = icfg.options.rapid_event_delay;
     if let Some(s) = icfg.start_action {
         layout

--- a/parser/src/cfg/tests/defcfg.rs
+++ b/parser/src/cfg/tests/defcfg.rs
@@ -121,3 +121,42 @@ fn non_applicable_os_deflocalkeys_always_succeeds_parsing() {
         .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
         .expect("passes");
 }
+
+#[test]
+fn require_prior_idle_parses_valid_value() {
+    let source = "
+(defcfg tap-hold-require-prior-idle 150)
+(defsrc a)
+(deflayer base a)
+";
+    let cfg = parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+    assert_eq!(cfg.options.require_prior_idle, 150);
+}
+
+#[test]
+fn require_prior_idle_allows_zero() {
+    let source = "
+(defcfg tap-hold-require-prior-idle 0)
+(defsrc a)
+(deflayer base a)
+";
+    let cfg = parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+    assert_eq!(cfg.options.require_prior_idle, 0);
+}
+
+#[test]
+fn require_prior_idle_rejects_non_numeric() {
+    let source = "
+(defcfg tap-hold-require-prior-idle nope)
+(defsrc a)
+(deflayer base a)
+";
+    parse_cfg(source)
+        .map(|_| ())
+        //.map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect_err("fails");
+}

--- a/parser/src/cfg/tests/defcfg.rs
+++ b/parser/src/cfg/tests/defcfg.rs
@@ -123,7 +123,7 @@ fn non_applicable_os_deflocalkeys_always_succeeds_parsing() {
 }
 
 #[test]
-fn require_prior_idle_parses_valid_value() {
+fn tap_hold_require_prior_idle_parses_valid_value() {
     let source = "
 (defcfg tap-hold-require-prior-idle 150)
 (defsrc a)
@@ -132,11 +132,11 @@ fn require_prior_idle_parses_valid_value() {
     let cfg = parse_cfg(source)
         .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
         .expect("passes");
-    assert_eq!(cfg.options.require_prior_idle, 150);
+    assert_eq!(cfg.options.tap_hold_require_prior_idle, 150);
 }
 
 #[test]
-fn require_prior_idle_allows_zero() {
+fn tap_hold_require_prior_idle_allows_zero() {
     let source = "
 (defcfg tap-hold-require-prior-idle 0)
 (defsrc a)
@@ -145,11 +145,11 @@ fn require_prior_idle_allows_zero() {
     let cfg = parse_cfg(source)
         .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
         .expect("passes");
-    assert_eq!(cfg.options.require_prior_idle, 0);
+    assert_eq!(cfg.options.tap_hold_require_prior_idle, 0);
 }
 
 #[test]
-fn require_prior_idle_rejects_non_numeric() {
+fn tap_hold_require_prior_idle_rejects_non_numeric() {
     let source = "
 (defcfg tap-hold-require-prior-idle nope)
 (defsrc a)

--- a/src/tests/sim_tests/tap_hold_tests.rs
+++ b/src/tests/sim_tests/tap_hold_tests.rs
@@ -431,7 +431,7 @@ fn neutral_keys_override_defhands_assignment() {
 // ========== tap-hold-require-prior-idle tests ==========
 
 #[test]
-fn require_prior_idle_typing_streak_resolves_tap() {
+fn tap_hold_require_prior_idle_typing_streak_resolves_tap() {
     let result = simulate(
         "
 (defcfg tap-hold-require-prior-idle 150)
@@ -449,7 +449,7 @@ fn require_prior_idle_typing_streak_resolves_tap() {
 }
 
 #[test]
-fn require_prior_idle_idle_long_enough_enters_hold() {
+fn tap_hold_require_prior_idle_idle_long_enough_enters_hold() {
     let result = simulate(
         "
 (defcfg tap-hold-require-prior-idle 150)
@@ -467,7 +467,7 @@ fn require_prior_idle_idle_long_enough_enters_hold() {
 }
 
 #[test]
-fn require_prior_idle_no_prior_key_enters_hold() {
+fn tap_hold_require_prior_idle_no_prior_key_enters_hold() {
     let result = simulate(
         "
 (defcfg tap-hold-require-prior-idle 150)
@@ -484,7 +484,7 @@ fn require_prior_idle_no_prior_key_enters_hold() {
 }
 
 #[test]
-fn require_prior_idle_boundary_just_within_threshold() {
+fn tap_hold_require_prior_idle_boundary_just_within_threshold() {
     // Prior key pressed 149ms ago (just within 150ms threshold).
     // ticks_since_occurrence will be ~150 (149 + 1 tick offset), which is
     // <= 150 threshold, so tap fires.
@@ -502,7 +502,7 @@ fn require_prior_idle_boundary_just_within_threshold() {
 }
 
 #[test]
-fn require_prior_idle_boundary_just_outside_threshold() {
+fn tap_hold_require_prior_idle_boundary_just_outside_threshold() {
     // Prior key pressed 150ms ago (just outside 150ms threshold).
     // ticks_since_occurrence will be ~151 (150 + 1 tick offset), which is
     // > 150 threshold, so normal tap-hold behavior applies.
@@ -521,7 +521,7 @@ fn require_prior_idle_boundary_just_outside_threshold() {
 }
 
 #[test]
-fn require_prior_idle_with_opposite_hand() {
+fn tap_hold_require_prior_idle_with_opposite_hand() {
     // tap-hold-require-prior-idle should short-circuit before tap-hold-opposite-hand
     // evaluates hand membership. During a typing streak, even an opposite-hand
     // key should resolve as tap.
@@ -543,7 +543,7 @@ fn require_prior_idle_with_opposite_hand() {
 }
 
 #[test]
-fn require_prior_idle_with_tap_hold_interval() {
+fn tap_hold_require_prior_idle_with_tap_hold_interval() {
     // tap-hold-require-prior-idle check runs before tap-hold-interval (quick re-press).
     // Both should work together: typing streak → tap immediately,
     // idle re-press → tap via tap_hold_interval.
@@ -562,7 +562,7 @@ fn require_prior_idle_with_tap_hold_interval() {
 }
 
 #[test]
-fn require_prior_idle_ignores_virtual_keys() {
+fn tap_hold_require_prior_idle_ignores_virtual_keys() {
     // Virtual key events (row 1) should not count as prior physical input.
     // Only real physical key presses (row 0) trigger the typing streak.
     let result = simulate(

--- a/src/tests/sim_tests/tap_hold_tests.rs
+++ b/src/tests/sim_tests/tap_hold_tests.rs
@@ -427,3 +427,157 @@ fn neutral_keys_override_defhands_assignment() {
     // j would normally be opposite-hand (hold), but neutral-keys overrides -> tap
     assert_eq!("t:50ms dn:F t:6ms dn:J t:44ms up:J t:50ms up:F", result);
 }
+
+// ========== tap-hold-require-prior-idle tests ==========
+
+#[test]
+fn require_prior_idle_typing_streak_resolves_tap() {
+    let result = simulate(
+        "
+(defcfg tap-hold-require-prior-idle 150)
+(defsrc a b d)
+(deflayer base a b @d)
+(defalias d (tap-hold 200 200 d lctl))
+        ",
+        // Type a, release, then quickly press d within idle window.
+        // 'a' was pressed 20ms ago (10ms press + 10ms gap), well within 150ms threshold.
+        "d:a t:10 u:a t:10 d:d t:50 u:d t:50",
+    )
+    .to_ascii();
+    // d should resolve as tap immediately (no 200ms waiting state)
+    assert_eq!("dn:A t:10ms up:A t:10ms dn:D t:50ms up:D", result);
+}
+
+#[test]
+fn require_prior_idle_idle_long_enough_enters_hold() {
+    let result = simulate(
+        "
+(defcfg tap-hold-require-prior-idle 150)
+(defsrc a b d)
+(deflayer base a b @d)
+(defalias d (tap-hold 200 200 d lctl))
+        ",
+        // Press a, release, wait 200ms (longer than 150ms threshold), then press d.
+        // d should enter normal WaitingState (hold on other key press).
+        "d:a t:10 u:a t:200 d:d t:250 u:d t:50",
+    )
+    .to_ascii();
+    // After 200ms idle, d enters normal tap-hold. Timeout at 200ms → hold (lctl).
+    assert_eq!("dn:A t:10ms up:A t:400ms dn:LCtrl t:50ms up:LCtrl", result);
+}
+
+#[test]
+fn require_prior_idle_no_prior_key_enters_hold() {
+    let result = simulate(
+        "
+(defcfg tap-hold-require-prior-idle 150)
+(defsrc a b d)
+(deflayer base a b @d)
+(defalias d (tap-hold 200 200 d lctl))
+        ",
+        // No prior key at all. d should enter normal WaitingState.
+        "d:d t:250 u:d t:50",
+    )
+    .to_ascii();
+    // Timeout → hold (lctl)
+    assert_eq!("t:200ms dn:LCtrl t:50ms up:LCtrl", result);
+}
+
+#[test]
+fn require_prior_idle_boundary_just_within_threshold() {
+    // Prior key pressed 149ms ago (just within 150ms threshold).
+    // ticks_since_occurrence will be ~150 (149 + 1 tick offset), which is
+    // <= 150 threshold, so tap fires.
+    let result = simulate(
+        "
+(defcfg tap-hold-require-prior-idle 150)
+(defsrc a d)
+(deflayer base a @d)
+(defalias d (tap-hold 200 200 d lctl))
+        ",
+        "d:a t:10 u:a t:139 d:d t:50 u:d t:50",
+    )
+    .to_ascii();
+    assert_eq!("dn:A t:10ms up:A t:139ms dn:D t:50ms up:D", result);
+}
+
+#[test]
+fn require_prior_idle_boundary_just_outside_threshold() {
+    // Prior key pressed 150ms ago (just outside 150ms threshold).
+    // ticks_since_occurrence will be ~151 (150 + 1 tick offset), which is
+    // > 150 threshold, so normal tap-hold behavior applies.
+    let result = simulate(
+        "
+(defcfg tap-hold-require-prior-idle 150)
+(defsrc a d)
+(deflayer base a @d)
+(defalias d (tap-hold 200 200 d lctl))
+        ",
+        // d enters WaitingState; released at 50ms → tap via release
+        "d:a t:10 u:a t:140 d:d t:50 u:d t:50",
+    )
+    .to_ascii();
+    assert_eq!("dn:A t:10ms up:A t:190ms dn:D t:6ms up:D", result);
+}
+
+#[test]
+fn require_prior_idle_with_opposite_hand() {
+    // tap-hold-require-prior-idle should short-circuit before tap-hold-opposite-hand
+    // evaluates hand membership. During a typing streak, even an opposite-hand
+    // key should resolve as tap.
+    let result = simulate(
+        "
+(defcfg tap-hold-require-prior-idle 150)
+(defhands (left a s d f g) (right h j k l ;))
+(defsrc a f j)
+(deflayer base a @f j)
+(defalias f (tap-hold-opposite-hand 200 f lctl))
+        ",
+        // a is left hand, f is left hand tap-hold. a pressed 20ms ago.
+        // Without tap-hold-require-prior-idle, pressing j (opposite hand) would hold.
+        // With tap-hold-require-prior-idle active, f resolves as tap before hand check.
+        "d:a t:10 u:a t:10 d:f t:50 u:f t:50",
+    )
+    .to_ascii();
+    assert_eq!("dn:A t:10ms up:A t:10ms dn:F t:50ms up:F", result);
+}
+
+#[test]
+fn require_prior_idle_with_tap_hold_interval() {
+    // tap-hold-require-prior-idle check runs before tap-hold-interval (quick re-press).
+    // Both should work together: typing streak → tap immediately,
+    // idle re-press → tap via tap_hold_interval.
+    let cfg = "
+(defcfg tap-hold-require-prior-idle 150)
+(defsrc a d)
+(deflayer base a @d)
+(defalias d (tap-hold 200 200 d lctl))
+    ";
+    // Case 1: typing streak (a then d quickly) → tap-hold-require-prior-idle fires
+    let result = simulate(cfg, "d:a t:10 u:a t:10 d:d t:50 u:d t:50").to_ascii();
+    assert_eq!("dn:A t:10ms up:A t:10ms dn:D t:50ms up:D", result);
+    // Case 2: idle, then d pressed twice (tap-hold-interval re-press)
+    let result = simulate(cfg, "d:d t:50 u:d t:50 d:d t:50 u:d t:50").to_ascii();
+    assert_eq!("t:50ms dn:D t:6ms up:D t:44ms dn:D t:50ms up:D", result);
+}
+
+#[test]
+fn require_prior_idle_ignores_virtual_keys() {
+    // Virtual key events (row 1) should not count as prior physical input.
+    // Only real physical key presses (row 0) trigger the typing streak.
+    let result = simulate(
+        "
+(defcfg tap-hold-require-prior-idle 150)
+(defsrc d)
+(defvirtualkeys vk1 a)
+(deflayer base @d)
+(defalias d (tap-hold 200 200 d lctl))
+        ",
+        // Virtual key tap, then d pressed 10ms later.
+        // vk should NOT trigger typing streak — d should enter normal hold.
+        "vk:vk1:tap t:10 d:d t:250 u:d t:50",
+    )
+    .to_ascii();
+    // Virtual key outputs A, then d times out to hold (lctl).
+    assert_eq!("dn:A t:1ms up:A t:209ms dn:LCtrl t:50ms up:LCtrl", result);
+}


### PR DESCRIPTION
## Summary

Adds a global `tap-hold-require-prior-idle` option to `defcfg`. When a different physical key was pressed within the configured number of milliseconds before a tap-hold key, the tap-hold resolves as tap immediately — skipping the waiting state entirely. This prevents accidental modifier activations during fast typing. Equivalent to ZMK's [`require-prior-idle-ms`](https://zmk.dev/docs/keymaps/behaviors/hold-tap#require-prior-idle-ms).

```
(defcfg tap-hold-require-prior-idle 150)
```

## How it works

In `do_action()`, before creating a `WaitingState` for any tap-hold variant, the code checks `historical_inputs` for a recent physical key press from a different coordinate. If one exists within the threshold, it short-circuits directly to the tap action. Otherwise normal tap-hold behavior applies.

- Only real physical key presses (row 0) are considered — virtual key events are filtered out.
- When `tap-hold-require-prior-idle` triggers, it fires before any other tap-hold configuration (`tap-hold-opposite-hand`, `concurrent-tap-hold`, etc.) is consulted.
- The value `0` disables the feature (default).

## Design

**Layout-level field, not per-action.** Follows the same pattern as `concurrent-tap-hold` / `quick_tap_hold_timeout` — a single `defcfg` value wired to `layout.bm().require_prior_idle`. A global threshold is the right default; per-action override could be a follow-up if there's demand.

**Minimal keyberon surface.** The feature needs to live in keyberon because `do_action()` is the only place with access to both the action type and the `historical_inputs` timing data. But the touch is small: one `u16` field on `Layout`, initialization, and 10 lines of short-circuit logic.

## Test coverage

**8 sim tests:** typing streak → tap, idle → hold, no prior key → hold, boundary just within/outside threshold, interaction with `tap-hold-opposite-hand`, interaction with `tap-hold-interval`, virtual keys filtered out.

**3 parser tests:** valid value parses, zero accepted, non-numeric rejected.

## Known limitation

`historical_inputs` records events as they arrive via `event()`, before queue processing. Under `pause_input_processing_ticks` (oneshot rapid-event delay, default 5ms), a key pressed shortly after a tap-hold key could appear in history before the tap-hold's `do_action()` runs. This is inherent to all `historical_inputs` consumers, not introduced by this PR. The practical window is ~5ms during oneshot processing; worst case is a benign tap instead of hold.

## Combined with `tap-hold-opposite-hand` (#1955)

Together, these two features replace the 67-line `home-row-mod-advanced.kbd` workaround (nomods layer, fakekeys, multi wrappers) with ~25 lines of config. The included sample at [`cfg_samples/home-row-mod-prior-idle.kbd`](https://github.com/malpern/kanata/blob/feat/require-prior-idle/cfg_samples/home-row-mod-prior-idle.kbd) demonstrates this.