### PR TITLE
Added kwanata info to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You can see a [list of known issues here](./docs/platform-known-issues.adoc).
 ### Demo
 
 #### Demo video
+
 [Showcase of multi-layer functionality (30s, 1.7 MB)](https://user-images.githubusercontent.com/6634136/183001314-f64a7e26-4129-4f20-bf26-7165a6e02c38.mp4).
 
 #### Online simulator
@@ -165,6 +166,7 @@ For example:
 cargo build --release --features cmd,interception_driver
 cargo install --features cmd,interception_driver
 ```
+
 </details>
 
 ## Other installation methods
@@ -201,6 +203,7 @@ Unless explicitly stated otherwise, your contributions to kanata will be made
 under the LGPL-3.0-only[*] license.
 
 Some directories are exceptions:
+
 - [keyberon](./keyberon): MIT License
 - [interception](./interception): MIT or Apache-2.0 Licenses
 
@@ -226,13 +229,14 @@ Some directories are exceptions:
 - [kanata-tray](https://github.com/rszyma/kanata-tray): Control kanata from a tray icon
 - [OverKeys](https://github.com/conventoangelo/overkeys): Visual layer display for kanata - see your active layers and keymaps in real-time (Windows)
 - Application-aware layer switching:
-   - [qanata (Linux)](https://github.com/veyxov/qanata)
-   - [kanawin (Windows)](https://github.com/Aqaao/kanawin)
-   - [window_tools (Windows)](https://github.com/reidprichard/window_tools)
-   - [nata (Linux)](https://github.com/mdSlash/nata)
-   - [kanata-vk-agent (macOS)](https://github.com/devsunb/kanata-vk-agent)
-   - [hyprkan (Linux)](https://github.com/mdSlash/hyprkan)
-   - [kanata-switcher (Linux, all DEs)](https://github.com/7mind/kanata-switcher)
+  - [qanata (Linux)](https://github.com/veyxov/qanata)
+  - [kanawin (Windows)](https://github.com/Aqaao/kanawin)
+  - [window_tools (Windows)](https://github.com/reidprichard/window_tools)
+  - [nata (Linux)](https://github.com/mdSlash/nata)
+  - [kanata-vk-agent (macOS)](https://github.com/devsunb/kanata-vk-agent)
+  - [hyprkan (Linux)](https://github.com/mdSlash/hyprkan)
+  - [kanata-switcher (Linux, all DEs)](https://github.com/7mind/kanata-switcher)
+  - [kwanata (Linux-KDE)](https://github.com/jfsicilia/kwanata): A KDE Plasma companion for Kanata - Automatically activates Kanata's layers/virtualkeys and launches or raises apps.
 
 ## What does the name mean?
 
@@ -296,6 +300,7 @@ at the time of writing that make kmonad suboptimal for my personal workflows.
 This project is written in Rust because Rust is my favourite programming
 language and the prior work of the awesome [keyberon crate](https://github.com/TeXitoi/keyberon)
 exists.
+
 </details>
 
 ## Similar Projects


### PR DESCRIPTION
Added a new application-aware layer switching for Linux KDE Plasma systems. Besides allowing layer/vkey switch on app change, it provides an easy way to launch or raise an app from a kanata key combo. 

