### PR TITLE
feat: add per-action require-prior-idle override for tap-hold

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2074,6 +2074,11 @@ This is useful for home row mods where fast typing should not trigger modifiers.
 Requires a `defhands` directive. Supports list-form options for fine-grained control.
 See <<defhands and tap-hold-opposite-hand>> below.
 |===
+
+All `tap-hold` variants support an optional trailing `(require-prior-idle <ms>)` option
+to override the global <<tap-hold-require-prior-idle>> setting for that specific action.
+Use `(require-prior-idle 0)` to disable idle detection for a specific key.
+
 **Description**
 
 The `+tap-hold+` action allows you to have one action/key for a "tap" and a
@@ -4157,6 +4162,47 @@ The default value is `0` (disabled) and the unit is milliseconds.
 - When `tap-hold-require-prior-idle` triggers, the tap action is chosen before any other
   `tap-hold` configuration (e.g., `tap-hold-opposite-hand`, `concurrent-tap-hold`)
   is consulted.
+
+==== Per-action override
+
+The global `tap-hold-require-prior-idle` value can be overridden on individual
+`tap-hold` actions using the `(require-prior-idle <ms>)` option.
+This is useful when most keys benefit from idle detection (e.g., home-row mods)
+but specific keys (e.g., a layer-tap key) need immediate activation even during
+fast typing.
+
+The option can be appended to any `tap-hold` variant as a trailing
+`(keyword value)` list:
+
+.Example: disable for a specific key
+[source]
+----
+(defcfg tap-hold-require-prior-idle 150)
+(defalias
+  ;; HRMs use the global 150ms threshold
+  a (tap-hold 200 200 a lmet)
+  s (tap-hold 200 200 s lalt)
+  ;; Layer key disables idle detection for immediate activation
+  nav (tap-hold 200 200 tab (layer-toggle nav) (require-prior-idle 0))
+)
+----
+
+.Example: enable for a specific key without a global setting
+[source]
+----
+(defalias
+  a (tap-hold 200 200 a lmet (require-prior-idle 150))
+)
+----
+
+- `(require-prior-idle 0)` disables the feature for that action,
+  even when a global threshold is set.
+- A non-zero value enables or changes the threshold for that action only.
+- When no per-action override is specified, the global `defcfg` value is used.
+- Works with all `tap-hold` variants: `tap-hold`, `tap-hold-press`,
+  `tap-hold-release`, `tap-hold-press-timeout`, `tap-hold-release-timeout`,
+  `tap-hold-release-keys`, `tap-hold-except-keys`, `tap-hold-tap-keys`,
+  and `tap-hold-opposite-hand`.
 
 [[override-release-on-activation]]
 === override-release-on-activation

--- a/keyberon/src/action.rs
+++ b/keyberon/src/action.rs
@@ -177,6 +177,10 @@ where
     /// because a human might have a slow release but they did
     /// indeed want a hold to activate.
     pub on_press_reset_timeout_to: Option<std::num::NonZeroU16>,
+    /// Per-action override for the global `tap_hold_require_prior_idle` setting.
+    /// If `Some(n)`, uses `n` instead of the global value (0 = disabled for this action).
+    /// If `None`, falls back to the global `defcfg` value.
+    pub require_prior_idle: Option<u16>,
 }
 
 /// Define one shot key behaviour.

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -1829,17 +1829,18 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
                 config,
                 tap_hold_interval,
                 on_press_reset_timeout_to,
+                require_prior_idle,
             }) => {
                 // Typing streak detection: if a different physical key was pressed
                 // recently, resolve as tap immediately without entering WaitingState.
-                if self.tap_hold_require_prior_idle > 0 {
+                // Per-action override takes precedence over the global defcfg value.
+                let idle_threshold = require_prior_idle.unwrap_or(self.tap_hold_require_prior_idle);
+                if idle_threshold > 0 {
                     let prior_idle_tap = self
                         .historical_inputs
                         .iter_hevents()
                         .find(|prior| prior.event.0 == REAL_KEY_ROW && prior.event != coord)
-                        .is_some_and(|prior| {
-                            prior.ticks_since_occurrence <= self.tap_hold_require_prior_idle
-                        });
+                        .is_some_and(|prior| prior.ticks_since_occurrence <= idle_threshold);
                     if prior_idle_tap {
                         let custom = self.do_action(tap, coord, delay, is_oneshot, layer_stack);
                         self.last_press_tracker.update_coord(coord);
@@ -2298,6 +2299,7 @@ mod test {
             [[
                 HoldTap(&HoldTapAction {
                     on_press_reset_timeout_to: None,
+                    require_prior_idle: None,
                     timeout: 200,
                     hold: l(1),
                     tap: k(Space),
@@ -2307,6 +2309,7 @@ mod test {
                 }),
                 HoldTap(&HoldTapAction {
                     on_press_reset_timeout_to: None,
+                    require_prior_idle: None,
                     timeout: 200,
                     hold: k(LCtrl),
                     timeout_action: k(LShift),
@@ -2352,6 +2355,7 @@ mod test {
             [[
                 HoldTap(&HoldTapAction {
                     on_press_reset_timeout_to: None,
+                    require_prior_idle: None,
                     timeout: 200,
                     hold: l(1),
                     tap: k(Space),
@@ -2361,6 +2365,7 @@ mod test {
                 }),
                 HoldTap(&HoldTapAction {
                     on_press_reset_timeout_to: None,
+                    require_prior_idle: None,
                     timeout: 200,
                     hold: k(LCtrl),
                     timeout_action: k(LCtrl),
@@ -2405,6 +2410,7 @@ mod test {
         static LAYERS: Layers<2, 1> = &[[[
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(LAlt),
                 timeout_action: k(LAlt),
@@ -2414,6 +2420,7 @@ mod test {
             }),
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 20,
                 hold: k(LCtrl),
                 timeout_action: k(LCtrl),
@@ -2456,6 +2463,7 @@ mod test {
         static LAYERS: Layers<2, 1> = &[[[
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(LAlt),
                 timeout_action: k(LAlt),
@@ -2515,6 +2523,7 @@ mod test {
         static LAYERS: Layers<2, 1> = &[[[
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(LAlt),
                 timeout_action: k(LAlt),
@@ -2556,6 +2565,7 @@ mod test {
         static LAYERS: Layers<3, 1> = &[[[
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(LAlt),
                 timeout_action: k(LAlt),
@@ -2565,6 +2575,7 @@ mod test {
             }),
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(RAlt),
                 timeout_action: k(RAlt),
@@ -2574,6 +2585,7 @@ mod test {
             }),
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(LCtrl),
                 timeout_action: k(LCtrl),
@@ -2739,6 +2751,7 @@ mod test {
         static LAYERS: Layers<4, 1> = &[[[
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(Kb1),
                 timeout_action: k(Kb1),
@@ -2748,6 +2761,7 @@ mod test {
             }),
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(Kb3),
                 timeout_action: k(Kb3),
@@ -2757,6 +2771,7 @@ mod test {
             }),
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(Kb5),
                 timeout_action: k(Kb5),
@@ -2766,6 +2781,7 @@ mod test {
             }),
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(Kb7),
                 timeout_action: k(Kb7),
@@ -2840,6 +2856,7 @@ mod test {
         static LAYERS: Layers<2, 1> = &[[[
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(LAlt),
                 timeout_action: k(LAlt),
@@ -2896,6 +2913,7 @@ mod test {
         static LAYERS: Layers<3, 1> = &[[[
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(LAlt),
                 timeout_action: k(LAlt),
@@ -2906,6 +2924,7 @@ mod test {
             k(Enter),
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(LAlt),
                 timeout_action: k(LAlt),
@@ -3020,6 +3039,7 @@ mod test {
     fn tap_hold_interval_short_hold() {
         static LAYERS: Layers<1, 1> = &[[[HoldTap(&HoldTapAction {
             on_press_reset_timeout_to: None,
+            require_prior_idle: None,
             timeout: 50,
             hold: k(LAlt),
             timeout_action: k(LAlt),
@@ -3064,6 +3084,7 @@ mod test {
         static LAYERS: Layers<2, 1> = &[[[
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 50,
                 hold: k(LAlt),
                 timeout_action: k(LAlt),
@@ -3073,6 +3094,7 @@ mod test {
             }),
             HoldTap(&HoldTapAction {
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
                 timeout: 200,
                 hold: k(RAlt),
                 timeout_action: k(RAlt),
@@ -3591,6 +3613,7 @@ mod test {
                 }),
                 HoldTap(&HoldTapAction {
                     on_press_reset_timeout_to: None,
+                    require_prior_idle: None,
                     timeout: 100,
                     hold: k(LAlt),
                     timeout_action: k(LAlt),
@@ -3657,6 +3680,7 @@ mod test {
                         }),
                         &HoldTap(&HoldTapAction {
                             on_press_reset_timeout_to: None,
+                            require_prior_idle: None,
                             timeout: 100,
                             hold: k(LAlt),
                             timeout_action: k(LAlt),
@@ -4098,6 +4122,7 @@ mod test {
                     1,
                     &HoldTap(&HoldTapAction {
                         on_press_reset_timeout_to: None,
+                        require_prior_idle: None,
                         timeout: 100,
                         hold: k(A),
                         timeout_action: k(A),
@@ -4110,6 +4135,7 @@ mod test {
                     2,
                     &HoldTap(&HoldTapAction {
                         on_press_reset_timeout_to: None,
+                        require_prior_idle: None,
                         timeout: 100,
                         hold: k(B),
                         timeout_action: k(B),
@@ -4362,6 +4388,7 @@ mod test {
                 NoOp,
                 HoldTap(&HoldTapAction {
                     on_press_reset_timeout_to: None,
+                    require_prior_idle: None,
                     timeout: 50,
                     hold: k(Space),
                     timeout_action: k(Space),
@@ -4410,6 +4437,7 @@ mod test {
                 NoOp,
                 HoldTap(&HoldTapAction {
                     on_press_reset_timeout_to: None,
+                    require_prior_idle: None,
                     timeout: 50,
                     hold: Trans,
                     timeout_action: Trans,
@@ -4646,6 +4674,7 @@ mod test {
                 NoOp,
                 HoldTap(&HoldTapAction {
                     on_press_reset_timeout_to: None,
+                    require_prior_idle: None,
                     timeout: 50,
                     hold: k(B),
                     timeout_action: k(B),
@@ -4660,6 +4689,7 @@ mod test {
                 Layer(3),
                 HoldTap(&HoldTapAction {
                     on_press_reset_timeout_to: None,
+                    require_prior_idle: None,
                     timeout: 50,
                     hold: k(C),
                     timeout_action: k(C),
@@ -4674,6 +4704,7 @@ mod test {
                 NoOp,
                 HoldTap(&HoldTapAction {
                     on_press_reset_timeout_to: None,
+                    require_prior_idle: None,
                     timeout: 50,
                     hold: k(D),
                     timeout_action: k(D),
@@ -4788,6 +4819,7 @@ mod test {
             config: HoldTapConfig::Default,
             tap_hold_interval: 0,
             on_press_reset_timeout_to: None,
+            require_prior_idle: None,
         })]]];
         let mut layout = Layout::new(LAYERS);
         // Nothing set initially.
@@ -4821,6 +4853,7 @@ mod test {
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 0,
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
             }),
             k(A),
         ]]];
@@ -4854,6 +4887,7 @@ mod test {
                 config: HoldTapConfig::PermissiveHold,
                 tap_hold_interval: 0,
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
             }),
             k(A),
         ]]];
@@ -4889,6 +4923,7 @@ mod test {
                 config: HoldTapConfig::HoldOnOtherKeyPress,
                 tap_hold_interval: 0,
                 on_press_reset_timeout_to: None,
+                require_prior_idle: None,
             }),
             k(A),
         ]]];

--- a/parser/src/cfg/defhands.rs
+++ b/parser/src/cfg/defhands.rs
@@ -107,6 +107,7 @@ pub(super) fn parse_tap_hold_opposite_hand(
     let mut neutral_behavior = DecisionBehavior::Ignore;
     let mut unknown_hand = DecisionBehavior::Ignore;
     let mut neutral_keys: Vec<OsCode> = Vec::new();
+    let mut require_prior_idle: Option<u16> = None;
     let mut seen_options: HashSet<&str> = HashSet::default();
 
     for option_expr in &ac_params[3..] {
@@ -175,10 +176,17 @@ pub(super) fn parse_tap_hold_opposite_hand(
                 }
                 neutral_keys = parse_key_atoms(&option[1..], s, "neutral-keys")?;
             }
+            "require-prior-idle" => {
+                require_prior_idle = Some(tap_hold::parse_require_prior_idle_option(
+                    option,
+                    option_expr,
+                    s,
+                )?);
+            }
             _ => bail_expr!(
                 &option[0],
                 "unknown option '{}' for tap-hold-opposite-hand. \
-                Valid options: timeout, same-hand, neutral, unknown-hand, neutral-keys",
+                Valid options: timeout, same-hand, neutral, unknown-hand, neutral-keys, require-prior-idle",
                 kw
             ),
         }
@@ -207,6 +215,7 @@ pub(super) fn parse_tap_hold_opposite_hand(
         hold: *hold_action,
         timeout_action: *timeout_action,
         on_press_reset_timeout_to: None,
+        require_prior_idle,
     }))))
 }
 

--- a/parser/src/cfg/tap_hold.rs
+++ b/parser/src/cfg/tap_hold.rs
@@ -1,19 +1,107 @@
 use super::*;
 
+use crate::anyhow_expr;
 use crate::bail;
 use crate::bail_expr;
+
+/// Options that can be specified as trailing `(keyword value)` lists on any tap-hold action.
+#[derive(Default)]
+pub(crate) struct TapHoldOptions {
+    pub(crate) require_prior_idle: Option<u16>,
+}
+
+/// Parse the value of a `(require-prior-idle <ms>)` option list.
+/// Validates that the list has exactly 2 items and the value is a u16.
+pub(crate) fn parse_require_prior_idle_option(
+    option: &[SExpr],
+    option_expr: &SExpr,
+    s: &ParserState,
+) -> Result<u16> {
+    if option.len() != 2 {
+        bail_expr!(
+            option_expr,
+            "require-prior-idle option expects exactly 2 items: \
+            `(require-prior-idle <ms>)`"
+        );
+    }
+    parse_u16(&option[1], s, "require-prior-idle")
+}
+
+/// Parse trailing `(keyword value)` option lists from tap-hold action parameters.
+/// Returns the parsed options. Errors on unknown or duplicate options.
+pub(crate) fn parse_tap_hold_options(
+    option_exprs: &[SExpr],
+    s: &ParserState,
+) -> Result<TapHoldOptions> {
+    let mut opts = TapHoldOptions::default();
+    let mut seen_options: HashSet<&str> = HashSet::default();
+
+    for option_expr in option_exprs {
+        let Some(option) = option_expr.list(s.vars()) else {
+            bail_expr!(
+                option_expr,
+                "expected option list, e.g. `(require-prior-idle 150)`"
+            );
+        };
+        if option.is_empty() {
+            bail_expr!(option_expr, "option list cannot be empty");
+        }
+        let kw = option[0]
+            .atom(s.vars())
+            .ok_or_else(|| anyhow_expr!(&option[0], "option name must be a string"))?;
+        if !seen_options.insert(kw) {
+            bail_expr!(&option[0], "duplicate option '{}'", kw);
+        }
+        match kw {
+            "require-prior-idle" => {
+                opts.require_prior_idle =
+                    Some(parse_require_prior_idle_option(option, option_expr, s)?);
+            }
+            _ => bail_expr!(
+                &option[0],
+                "unknown tap-hold option '{}'. \
+                Valid options: require-prior-idle",
+                kw
+            ),
+        }
+    }
+    Ok(opts)
+}
+
+const TAP_HOLD_OPTION_KEYWORDS: &[&str] = &["require-prior-idle"];
+
+/// Count how many trailing expressions are tap-hold option lists.
+/// An option list is a list whose first element is a known option keyword.
+/// Stops at the first non-option expression (scanning from the end).
+fn count_trailing_options(ac_params: &[SExpr], s: &ParserState) -> usize {
+    let mut count = 0;
+    for expr in ac_params.iter().rev() {
+        if let Some(list) = expr.list(s.vars()) {
+            if let Some(kw) = list.first().and_then(|e| e.atom(s.vars())) {
+                if TAP_HOLD_OPTION_KEYWORDS.contains(&kw) {
+                    count += 1;
+                    continue;
+                }
+            }
+        }
+        break;
+    }
+    count
+}
 
 pub(crate) fn parse_tap_hold(
     ac_params: &[SExpr],
     s: &ParserState,
     config: HoldTapConfig<'static>,
 ) -> Result<&'static KanataAction> {
-    if ac_params.len() != 4 {
+    let n_opts = count_trailing_options(ac_params, s);
+    let n_positional = ac_params.len() - n_opts;
+    if n_positional != 4 {
         bail!(
             r"tap-hold expects 4 items after it, got {}.
 Params in order:
 <tap-repress-timeout> <hold-timeout> <tap-action> <hold-action>",
-            ac_params.len(),
+            n_positional,
         )
     }
     let tap_repress_timeout = parse_u16(&ac_params[0], s, "tap repress timeout")?;
@@ -23,6 +111,7 @@ Params in order:
     if matches!(tap_action, Action::HoldTap { .. }) {
         bail!("tap-hold does not work in the tap-action of tap-hold")
     }
+    let opts = parse_tap_hold_options(&ac_params[n_positional..], s)?;
     Ok(s.a.sref(Action::HoldTap(s.a.sref(HoldTapAction {
         config,
         tap_hold_interval: tap_repress_timeout,
@@ -31,6 +120,7 @@ Params in order:
         hold: *hold_action,
         timeout_action: *hold_action,
         on_press_reset_timeout_to: None,
+        require_prior_idle: opts.require_prior_idle,
     }))))
 }
 
@@ -41,23 +131,25 @@ pub(crate) fn parse_tap_hold_timeout(
 ) -> Result<&'static KanataAction> {
     const PARAMS_FOR_RELEASE: &str = "Params in order:\n\
        <tap-repress-timeout> <hold-timeout> <tap-action> <hold-action> <timeout-action> [?reset-timeout-on-press]";
+    let n_opts = count_trailing_options(ac_params, s);
+    let n_positional = ac_params.len() - n_opts;
     match config {
         HoldTapConfig::PermissiveHold => {
-            if ac_params.len() != 5 && ac_params.len() != 6 {
+            if n_positional != 5 && n_positional != 6 {
                 bail!(
                     "tap-hold-release-timeout expects at least 5 items after it, got {}.\n\
                     {PARAMS_FOR_RELEASE}",
-                    ac_params.len(),
+                    n_positional,
                 )
             }
         }
         HoldTapConfig::HoldOnOtherKeyPress => {
-            if ac_params.len() != 5 {
+            if n_positional != 5 {
                 bail!(
                     "tap-hold-press-timeout expects 5 items after it, got {}.\n\
                     Params in order:\n\
                     <tap-repress-timeout> <hold-timeout> <tap-action> <hold-action> <timeout-action>",
-                    ac_params.len(),
+                    n_positional,
                 )
             }
         }
@@ -72,7 +164,7 @@ pub(crate) fn parse_tap_hold_timeout(
         bail!("tap-hold does not work in the tap-action of tap-hold")
     }
     let on_press_reset_timeout_to = match config {
-        HoldTapConfig::PermissiveHold => match ac_params.len() {
+        HoldTapConfig::PermissiveHold => match n_positional {
             6 => match ac_params[5].atom(s.vars()) {
                 Some("reset-timeout-on-press") => std::num::NonZeroU16::new(hold_timeout),
                 _ => bail_expr!(&ac_params[5], "Unexpected parameter.\n{PARAMS_FOR_RELEASE}"),
@@ -83,6 +175,7 @@ pub(crate) fn parse_tap_hold_timeout(
         HoldTapConfig::HoldOnOtherKeyPress => None,
         _ => unreachable!("other configs not expected"),
     };
+    let opts = parse_tap_hold_options(&ac_params[n_positional..], s)?;
     Ok(s.a.sref(Action::HoldTap(s.a.sref(HoldTapAction {
         config,
         tap_hold_interval: tap_repress_timeout,
@@ -91,6 +184,7 @@ pub(crate) fn parse_tap_hold_timeout(
         hold: *hold_action,
         timeout_action: *timeout_action,
         on_press_reset_timeout_to,
+        require_prior_idle: opts.require_prior_idle,
     }))))
 }
 
@@ -100,13 +194,15 @@ pub(crate) fn parse_tap_hold_keys(
     custom_name: &str,
     custom_func: TapHoldCustomFunc,
 ) -> Result<&'static KanataAction> {
-    if ac_params.len() != 5 {
+    let n_opts = count_trailing_options(ac_params, s);
+    let n_positional = ac_params.len() - n_opts;
+    if n_positional != 5 {
         bail!(
             r"{} expects 5 items after it, got {}.
 Params in order:
 <tap-repress-timeout> <hold-timeout> <tap-action> <hold-action> <tap-trigger-keys>",
             custom_name,
-            ac_params.len(),
+            n_positional,
         )
     }
     let tap_repress_timeout = parse_u16(&ac_params[0], s, "tap repress timeout")?;
@@ -117,6 +213,7 @@ Params in order:
     if matches!(tap_action, Action::HoldTap { .. }) {
         bail!("tap-hold does not work in the tap-action of tap-hold")
     }
+    let opts = parse_tap_hold_options(&ac_params[n_positional..], s)?;
     Ok(s.a.sref(Action::HoldTap(s.a.sref(HoldTapAction {
         config: HoldTapConfig::Custom(custom_func(&tap_trigger_keys, &s.a)),
         tap_hold_interval: tap_repress_timeout,
@@ -125,6 +222,7 @@ Params in order:
         hold: *hold_action,
         timeout_action: *hold_action,
         on_press_reset_timeout_to: None,
+        require_prior_idle: opts.require_prior_idle,
     }))))
 }
 
@@ -132,13 +230,15 @@ pub(crate) fn parse_tap_hold_keys_trigger_tap_release(
     ac_params: &[SExpr],
     s: &ParserState,
 ) -> Result<&'static KanataAction> {
-    if !matches!(ac_params.len(), 6) {
+    let n_opts = count_trailing_options(ac_params, s);
+    let n_positional = ac_params.len() - n_opts;
+    if n_positional != 6 {
         bail!(
             r"{} expects 6 items after it, got {}.
 Params in order:
 <tap-repress-timeout> <hold-timeout> <tap-action> <hold-action> <tap-trigger-keys-on-press> <tap-trigger-keys-on-press-then-release>",
             TAP_HOLD_RELEASE_KEYS_TAP_RELEASE,
-            ac_params.len(),
+            n_positional,
         )
     }
     let tap_repress_timeout = parse_u16(&ac_params[0], s, "tap repress timeout")?;
@@ -152,6 +252,7 @@ Params in order:
     if matches!(tap_action, Action::HoldTap { .. }) {
         bail!("tap-hold does not work in the tap-action of tap-hold")
     }
+    let opts = parse_tap_hold_options(&ac_params[n_positional..], s)?;
     Ok(s.a.sref(Action::HoldTap(s.a.sref(HoldTapAction {
         config: HoldTapConfig::Custom(custom_tap_hold_release_trigger_tap_release(
             &tap_trigger_keys_on_press,
@@ -164,5 +265,6 @@ Params in order:
         hold: *hold_action,
         timeout_action: *hold_action,
         on_press_reset_timeout_to: None,
+        require_prior_idle: opts.require_prior_idle,
     }))))
 }

--- a/parser/src/cfg/tests/defcfg.rs
+++ b/parser/src/cfg/tests/defcfg.rs
@@ -160,3 +160,154 @@ fn tap_hold_require_prior_idle_rejects_non_numeric() {
         //.map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
         .expect_err("fails");
 }
+
+#[test]
+fn per_action_require_prior_idle_parses() {
+    let source = "
+(defsrc a)
+(deflayer base @a)
+(defalias a (tap-hold 200 200 a lctl (require-prior-idle 100)))
+";
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+}
+
+#[test]
+fn per_action_require_prior_idle_zero_parses() {
+    let source = "
+(defsrc a)
+(deflayer base @a)
+(defalias a (tap-hold 200 200 a lctl (require-prior-idle 0)))
+";
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+}
+
+#[test]
+fn per_action_require_prior_idle_rejects_non_numeric() {
+    let source = "
+(defsrc a)
+(deflayer base @a)
+(defalias a (tap-hold 200 200 a lctl (require-prior-idle nope)))
+";
+    parse_cfg(source).map(|_| ()).expect_err("fails");
+}
+
+#[test]
+fn per_action_require_prior_idle_rejects_unknown_option() {
+    let source = "
+(defsrc a)
+(deflayer base @a)
+(defalias a (tap-hold 200 200 a lctl (unknown-option 100)))
+";
+    parse_cfg(source).map(|_| ()).expect_err("fails");
+}
+
+#[test]
+fn per_action_require_prior_idle_rejects_duplicate() {
+    let source = "
+(defsrc a)
+(deflayer base @a)
+(defalias a (tap-hold 200 200 a lctl (require-prior-idle 100) (require-prior-idle 50)))
+";
+    parse_cfg(source).map(|_| ()).expect_err("fails");
+}
+
+#[test]
+fn per_action_require_prior_idle_on_tap_hold_press() {
+    let source = "
+(defsrc a)
+(deflayer base @a)
+(defalias a (tap-hold-press 200 200 a lctl (require-prior-idle 100)))
+";
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+}
+
+#[test]
+fn per_action_require_prior_idle_on_tap_hold_release() {
+    let source = "
+(defsrc a)
+(deflayer base @a)
+(defalias a (tap-hold-release 200 200 a lctl (require-prior-idle 100)))
+";
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+}
+
+#[test]
+fn per_action_require_prior_idle_on_tap_hold_release_timeout() {
+    let source = "
+(defsrc a)
+(deflayer base @a)
+(defalias a (tap-hold-release-timeout 200 200 a lctl lalt (require-prior-idle 100)))
+";
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+}
+
+#[test]
+fn per_action_require_prior_idle_on_tap_hold_press_timeout() {
+    let source = "
+(defsrc a)
+(deflayer base @a)
+(defalias a (tap-hold-press-timeout 200 200 a lctl lalt (require-prior-idle 100)))
+";
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+}
+
+#[test]
+fn per_action_require_prior_idle_on_tap_hold_release_keys() {
+    let source = "
+(defsrc a b)
+(deflayer base @a b)
+(defalias a (tap-hold-release-keys 200 200 a lctl (b) (require-prior-idle 100)))
+";
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+}
+
+#[test]
+fn per_action_require_prior_idle_on_tap_hold_except_keys() {
+    let source = "
+(defsrc a b)
+(deflayer base @a b)
+(defalias a (tap-hold-except-keys 200 200 a lctl (b) (require-prior-idle 100)))
+";
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+}
+
+#[test]
+fn per_action_require_prior_idle_on_tap_hold_opposite_hand() {
+    let source = "
+(defhands (left a s d f g) (right h j k l ;))
+(defsrc a)
+(deflayer base @a)
+(defalias a (tap-hold-opposite-hand 200 a lctl (require-prior-idle 100)))
+";
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+}
+
+#[test]
+fn per_action_require_prior_idle_on_tap_hold_release_tap_keys_release() {
+    let source = "
+(defsrc a b c)
+(deflayer base @a b c)
+(defalias a (tap-hold-release-tap-keys-release 200 200 a lctl (b) (c) (require-prior-idle 100)))
+";
+    parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+}

--- a/src/tests/sim_tests/tap_hold_tests.rs
+++ b/src/tests/sim_tests/tap_hold_tests.rs
@@ -581,3 +581,134 @@ fn tap_hold_require_prior_idle_ignores_virtual_keys() {
     // Virtual key outputs A, then d times out to hold (lctl).
     assert_eq!("dn:A t:1ms up:A t:209ms dn:LCtrl t:50ms up:LCtrl", result);
 }
+
+// ========== per-action require-prior-idle override tests ==========
+
+#[test]
+fn per_action_require_prior_idle_overrides_global() {
+    // Global defcfg sets 150ms, but per-action override sets 50ms.
+    // A prior key 60ms ago is within 150ms (global) but outside 50ms (per-action).
+    // Per-action should win: normal hold behavior, not tap.
+    let result = simulate(
+        "
+(defcfg tap-hold-require-prior-idle 150)
+(defsrc a d)
+(deflayer base a @d)
+(defalias d (tap-hold 200 200 d lctl (require-prior-idle 50)))
+        ",
+        "d:a t:10 u:a t:50 d:d t:250 u:d t:50",
+    )
+    .to_ascii();
+    // 60ms gap > 50ms per-action threshold → normal hold
+    assert_eq!("dn:A t:10ms up:A t:250ms dn:LCtrl t:50ms up:LCtrl", result);
+}
+
+#[test]
+fn per_action_require_prior_idle_disable_overrides_global() {
+    // Global defcfg sets 150ms, but per-action override sets 0 (disabled).
+    // Even during a typing streak, this action should use normal tap-hold.
+    let result = simulate(
+        "
+(defcfg tap-hold-require-prior-idle 150)
+(defsrc a d)
+(deflayer base a @d)
+(defalias d (tap-hold 200 200 d lctl (require-prior-idle 0)))
+        ",
+        // a pressed 20ms ago, well within 150ms global threshold.
+        // But per-action disables it, so d enters normal WaitingState.
+        "d:a t:10 u:a t:10 d:d t:250 u:d t:50",
+    )
+    .to_ascii();
+    // d enters hold (250ms > 200ms timeout)
+    assert_eq!("dn:A t:10ms up:A t:210ms dn:LCtrl t:50ms up:LCtrl", result);
+}
+
+#[test]
+fn per_action_require_prior_idle_enables_without_global() {
+    // No global defcfg (default 0), but per-action sets 150ms.
+    // The per-action value should enable the feature for this action only.
+    let result = simulate(
+        "
+(defsrc a d)
+(deflayer base a @d)
+(defalias d (tap-hold 200 200 d lctl (require-prior-idle 150)))
+        ",
+        "d:a t:10 u:a t:10 d:d t:50 u:d t:50",
+    )
+    .to_ascii();
+    // a pressed 20ms ago, within 150ms per-action threshold → tap
+    assert_eq!("dn:A t:10ms up:A t:10ms dn:D t:50ms up:D", result);
+}
+
+#[test]
+fn per_action_require_prior_idle_mixed_actions() {
+    // The issue #1967 use case: two tap-hold keys with different idle behavior.
+    // @a (HRM) uses the global 150ms threshold.
+    // @d (layer key) disables idle detection via per-action override.
+    // During a typing streak, @a should resolve as tap but @d should hold.
+    let cfg = "
+(defcfg tap-hold-require-prior-idle 150)
+(defsrc a d e)
+(deflayer base @a @d e)
+(defalias
+  a (tap-hold-press 200 200 a lmet)
+  d (tap-hold-press 200 200 d lctl (require-prior-idle 0))
+)
+    ";
+    // Case 1: type e, then quickly press @a → global idle fires, a resolves as tap
+    let result = simulate(cfg, "d:e t:10 u:e t:10 d:a t:50 u:a t:50").to_ascii();
+    assert_eq!("dn:E t:10ms up:E t:10ms dn:A t:50ms up:A", result);
+    // Case 2: type e, then quickly press @d → per-action 0 disables idle, d enters hold.
+    // tap-hold-press resolves on next key press: e pressed 10ms after d triggers hold.
+    let result = simulate(cfg, "d:e t:10 u:e t:10 d:d t:10 d:e t:50 u:e t:50 u:d t:50").to_ascii();
+    assert_eq!(
+        "dn:E t:10ms up:E t:20ms dn:LCtrl t:6ms dn:E t:44ms up:E t:50ms up:LCtrl",
+        result
+    );
+}
+
+#[test]
+fn per_action_require_prior_idle_with_tap_hold_release() {
+    // Per-action option works with tap-hold-release variant.
+    let result = simulate(
+        "
+(defcfg tap-hold-require-prior-idle 150)
+(defsrc a d)
+(deflayer base a @d)
+(defalias d (tap-hold-release 200 200 d lctl (require-prior-idle 0)))
+        ",
+        // Typing streak: a pressed 20ms ago. Global would force tap,
+        // but per-action 0 disables it.
+        "d:a t:10 u:a t:10 d:d t:250 u:d t:50",
+    )
+    .to_ascii();
+    // d enters normal hold (per-action override disables idle check)
+    assert_eq!("dn:A t:10ms up:A t:210ms dn:LCtrl t:50ms up:LCtrl", result);
+}
+
+#[test]
+fn per_action_require_prior_idle_with_opposite_hand() {
+    // Per-action option works with tap-hold-opposite-hand variant.
+    // Use j (right hand) pressing before f (left hand tap-hold).
+    // Without require-prior-idle, j is opposite-hand → f would hold.
+    // With global require-prior-idle 150, the typing streak forces tap.
+    // With per-action override 0, the override disables it and f holds.
+    let result = simulate(
+        "
+(defcfg tap-hold-require-prior-idle 150)
+(defhands (left a s d f g) (right h j k l ;))
+(defsrc j f)
+(deflayer base j @f)
+(defalias f (tap-hold-opposite-hand 200 f lctl
+  (timeout hold)
+  (require-prior-idle 0)))
+        ",
+        // j (right) pressed 20ms ago, then f (left) pressed.
+        // Global 150ms would force tap, but per-action 0 disables it.
+        // j is opposite hand → f should hold. timeout → hold.
+        "d:j t:10 u:j t:10 d:f t:250 u:f t:50",
+    )
+    .to_ascii();
+    // f enters normal opposite-hand behavior: j is opposite → hold
+    assert_eq!("dn:J t:10ms up:J t:210ms dn:LCtrl t:50ms up:LCtrl", result);
+}


### PR DESCRIPTION
## Summary

Adds a per-action `(require-prior-idle <ms>)` option to all `tap-hold` variants, allowing individual actions to override the global `tap-hold-require-prior-idle` defcfg value.

Closes #1967.

## Motivation

With the global `tap-hold-require-prior-idle` from #1960, users can't mix tap-hold behaviors — home-row mods benefit from idle detection, but layer-tap keys (e.g., tab/number-layer) need immediate activation even during fast typing. This is the per-action granularity follow-up noted in #1960.

## Usage

```lisp
(defcfg tap-hold-require-prior-idle 150)
(defalias
  ;; HRMs inherit global 150ms — no override needed
  a (tap-hold 200 200 a lmet)
  s (tap-hold 200 200 s lalt)
  ;; Layer key disables idle detection for immediate activation
  nav (tap-hold 200 200 tab (layer-toggle nav) (require-prior-idle 0))
  ;; Or enable per-action without a global setting
  d (tap-hold-release 200 200 d lctl (require-prior-idle 150))
)
```

## Design

Follows the `(keyword value)` option convention established by `tap-hold-opposite-hand`. The option name is `require-prior-idle` (no `tap-hold-` prefix since it's already inside a tap-hold action, matching how opposite-hand uses `timeout`, `same-hand`, etc.).

- `(require-prior-idle 0)` — disables for this action even when a global threshold is set
- `(require-prior-idle N)` — enables/overrides with N ms threshold
- Omitted — falls back to global `defcfg` value

**Keyberon:** Added `require_prior_idle: Option<u16>` to `HoldTapAction`. The existing idle check in `do_action()` uses the per-action value when present, falling back to the global `tap_hold_require_prior_idle`.

**Parser:** Shared `parse_tap_hold_options()` helper and `count_trailing_options()` enable all tap-hold variants to accept trailing option lists. Options are identified by checking the first atom against a keyword allowlist, so list-type positional params (e.g., `(layer-toggle nav)`) aren't misidentified. A shared `parse_require_prior_idle_option()` is used by both `tap_hold.rs` and `defhands.rs` to avoid duplication.

## Test coverage

**6 sim tests:** per-action override shrinks threshold, per-action disable overrides global, per-action enables without global, mixed actions (issue #1967 use case with two tap-hold keys behaving differently), works with `tap-hold-release`, works with `tap-hold-opposite-hand`.

**9 parser tests:** valid value, zero value, non-numeric rejected, unknown option rejected, duplicate rejected, plus one test per distinct parse path (`tap-hold-press`, `tap-hold-release`, `tap-hold-release-timeout`, `tap-hold-press-timeout`, `tap-hold-release-keys`, `tap-hold-except-keys`, `tap-hold-opposite-hand`, `tap-hold-release-tap-keys-release`).

## Supported variants

All tap-hold variants: `tap-hold`, `tap-hold-press`, `tap-hold-release`, `tap-hold-press-timeout`, `tap-hold-release-timeout`, `tap-hold-release-keys`, `tap-hold-release-tap-keys-release`, `tap-hold-except-keys`, `tap-hold-tap-keys`, and `tap-hold-opposite-hand`.