### PR TITLE
macos: move output readiness behind KbdOut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ default-run = "kanata"
 [lib]
 name = "kanata_state_machine"
 path = "src/lib.rs"
+crate-type = ["rlib", "staticlib"]
 
 [[bin]]
 name = "kanata"

--- a/src/kanata/macos.rs
+++ b/src/kanata/macos.rs
@@ -1,11 +1,11 @@
 use super::*;
 use anyhow::{Result, anyhow, bail};
-use karabiner_driverkit::is_sink_ready;
 use log::info;
 use parking_lot::Mutex;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use std::sync::mpsc::SyncSender as Sender;
+use std::time::Duration;
 
 impl Kanata {
     /// Enter an infinite loop that listens for OS key events and sends them to the processing thread.
@@ -33,14 +33,26 @@ impl Kanata {
             Err(e) => bail!("failed to open keyboard device(s): {}", e),
         };
 
+        {
+            let kanata = kanata.lock();
+            if !kanata
+                .kbd_out
+                .wait_until_ready(Some(Duration::from_secs(10)))
+            {
+                log::warn!(
+                    "output backend not ready after 10s. Key output may fail until the backend recovers."
+                );
+            }
+        }
+
         info!("keyboard grabbed, entering event processing loop");
 
         loop {
             // --- Event processing loop ---
             let needs_recovery = loop {
                 // Check output health before blocking on input
-                if !is_sink_ready() {
-                    log::warn!("DriverKit output lost — releasing input devices");
+                if !kanata.lock().kbd_out.output_ready() {
+                    log::warn!("output backend unavailable — releasing input devices");
                     break true;
                 }
 
@@ -63,7 +75,7 @@ impl Kanata {
                             Ok(()) => continue,
                             Err(e) if e.kind() == std::io::ErrorKind::NotConnected => {
                                 log::warn!(
-                                    "DriverKit output lost during write — releasing input devices"
+                                    "output backend unavailable during write — releasing input devices"
                                 );
                                 break true;
                             }
@@ -85,7 +97,7 @@ impl Kanata {
                         Ok(()) => continue,
                         Err(e) if e.kind() == std::io::ErrorKind::NotConnected => {
                             log::warn!(
-                                "DriverKit output lost during write — releasing input devices"
+                                "output backend unavailable during write — releasing input devices"
                             );
                             break true;
                         }
@@ -121,23 +133,32 @@ impl Kanata {
 
             info!(
                 "Input devices released. Keyboard is usable (without remapping). \
-                 Waiting for DriverKit output to recover..."
+                 Waiting for the output backend to recover..."
             );
 
-            // --- Wait for the pqrs client to re-establish the connection ---
+            // --- Wait for the output backend to re-establish the connection ---
             loop {
-                std::thread::sleep(std::time::Duration::from_millis(500));
-                if is_sink_ready() {
-                    // Let the pqrs client's callback sequence finish before
-                    // we re-seize input devices. The client fires several
-                    // callbacks in quick succession (connected, driver_connected,
-                    // virtual_hid_keyboard_ready); seizing too early can race
+                if kanata
+                    .lock()
+                    .kbd_out
+                    .wait_until_ready(Some(Duration::from_millis(500)))
+                {
+                    // Let the direct DriverKit backend finish its callback sequence
+                    // before we re-seize input devices. Seizing too early can race
                     // with IOKit enumeration triggered by those callbacks.
-                    std::thread::sleep(std::time::Duration::from_secs(1));
-                    info!("DriverKit output recovered — re-grabbing input devices");
+                    std::thread::sleep(Duration::from_secs(1));
+                    info!("output backend recovered — re-grabbing input devices");
                     break;
                 }
             }
+
+            {
+                let mut kanata = kanata.lock();
+                kanata
+                    .kbd_out
+                    .release_tracked_output_keys("output-backend-recovery");
+            }
+            PRESSED_KEYS.lock().clear();
 
             // Re-seize input devices using regrab_input() which creates a fresh
             // pipe and listener thread without re-initializing the sink client.

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -56,7 +56,10 @@ fn collect_and_sort_events(
     }
 }
 
-#[cfg(feature = "passthru_ahk")]
+#[cfg(any(
+    feature = "passthru_ahk",
+    all(feature = "simulated_input", feature = "simulated_output")
+))]
 use std::sync::mpsc::Sender as ASender;
 
 use kanata_keyberon::action::ReleasableState;
@@ -702,7 +705,10 @@ impl Kanata {
         })
     }
 
-    #[cfg(feature = "passthru_ahk")]
+    #[cfg(any(
+        feature = "passthru_ahk",
+        all(feature = "simulated_input", feature = "simulated_output")
+    ))]
     pub fn new_with_output_channel(
         args: &ValidatedArgs,
         tx: Option<ASender<InputEvent>>,

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -20,10 +20,12 @@ use kanata_parser::keys::*;
 use karabiner_driverkit::*;
 use objc::runtime::Class;
 use objc::{msg_send, sel, sel_impl};
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
 use std::io;
 use std::io::Error;
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Copy)]
 pub struct InputEvent {
@@ -104,28 +106,6 @@ impl KbdIn {
 
         if !device_names.is_empty() || register_device("") {
             if grab() {
-                // Wait for the DriverKit virtual keyboard to become ready.
-                // The pqrs client connects asynchronously; give it time.
-                let mut ready = false;
-                for i in 0..100 {
-                    if is_sink_ready() {
-                        ready = true;
-                        break;
-                    }
-                    if i % 10 == 0 && i > 0 {
-                        log::info!(
-                            "Waiting for DriverKit virtual keyboard... ({:.1}s)",
-                            i as f64 * 0.1
-                        );
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(100));
-                }
-                if !ready {
-                    log::warn!(
-                        "DriverKit virtual keyboard not ready after 10s. \
-                         Key output may fail until the daemon connects."
-                    );
-                }
                 Ok(Self { grabbed: true })
             } else {
                 Err(anyhow!("grab failed"))
@@ -277,12 +257,16 @@ impl TryFrom<KeyEvent> for InputEvent {
 }
 
 #[cfg(all(not(feature = "simulated_output"), not(feature = "passthru_ahk")))]
-pub struct KbdOut {}
+pub struct KbdOut {
+    output_pressed_since: HashMap<OsCode, Instant>,
+}
 
 #[cfg(all(not(feature = "simulated_output"), not(feature = "passthru_ahk")))]
 impl KbdOut {
     pub fn new() -> Result<Self, io::Error> {
-        Ok(KbdOut {})
+        Ok(KbdOut {
+            output_pressed_since: HashMap::default(),
+        })
     }
 
     pub fn write(&mut self, event: InputEvent) -> Result<(), io::Error> {
@@ -298,9 +282,52 @@ impl KbdOut {
         Ok(())
     }
 
+    pub fn output_ready(&self) -> bool {
+        is_sink_ready()
+    }
+
+    pub fn wait_until_ready(&self, timeout: Option<Duration>) -> bool {
+        let start = Instant::now();
+        let mut attempt = 0u32;
+
+        loop {
+            if self.output_ready() {
+                return true;
+            }
+
+            if let Some(timeout) = timeout
+                && start.elapsed() >= timeout
+            {
+                return false;
+            }
+
+            attempt += 1;
+            if attempt % 10 == 0 {
+                if let Some(timeout) = timeout {
+                    log::info!(
+                        "Waiting for DriverKit virtual keyboard... ({:.1}s/{:.1}s)",
+                        start.elapsed().as_secs_f64(),
+                        timeout.as_secs_f64()
+                    );
+                } else {
+                    log::info!(
+                        "Waiting for DriverKit virtual keyboard... ({:.1}s)",
+                        start.elapsed().as_secs_f64()
+                    );
+                }
+            }
+
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+
     pub fn write_key(&mut self, key: OsCode, value: KeyValue) -> Result<(), io::Error> {
         if let Ok(event) = InputEvent::try_from(KeyEvent { value, code: key }) {
-            self.write(event)
+            let result = self.write(event);
+            if result.is_ok() {
+                self.record_output_transition_after_write(key, value);
+            }
+            result
         } else {
             log::debug!("couldn't write unrecognized {key:?}");
             Err(io::Error::other("OsCode not recognized!"))
@@ -325,6 +352,24 @@ impl KbdOut {
 
     pub fn release_key(&mut self, key: OsCode) -> Result<(), io::Error> {
         self.write_key(key, KeyValue::Release)
+    }
+
+    pub fn release_tracked_output_keys(&mut self, reason: &str) {
+        let tracked_keys: Vec<OsCode> = self.output_pressed_since.keys().copied().collect();
+        if tracked_keys.is_empty() {
+            return;
+        }
+
+        for key in tracked_keys {
+            if let Err(error) = self.write_key(key, KeyValue::Release) {
+                log::warn!(
+                    "failed to release tracked output key during {} recovery: key={key:?} error={error}",
+                    reason
+                );
+            }
+        }
+
+        self.output_pressed_since.clear();
     }
 
     pub fn send_unicode(&mut self, c: char) -> Result<(), io::Error> {
@@ -489,6 +534,20 @@ impl KbdOut {
         let event = CGEvent::new(event_source)
             .map_err(|_| Error::other("failed to create core graphics event"))?;
         Ok(event)
+    }
+
+    fn record_output_transition_after_write(&mut self, key: OsCode, value: KeyValue) {
+        match value {
+            KeyValue::Press | KeyValue::Repeat => {
+                self.output_pressed_since
+                    .entry(key)
+                    .or_insert_with(Instant::now);
+            }
+            KeyValue::Release => {
+                self.output_pressed_since.remove(&key);
+            }
+            KeyValue::Tap | KeyValue::WakeUp => {}
+        }
     }
 
     /// Applies a calculated mouse move to a CGPoint.

--- a/src/oskbd/sim_passthru.rs
+++ b/src/oskbd/sim_passthru.rs
@@ -74,6 +74,12 @@ impl KbdOut {
         }
         Ok(())
     }
+    pub fn output_ready(&self) -> bool {
+        true
+    }
+    pub fn wait_until_ready(&self, _timeout: Option<std::time::Duration>) -> bool {
+        true
+    }
     pub fn write_key(&mut self, key: OsCode, value: KeyValue) -> Result<(), io::Error> {
         let key_ev = KeyEvent::new(key, value);
         let event = {
@@ -98,6 +104,7 @@ impl KbdOut {
     pub fn release_key(&mut self, key: OsCode) -> Result<(), io::Error> {
         self.write_key(key, KeyValue::Release)
     }
+    pub fn release_tracked_output_keys(&mut self, _reason: &str) {}
     pub fn send_unicode(&mut self, c: char) -> Result<(), io::Error> {
         trace!("outU:{c}");
         Ok(())

--- a/src/oskbd/simulated.rs
+++ b/src/oskbd/simulated.rs
@@ -371,6 +371,12 @@ impl KbdOut {
         self.outputs.push(format!("out:{event}"));
         Ok(())
     }
+    pub fn output_ready(&self) -> bool {
+        true
+    }
+    pub fn wait_until_ready(&self, _timeout: Option<std::time::Duration>) -> bool {
+        true
+    }
     pub fn write_key(&mut self, key: OsCode, value: KeyValue) -> Result<(), io::Error> {
         let key_ev = KeyEvent::new(key, value);
         let event = {
@@ -398,6 +404,7 @@ impl KbdOut {
         self.log.release_key(key);
         self.write_key(key, KeyValue::Release)
     }
+    pub fn release_tracked_output_keys(&mut self, _reason: &str) {}
     pub fn send_unicode(&mut self, c: char) -> Result<(), io::Error> {
         self.log.send_unicode(c);
         self.outputs.push(format!("outU:{c}"));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,6 +8,13 @@ use std::sync::Mutex;
 ))]
 mod sim_tests;
 
+#[cfg(all(
+    target_os = "macos",
+    feature = "simulated_input",
+    feature = "simulated_output"
+))]
+mod passthru_macos_tests;
+
 static CFG_PARSE_LOCK: Mutex<()> = Mutex::new(());
 
 fn init_log() {

--- a/src/tests/passthru_macos_tests.rs
+++ b/src/tests/passthru_macos_tests.rs
@@ -1,0 +1,36 @@
+use crate::oskbd::{KeyEvent, KeyValue};
+use crate::{Kanata, ValidatedArgs, str_to_oscode};
+use std::path::PathBuf;
+use std::sync::mpsc;
+
+fn passthru_args() -> ValidatedArgs {
+    ValidatedArgs {
+        paths: vec![PathBuf::from("./cfg_samples/minimal.kbd")],
+        #[cfg(feature = "tcp_server")]
+        tcp_server_address: None,
+        nodelay: true,
+    }
+}
+
+#[test]
+fn passthru_runtime_output_channel_is_ready_and_emits_events() {
+    let args = passthru_args();
+    let (tx, rx) = mpsc::channel();
+    let runtime = Kanata::new_with_output_channel(&args, Some(tx)).expect("passthru runtime");
+
+    {
+        let mut runtime = runtime.lock();
+        assert!(runtime.kbd_out.output_ready());
+
+        let key = str_to_oscode("a").expect("key code");
+        runtime
+            .kbd_out
+            .write_key(key, KeyValue::Press)
+            .expect("write key through passthru output");
+    }
+
+    let event = rx.try_recv().expect("passthru output event");
+    let key_event = KeyEvent::try_from(event).expect("output event should decode");
+    assert_eq!(key_event.code, str_to_oscode("a").expect("key code"));
+    assert_eq!(key_event.value, KeyValue::Press);
+}


### PR DESCRIPTION
This PR makes a narrow macOS backend cleanup.

Before this change, the macOS event loop directly depended on the direct DriverKit output path for output readiness checks. That made the event loop more tightly coupled to one output transport than necessary.

This change moves output readiness behind `KbdOut` so the event loop depends on the macOS output backend rather than hard-coding direct DriverKit readiness calls.

What changes:
- macOS event loop now uses `KbdOut` for output readiness
- direct DriverKit readiness remains implemented by the default macOS backend
- simulated/passthrough output backends implement the same readiness surface
- input setup no longer waits on output sink readiness
- `new_with_output_channel(...)` is available for the simulated-input + simulated-output passthrough-style build

What does not change:
- standalone Kanata on macOS still uses the direct DriverKit backend by default
- no Linux or Windows behavior changes
- no app-specific or product-specific IPC logic is introduced

Why this seems worth upstreaming:
- reduces macOS backend coupling
- preserves current behavior
- keeps the change local to backend code
- makes alternate macOS output backends possible without changing Kanata core semantics

Validation:
- `cargo build`
- `cargo test --features simulated_input,simulated_output passthru_runtime_output_channel_is_ready_and_emits_events`
