### PR TITLE
feat: add (device N) switch condition for per-device key mappings

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,59 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Detect workflow changes in PR
+        id: workflow-changes
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          if git diff --quiet "origin/${{ github.base_ref }}" -- .github/workflows/claude-code-review.yml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Claude Code Review
+        id: claude-review
+        if: steps.workflow-changes.outputs.changed != 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --allowed-tools Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Read,Glob,Grep
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and Rust best practices
+            - Potential bugs or issues
+            - Performance considerations (this is a hot-path keyboard remapping engine)
+            - API design and backward compatibility
+            - Test coverage
+
+            Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+      - name: Skip Claude review for workflow-file changes
+        if: steps.workflow-changes.outputs.changed == 'true'
+        run: |
+          echo "Skipping Claude review because .github/workflows/claude-code-review.yml changed in this PR."

--- a/keyberon/src/action/switch.rs
+++ b/keyberon/src/action/switch.rs
@@ -49,6 +49,7 @@ const INPUT_VAL: u16 = 851;
 const HISTORICAL_INPUT_VAL: u16 = 852;
 const LAYER_VAL: u16 = 853;
 const BASE_LAYER_VAL: u16 = 854;
+const DEVICE_VAL: u16 = 855;
 
 // Binary values:
 // 0b0100 ...
@@ -87,6 +88,7 @@ enum OpCodeType {
     TicksSinceGreaterThan(TicksSinceNthKey),
     Layer(u16),
     BaseLayer(u16),
+    Device(u16),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -131,6 +133,7 @@ impl<'a, T> Switch<'a, T> {
     /// the currently active keys, and historically pressed keys.
     ///
     /// The `historical_keys` parameter should iterate in the order of most-recent-first.
+    #[allow(clippy::too_many_arguments)]
     pub fn actions<A1, A2, H1, H2, L>(
         &self,
         active_keys: A1,
@@ -139,6 +142,7 @@ impl<'a, T> Switch<'a, T> {
         historical_positions: H2,
         layers: L,
         default_layer: u16,
+        current_device: Option<u8>,
     ) -> SwitchActions<'a, T, A1, A2, H1, H2, L>
     where
         A1: Iterator<Item = KeyCode> + Clone,
@@ -155,6 +159,7 @@ impl<'a, T> Switch<'a, T> {
             historical_positions,
             layers,
             default_layer,
+            current_device,
             case_index: 0,
         }
     }
@@ -177,6 +182,7 @@ where
     historical_positions: H2,
     layers: L,
     default_layer: u16,
+    current_device: Option<u8>,
     case_index: usize,
 }
 
@@ -201,6 +207,7 @@ where
                 self.historical_positions.clone(),
                 self.layers.clone(),
                 self.default_layer,
+                self.current_device,
             ) {
                 let ret_ac = case.1;
                 match case.2 {
@@ -315,6 +322,11 @@ impl OpCode {
         (Self(BASE_LAYER_VAL), Self(base_layer))
     }
 
+    /// Return OpCodes specifying a device index check.
+    pub fn new_device(device_idx: u8) -> (Self, Self) {
+        (Self(DEVICE_VAL), Self(device_idx as u16))
+    }
+
     /// Return the interpretation of this `OpCode`.
     fn opcode_type(self, next: Option<OpCode>) -> OpCodeType {
         if self.0 < KEY_MAX {
@@ -329,6 +341,7 @@ impl OpCode {
                 }),
                 LAYER_VAL => OpCodeType::Layer(op2.0),
                 BASE_LAYER_VAL => OpCodeType::BaseLayer(op2.0),
+                DEVICE_VAL => OpCodeType::Device(op2.0),
                 _ => unreachable!("unexpected opcode {self:?}"),
             }
         } else {
@@ -366,6 +379,7 @@ impl From<u16> for OperatorAndEndIndex {
 }
 
 /// Evaluate the return value of an expression evaluated on the given key codes.
+#[allow(clippy::too_many_arguments)]
 fn evaluate_boolean(
     bool_expr: &[OpCode],
     key_codes: impl Iterator<Item = KeyCode> + Clone,
@@ -374,6 +388,7 @@ fn evaluate_boolean(
     historical_inputs: impl Iterator<Item = HistoricalEvent<KCoord>> + Clone,
     layers: impl Iterator<Item = u16> + Clone,
     default_layer: u16,
+    current_device: Option<u8>,
 ) -> bool {
     let mut ret = true;
     let mut current_index = 0;
@@ -465,6 +480,11 @@ fn evaluate_boolean(
                 current_index += 1;
                 ret = default_layer == base_layer;
             }
+            OpCodeType::Device(device_idx) => {
+                // opcode has size 2
+                current_index += 1;
+                ret = current_device == Some(device_idx as u8);
+            }
         };
         if current_op == Not {
             ret = !ret;
@@ -493,6 +513,7 @@ fn evaluate_bool_test(opcodes: &[OpCode], keycodes: impl Iterator<Item = KeyCode
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     )
 }
 
@@ -752,6 +773,7 @@ fn switch_fallthrough() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     );
     assert_eq!(actions.next(), Some(&Action::<()>::KeyCode(KeyCode::A)));
     assert_eq!(actions.next(), Some(&Action::<()>::KeyCode(KeyCode::B)));
@@ -773,6 +795,7 @@ fn switch_break() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     );
     assert_eq!(actions.next(), Some(&Action::<()>::KeyCode(KeyCode::A)));
     assert_eq!(actions.next(), None);
@@ -801,6 +824,7 @@ fn switch_no_actions() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     );
     assert_eq!(actions.next(), None);
 }
@@ -861,6 +885,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     ));
     assert!(evaluate_boolean(
         opcode_true2.as_slice(),
@@ -870,6 +895,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     ));
     assert!(!evaluate_boolean(
         opcode_false.as_slice(),
@@ -879,6 +905,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     ));
     assert!(!evaluate_boolean(
         opcode_false2.as_slice(),
@@ -888,6 +915,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     ));
 }
 
@@ -973,6 +1001,7 @@ fn switch_historical_bools() {
                 [].iter().copied(),
                 [].iter().copied(),
                 0,
+                None,
             ),
             expectation
         );
@@ -1089,6 +1118,7 @@ fn switch_historical_ticks_since() {
                 [].iter().copied(),
                 [].iter().copied(),
                 0,
+                None,
             ),
             expectation
         );
@@ -1323,6 +1353,7 @@ fn switch_inputs() {
                 [].iter().copied(),
                 [].iter().copied(),
                 0,
+                None,
             ),
             expectation
         );
@@ -1391,6 +1422,7 @@ fn switch_historical_inputs() {
                 historical_inputs.iter().copied(),
                 [].iter().copied(),
                 0,
+                None,
             ),
             expectation
         );
@@ -1401,4 +1433,130 @@ fn switch_historical_inputs() {
     test(&opcodes_false_or, false);
     test(&opcodes_true_or1, true);
     test(&opcodes_true_or2, true);
+}
+
+#[test]
+fn device_opcode_encoding_roundtrip() {
+    let (op1, op2) = OpCode::new_device(0);
+    assert_eq!(op1.opcode_type(Some(op2)), OpCodeType::Device(0));
+    let (op1, op2) = OpCode::new_device(255);
+    assert_eq!(op1.opcode_type(Some(op2)), OpCodeType::Device(255));
+    let (op1, op2) = OpCode::new_device(42);
+    assert_eq!(op1.opcode_type(Some(op2)), OpCodeType::Device(42));
+}
+
+#[test]
+fn device_evaluate_boolean_matches() {
+    let (op1, op2) = OpCode::new_device(0);
+    let opcodes = [op1, op2];
+    assert!(evaluate_boolean(
+        &opcodes,
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        Some(0),
+    ));
+    assert!(!evaluate_boolean(
+        &opcodes,
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        Some(1),
+    ));
+    assert!(!evaluate_boolean(
+        &opcodes,
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        None,
+    ));
+}
+
+#[test]
+fn device_evaluate_boolean_with_and() {
+    let (d1, d2) = OpCode::new_device(1);
+    let opcodes = [
+        OpCode::new_bool(And, 4),
+        OpCode::new_key(KeyCode::A),
+        d1,
+        d2,
+    ];
+    assert!(evaluate_boolean(
+        &opcodes,
+        [KeyCode::A].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        Some(1),
+    ));
+    assert!(!evaluate_boolean(
+        &opcodes,
+        [KeyCode::A].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        Some(0),
+    ));
+    assert!(!evaluate_boolean(
+        &opcodes,
+        [KeyCode::B].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        Some(1),
+    ));
+}
+
+#[test]
+fn device_evaluate_boolean_with_not() {
+    let (d1, d2) = OpCode::new_device(0);
+    let opcodes = [OpCode::new_bool(Not, 3), d1, d2];
+    // (not (device 0)) with current_device=1 should be true
+    assert!(evaluate_boolean(
+        &opcodes,
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        Some(1),
+    ));
+    // (not (device 0)) with current_device=0 should be false
+    assert!(!evaluate_boolean(
+        &opcodes,
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        Some(0),
+    ));
+    // (not (device 0)) with current_device=None should be true (device 0 doesn't match None)
+    assert!(evaluate_boolean(
+        &opcodes,
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        None,
+    ));
 }

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -128,6 +128,9 @@ where
     /// Only stores data when the `tap_hold_tracker` feature is enabled;
     /// otherwise this is a zero-sized no-op.
     pub tap_hold_tracker: crate::tap_hold_tracker::TapHoldTracker,
+    /// The device index of the most recently processed input event.
+    /// Used by switch `(device N)` conditions.
+    pub current_device: Option<u8>,
 }
 
 pub use crate::tap_hold_tracker::{HoldActivatedInfo, TapActivatedInfo};
@@ -1183,6 +1186,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
             chords_v2: None,
             contextual_execution: ContextualExecution::new(),
             tap_hold_tracker: Default::default(),
+            current_device: None,
         }
     }
     pub fn new_with_trans_action_settings(
@@ -2218,6 +2222,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
                     // Note on truncating cast: I expect default layer to be in range by other
                     // assertions.
                     self.default_layer as u16,
+                    self.current_device,
                 ) {
                     action_queue.push_back(Some((coord, 0, ac, layer_stack.collect())));
                 }

--- a/parser/src/cfg/switch.rs
+++ b/parser/src/cfg/switch.rs
@@ -90,6 +90,7 @@ pub fn parse_switch_case_bool(
             InputHistory,
             Layer,
             BaseLayer,
+            Device,
         }
         #[derive(Copy, Clone)]
         enum InputType {
@@ -116,6 +117,7 @@ pub fn parse_switch_case_bool(
                 "input-history" => Some(AllowedListOps::InputHistory),
                 "layer" => Some(AllowedListOps::Layer),
                 "base-layer" => Some(AllowedListOps::BaseLayer),
+                "device" => Some(AllowedListOps::Device),
                 _ => None,
             })
             .ok_or_else(|| {
@@ -123,7 +125,7 @@ pub fn parse_switch_case_bool(
                     op_expr,
                     "lists inside switch logic must begin with one of:\n\
                     or | and | not | key-history | key-timing\n\
-                    | input | input-history | layer | base-layer",
+                    | input | input-history | layer | base-layer | device",
                 )
             })?;
 
@@ -266,6 +268,18 @@ pub fn parse_switch_case_bool(
                     AllowedListOps::BaseLayer => OpCode::new_base_layer(layer),
                     _ => unreachable!(),
                 };
+                ops.extend(&[op1, op2]);
+                Ok(())
+            }
+            AllowedListOps::Device => {
+                if l.len() != 2 {
+                    bail_expr!(
+                        op_expr,
+                        "device must have 1 parameter: device-index (0-255)"
+                    );
+                }
+                let device_idx = parse_u8_with_range(&l[1], s, "device-index", 0, 255)?;
+                let (op1, op2) = OpCode::new_device(device_idx);
                 ops.extend(&[op1, op2]);
                 Ok(())
             }

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -733,6 +733,8 @@ fn parse_switch() {
     ((input real lctl)) $var1 break
     ((input-history virtual vk2 1)) $var1 break
     ((input-history real lsft 8)) $var1 break
+    ((device 0)) $var1 break
+    ((and (device 1) a)) $var1 break
   )
 )
 "#;
@@ -854,6 +856,27 @@ fn parse_switch() {
                     &Action::KeyCode(KeyCode::A),
                     BreakOrFallthrough::Break
                 ),
+                {
+                    let (d1, d2) = OpCode::new_device(0);
+                    (
+                        &[d1, d2][..],
+                        &Action::KeyCode(KeyCode::A),
+                        BreakOrFallthrough::Break,
+                    )
+                },
+                {
+                    let (d1, d2) = OpCode::new_device(1);
+                    (
+                        &[
+                            OpCode::new_bool(And, 4),
+                            d1,
+                            d2,
+                            OpCode::new_key(KeyCode::A),
+                        ][..],
+                        &Action::KeyCode(KeyCode::A),
+                        BreakOrFallthrough::Break,
+                    )
+                },
             ]
         })
     );

--- a/simulated_input/src/sim.rs
+++ b/simulated_input/src/sim.rs
@@ -278,6 +278,7 @@ fn main_impl() -> Result<()> {
                             k.handle_input_event(&KeyEvent {
                                 code: key_code,
                                 value: KeyValue::Press,
+                                device_index: 0,
                             })?;
                         }
                         "release" | "↑" | "u" | "up" => {
@@ -287,6 +288,7 @@ fn main_impl() -> Result<()> {
                             k.handle_input_event(&KeyEvent {
                                 code: key_code,
                                 value: KeyValue::Release,
+                                device_index: 0,
                             })?;
                         }
                         "repeat" | "⟳" | "r" => {
@@ -296,6 +298,7 @@ fn main_impl() -> Result<()> {
                             k.handle_input_event(&KeyEvent {
                                 code: key_code,
                                 value: KeyValue::Repeat,
+                                device_index: 0,
                             })?;
                         }
                         // Virtual/fake key activation: fakekey:name[:action] or vk:name[:action]
@@ -334,6 +337,7 @@ fn main_impl() -> Result<()> {
                                 k.handle_input_event(&KeyEvent {
                                     code: key_code,
                                     value: KeyValue::Press,
+                                    device_index: 0,
                                 })?;
                             }
                             "↑" => {
@@ -343,6 +347,7 @@ fn main_impl() -> Result<()> {
                                 k.handle_input_event(&KeyEvent {
                                     code: key_code,
                                     value: KeyValue::Release,
+                                    device_index: 0,
                                 })?;
                             }
                             "⟳" => {
@@ -357,6 +362,7 @@ fn main_impl() -> Result<()> {
                                 k.handle_input_event(&KeyEvent {
                                     code: key_code,
                                     value: KeyValue::Repeat,
+                                    device_index: 0,
                                 })?;
                             }
                             "🎭" => {

--- a/src/kanata/linux.rs
+++ b/src/kanata/linux.rs
@@ -44,18 +44,19 @@ impl Kanata {
             let events = kbd_in.read().map_err(|e| anyhow!("failed read: {}", e))?;
             log::trace!("event count: {}\nevents:\n{events:?}", events.len());
 
-            for in_event in events.iter().copied() {
+            for (in_event, device_idx) in events.iter().copied() {
                 if let Some(ms_mvmt_key) = *mouse_movement_key.lock()
                     && let EventSummary::RelativeAxis(_, _, _) = in_event.destructure()
                 {
-                    let fake_event = KeyEvent::new(ms_mvmt_key, KeyValue::Tap);
+                    let fake_event =
+                        KeyEvent::new(ms_mvmt_key, KeyValue::Tap).with_device(device_idx);
                     if let Err(e) = tx.try_send(fake_event) {
                         bail!("failed to send on channel: {}", e)
                     }
                 }
 
                 let key_event = match KeyEvent::try_from(in_event) {
-                    Ok(ev) => ev,
+                    Ok(ev) => ev.with_device(device_idx),
                     _ => {
                         // Pass-through non-key and non-scroll events
                         let mut kanata = kanata.lock();
@@ -154,7 +155,7 @@ fn handle_scroll(
     kanata: &Mutex<Kanata>,
     in_event: InputEvent,
     code: OsCode,
-    all_events: &[InputEvent],
+    all_events: &[(InputEvent, u8)],
 ) -> Result<bool> {
     let direction: MWheelDirection = code.try_into().unwrap();
     let scroll_distance = in_event.value().unsigned_abs() as u16;
@@ -176,7 +177,7 @@ fn handle_scroll(
                     // scroll event. In this scenario, the hi-res event should be used to call
                     // scroll, and not the normal event. Otherwise, too much scrolling will happen.
                     let mut kanata = kanata.lock();
-                    if !all_events.iter().any(|ev| {
+                    if !all_events.iter().any(|(ev, _)| {
                         matches!(
                             ev.destructure(),
                             EventSummary::RelativeAxis(

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -846,9 +846,15 @@ impl Kanata {
         Ok(())
     }
 
-    /// Update keyberon layout state for press/release, handle repeat separately
+    /// Update keyberon layout state for press/release, handle repeat separately.
+    ///
+    /// Note: `current_device` is set here per-event and may be stale when switch actions
+    /// evaluate later (e.g. inside tap-hold's WaitingState resolution from `tick()`).
+    /// This is a known limitation — per-device tap-hold behavior requires a deeper change
+    /// to thread device identity through keyberon's internal state machine.
     pub fn handle_input_event(&mut self, event: &KeyEvent) -> Result<()> {
         log::debug!("process recv ev {event:?}");
+        self.layout.bm().current_device = Some(event.device_index);
         let evc: u16 = event.code.into();
         self.ticks_since_idle = 0;
         let kbrn_ev = match event.value {
@@ -2790,7 +2796,11 @@ mod collect_and_sort_events_tests {
     use std::sync::mpsc::sync_channel;
 
     fn make_event(code: OsCode, value: KeyValue) -> KeyEvent {
-        KeyEvent { code, value }
+        KeyEvent {
+            code,
+            value,
+            device_index: 0,
+        }
     }
 
     #[test]

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -68,7 +68,11 @@ impl Kanata {
                                 false => KeyValue::Press,
                                 true => KeyValue::Release,
                             };
-                            KeyEvent { code, value }
+                            KeyEvent {
+                                code,
+                                value,
+                                device_index: 0,
+                            }
                         }
                         ic::Stroke::Mouse {
                             state,
@@ -194,51 +198,61 @@ fn mouse_state_to_event(state: ic::MouseState, rolling: i16) -> Option<KeyEvent>
         Some(KeyEvent {
             code: OsCode::BTN_RIGHT,
             value: KeyValue::Press,
+            device_index: 0,
         })
     } else if state.contains(ic::MouseState::RIGHT_BUTTON_UP) {
         Some(KeyEvent {
             code: OsCode::BTN_RIGHT,
             value: KeyValue::Release,
+            device_index: 0,
         })
     } else if state.contains(ic::MouseState::LEFT_BUTTON_DOWN) {
         Some(KeyEvent {
             code: OsCode::BTN_LEFT,
             value: KeyValue::Press,
+            device_index: 0,
         })
     } else if state.contains(ic::MouseState::LEFT_BUTTON_UP) {
         Some(KeyEvent {
             code: OsCode::BTN_LEFT,
             value: KeyValue::Release,
+            device_index: 0,
         })
     } else if state.contains(ic::MouseState::MIDDLE_BUTTON_DOWN) {
         Some(KeyEvent {
             code: OsCode::BTN_MIDDLE,
             value: KeyValue::Press,
+            device_index: 0,
         })
     } else if state.contains(ic::MouseState::MIDDLE_BUTTON_UP) {
         Some(KeyEvent {
             code: OsCode::BTN_MIDDLE,
             value: KeyValue::Release,
+            device_index: 0,
         })
     } else if state.contains(ic::MouseState::BUTTON_4_DOWN) {
         Some(KeyEvent {
             code: OsCode::BTN_SIDE,
             value: KeyValue::Press,
+            device_index: 0,
         })
     } else if state.contains(ic::MouseState::BUTTON_4_UP) {
         Some(KeyEvent {
             code: OsCode::BTN_SIDE,
             value: KeyValue::Release,
+            device_index: 0,
         })
     } else if state.contains(ic::MouseState::BUTTON_5_DOWN) {
         Some(KeyEvent {
             code: OsCode::BTN_EXTRA,
             value: KeyValue::Press,
+            device_index: 0,
         })
     } else if state.contains(ic::MouseState::BUTTON_5_UP) {
         Some(KeyEvent {
             code: OsCode::BTN_EXTRA,
             value: KeyValue::Release,
+            device_index: 0,
         })
     } else if state.contains(ic::MouseState::WHEEL) {
         let osc = if rolling >= 0 {
@@ -250,6 +264,7 @@ fn mouse_state_to_event(state: ic::MouseState, rolling: i16) -> Option<KeyEvent>
             Some(KeyEvent {
                 code: osc,
                 value: KeyValue::Tap,
+                device_index: 0,
             })
         } else {
             None
@@ -264,6 +279,7 @@ fn mouse_state_to_event(state: ic::MouseState, rolling: i16) -> Option<KeyEvent>
             Some(KeyEvent {
                 code: osc,
                 value: KeyValue::Tap,
+                device_index: 0,
             })
         } else {
             None

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -29,7 +29,8 @@ use kanata_parser::custom_action::*;
 use kanata_parser::keys::*;
 
 pub struct KbdIn {
-    devices: HashMap<Token, (Device, String)>,
+    /// Maps poll tokens to (device, path, device_index).
+    devices: HashMap<Token, (Device, String, u8)>,
     /// Some(_) if devices are explicitly listed, otherwise None.
     missing_device_paths: Option<Vec<String>>,
     poll: Poll,
@@ -40,6 +41,16 @@ pub struct KbdIn {
     include_names: Option<Vec<String>>,
     exclude_names: Option<Vec<String>>,
     device_detect_mode: DeviceDetectMode,
+    next_device_index: u8,
+}
+
+/// Information about a registered input device.
+/// Currently unused — scaffolding for device name-based matching (see follow-up issue #6).
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct DeviceInfo {
+    pub name: String,
+    pub index: u8,
 }
 
 const INOTIFY_TOKEN_VALUE: usize = 0;
@@ -105,6 +116,7 @@ impl KbdIn {
             include_names,
             exclude_names,
             device_detect_mode,
+            next_device_index: 0,
         };
 
         for (device, dev_path) in devices.into_iter() {
@@ -134,11 +146,19 @@ impl KbdIn {
         self.poll
             .registry()
             .register(&mut SourceFd(&fd), tok, Interest::READABLE)?;
-        self.devices.insert(tok, (dev, path));
+        let device_idx = self.next_device_index;
+        match self.next_device_index.checked_add(1) {
+            Some(next) => self.next_device_index = next,
+            None => log::warn!(
+                "device index overflow: device {path} shares index 255 with another device"
+            ),
+        }
+        log::info!("assigned device index {device_idx} to {path}");
+        self.devices.insert(tok, (dev, path, device_idx));
         Ok(())
     }
 
-    pub fn read(&mut self) -> Result<Vec<InputEvent>, io::Error> {
+    pub fn read(&mut self) -> Result<Vec<(InputEvent, u8)>, io::Error> {
         let mut input_events = vec![];
         loop {
             log::trace!("polling");
@@ -152,11 +172,12 @@ impl KbdIn {
 
             let mut do_rediscover = false;
             for event in &self.events {
-                if let Some((device, _)) = self.devices.get_mut(&event.token()) {
+                if let Some((device, _, dev_idx)) = self.devices.get_mut(&event.token()) {
+                    let dev_idx = *dev_idx;
                     if let Err(e) = device.fetch_events().map(|evs| {
                         evs.into_iter()
                             .take(EVENT_LIMIT)
-                            .for_each(|ev| input_events.push(ev))
+                            .for_each(|ev| input_events.push((ev, dev_idx)))
                     }) {
                         // Currently the kind() is uncategorized... not helpful, need to match
                         // on os error. code 19 is ENODEV, "no such device".
@@ -165,7 +186,7 @@ impl KbdIn {
                                 self.poll
                                     .registry()
                                     .deregister(&mut SourceFd(&device.as_raw_fd()))?;
-                                if let Some((_, path)) = self.devices.remove(&event.token()) {
+                                if let Some((_, path, _)) = self.devices.remove(&event.token()) {
                                     log::warn!("removing kbd device: {path}");
                                     if let Some(ref mut missing) = self.missing_device_paths {
                                         missing.push(path);
@@ -241,7 +262,7 @@ impl KbdIn {
                 if !self
                     .devices
                     .values()
-                    .any(|(_, registered_path)| &path == registered_path)
+                    .any(|(_, registered_path, _)| &path == registered_path)
                 {
                     self.register_device(dev, path)
                 } else {
@@ -250,6 +271,18 @@ impl KbdIn {
             })?;
         }
         Ok(())
+    }
+
+    /// Returns information about all registered input devices.
+    #[allow(dead_code)]
+    pub fn device_info(&self) -> Vec<DeviceInfo> {
+        self.devices
+            .values()
+            .map(|(dev, _path, idx)| DeviceInfo {
+                name: dev.name().unwrap_or("unknown").to_string(),
+                index: *idx,
+            })
+            .collect()
     }
 }
 
@@ -328,6 +361,7 @@ impl TryFrom<InputEvent> for KeyEvent {
             evdev::EventSummary::Key(_, k, _) => Ok(Self {
                 code: OsCode::from_u16(k.0).ok_or(())?,
                 value: KeyValue::from(item.value()),
+                device_index: 0,
             }),
             evdev::EventSummary::RelativeAxis(_, axis_type, _) => {
                 let dist = item.value();
@@ -351,6 +385,7 @@ impl TryFrom<InputEvent> for KeyEvent {
                 Ok(KeyEvent {
                     code,
                     value: KeyValue::Tap,
+                    device_index: 0,
                 })
             }
             _ => Err(()),

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -229,6 +229,7 @@ impl TryFrom<InputEvent> for KeyEvent {
                 } else {
                     KeyValue::Release
                 },
+                device_index: 0,
             })
         } else {
             Err(())
@@ -322,7 +323,11 @@ impl KbdOut {
     }
 
     pub fn write_key(&mut self, key: OsCode, value: KeyValue) -> Result<(), io::Error> {
-        if let Ok(event) = InputEvent::try_from(KeyEvent { value, code: key }) {
+        if let Ok(event) = InputEvent::try_from(KeyEvent {
+            value,
+            code: key,
+            device_index: 0,
+        }) {
             let result = self.write(event);
             if result.is_ok() {
                 self.record_output_transition_after_write(key, value);
@@ -338,6 +343,7 @@ impl KbdOut {
         if let Ok(event) = InputEvent::try_from(KeyEvent {
             value,
             code: OsCode::from_u16(code as u16).unwrap(),
+            device_index: 0,
         }) {
             self.write(event)
         } else {

--- a/src/oskbd/mod.rs
+++ b/src/oskbd/mod.rs
@@ -105,12 +105,22 @@ use kanata_parser::keys::OsCode;
 pub struct KeyEvent {
     pub code: OsCode,
     pub value: KeyValue,
+    pub device_index: u8,
 }
 
 #[allow(dead_code, unused)]
 impl KeyEvent {
     pub fn new(code: OsCode, value: KeyValue) -> Self {
-        Self { code, value }
+        Self {
+            code,
+            value,
+            device_index: 0,
+        }
+    }
+
+    pub fn with_device(mut self, idx: u8) -> Self {
+        self.device_index = idx;
+        self
     }
 }
 
@@ -138,6 +148,7 @@ impl fmt::Debug for KeyEvent {
                 &format_args!("{:?} ({})", self.code, self.code.as_u16()),
             )
             .field("value", &self.value)
+            .field("device_index", &self.device_index)
             .finish()
     }
 }

--- a/src/oskbd/sim_passthru.rs
+++ b/src/oskbd/sim_passthru.rs
@@ -178,6 +178,7 @@ impl TryFrom<InputEvent> for KeyEvent {
                 true => KeyValue::Release,
                 false => KeyValue::Press,
             },
+            device_index: 0,
         })
     }
 }

--- a/src/oskbd/simulated.rs
+++ b/src/oskbd/simulated.rs
@@ -490,6 +490,7 @@ impl TryFrom<InputEvent> for KeyEvent {
                 true => KeyValue::Release,
                 false => KeyValue::Press,
             },
+            device_index: 0,
         })
     }
 }

--- a/src/oskbd/windows/exthook_os.rs
+++ b/src/oskbd/windows/exthook_os.rs
@@ -86,6 +86,7 @@ impl TryFrom<InputEvent> for KeyEvent {
                 true => KeyValue::Release,
                 false => KeyValue::Press,
             },
+            device_index: 0,
         })
     }
 }

--- a/src/oskbd/windows/llhook.rs
+++ b/src/oskbd/windows/llhook.rs
@@ -141,6 +141,7 @@ impl TryFrom<InputEvent> for KeyEvent {
                 true => KeyValue::Release,
                 false => KeyValue::Press,
             },
+            device_index: 0,
         })
     }
 }

--- a/src/oskbd/windows/llhook/mouse.rs
+++ b/src/oskbd/windows/llhook/mouse.rs
@@ -393,7 +393,11 @@ impl TryFrom<MouseEventType> for KeyEvent {
                     MouseButton::X2(..) => BTN_EXTRA,
                     MouseButton::UnkownX(..) | MouseButton::Other(..) => return Err(()),
                 };
-                Ok(KeyEvent { code, value })
+                Ok(KeyEvent {
+                    code,
+                    value,
+                    device_index: 0,
+                })
             }
             Wheel(MouseWheelEvent { wheel, direction }) => {
                 use MouseWheel::*;
@@ -413,6 +417,7 @@ impl TryFrom<MouseEventType> for KeyEvent {
                 Ok(KeyEvent {
                     code,
                     value: KeyValue::Tap,
+                    device_index: 0,
                 })
             }
         }

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -438,6 +438,7 @@ impl TcpServer {
                                             .send(KeyEvent {
                                                 code: OsCode::KEY_RESERVED,
                                                 value: KeyValue::WakeUp,
+                                                device_index: 0,
                                             })
                                             .expect("write key event");
                                     }

--- a/src/tests/sim_tests/mod.rs
+++ b/src/tests/sim_tests/mod.rs
@@ -107,6 +107,7 @@ fn simulate_with_file_content<S: AsRef<str>>(
                     k.handle_input_event(&KeyEvent {
                         code: key_code,
                         value: KeyValue::Press,
+                        device_index: 0,
                     })
                     .expect("input handles fine");
                     #[cfg(not(all(target_os = "windows", not(feature = "interception_driver"))))]
@@ -121,6 +122,7 @@ fn simulate_with_file_content<S: AsRef<str>>(
                     k.handle_input_event(&KeyEvent {
                         code: key_code,
                         value: KeyValue::Release,
+                        device_index: 0,
                     })
                     .expect("input handles fine");
                     crate::PRESSED_KEYS.lock().remove(&key_code);
@@ -130,8 +132,46 @@ fn simulate_with_file_content<S: AsRef<str>>(
                     k.handle_input_event(&KeyEvent {
                         code: key_code,
                         value: KeyValue::Repeat,
+                        device_index: 0,
                     })
                     .expect("input handles fine");
+                }
+                // Device-specific press: d0:key, d1:key, ... d9:key
+                dev_press
+                    if dev_press.len() == 2
+                        && dev_press.starts_with('d')
+                        && dev_press.as_bytes()[1].is_ascii_digit() =>
+                {
+                    let device_index = dev_press.as_bytes()[1] - b'0';
+                    let key_code = str_to_oscode(val).expect("valid keycode");
+                    k.handle_input_event(&KeyEvent {
+                        code: key_code,
+                        value: KeyValue::Press,
+                        device_index,
+                    })
+                    .expect("input handles fine");
+                    #[cfg(not(all(target_os = "windows", not(feature = "interception_driver"))))]
+                    crate::PRESSED_KEYS.lock().insert(key_code);
+                    #[cfg(all(target_os = "windows", not(feature = "interception_driver")))]
+                    crate::PRESSED_KEYS
+                        .lock()
+                        .insert(key_code, web_time::Instant::now());
+                }
+                // Device-specific release: u0:key, u1:key, ... u9:key
+                dev_rel
+                    if dev_rel.len() == 2
+                        && dev_rel.starts_with('u')
+                        && dev_rel.as_bytes()[1].is_ascii_digit() =>
+                {
+                    let device_index = dev_rel.as_bytes()[1] - b'0';
+                    let key_code = str_to_oscode(val).expect("valid keycode");
+                    k.handle_input_event(&KeyEvent {
+                        code: key_code,
+                        value: KeyValue::Release,
+                        device_index,
+                    })
+                    .expect("input handles fine");
+                    crate::PRESSED_KEYS.lock().remove(&key_code);
                 }
                 // Virtual/fake key activation: vk:name[:action] or fakekey:name[:action]
                 // Supported actions: press (p), release, tap (t), toggle (g)

--- a/src/tests/sim_tests/switch_sim_tests.rs
+++ b/src/tests/sim_tests/switch_sim_tests.rs
@@ -53,6 +53,40 @@ fn sim_switch_noop() {
 }
 
 #[test]
+fn sim_switch_device() {
+    let result = simulate(
+        "
+         (defcfg)
+         (defsrc a)
+         (deflayer base (switch
+            ((device 0)) x break
+            ((device 1)) y break))
+        ",
+        // Press 'a' from device 0, then from device 1
+        "d0:a u0:a t:10 d1:a u1:a t:10",
+    )
+    .no_time();
+    assert_eq!("out:↓X out:↑X out:↓Y out:↑Y", result);
+}
+
+#[test]
+fn sim_switch_device_with_not() {
+    let result = simulate(
+        "
+         (defcfg)
+         (defsrc a)
+         (deflayer base (switch
+            ((not (device 0))) y break
+            () x break))
+        ",
+        // Device 0 should fall through to default, device 1 matches (not (device 0))
+        "d0:a u0:a t:10 d1:a u1:a t:10",
+    )
+    .no_time();
+    assert_eq!("out:↓X out:↑X out:↓Y out:↑Y", result);
+}
+
+#[test]
 fn sim_switch_trans_not_top_layer() {
     let result = simulate(
         "

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -138,6 +138,7 @@ fn simulate_impl(cfg: &str, sim: &str) -> Result<String> {
                         k.handle_input_event(&KeyEvent {
                             code: key_code,
                             value: KeyValue::Press,
+                            device_index: 0,
                         })?;
                     }
                     "release" | "↑" | "u" | "up" => {
@@ -146,6 +147,7 @@ fn simulate_impl(cfg: &str, sim: &str) -> Result<String> {
                         k.handle_input_event(&KeyEvent {
                             code: key_code,
                             value: KeyValue::Release,
+                            device_index: 0,
                         })?;
                     }
                     "repeat" | "⟳" | "r" => {
@@ -154,6 +156,7 @@ fn simulate_impl(cfg: &str, sim: &str) -> Result<String> {
                         k.handle_input_event(&KeyEvent {
                             code: key_code,
                             value: KeyValue::Repeat,
+                            device_index: 0,
                         })?;
                     }
                     // Virtual/fake key activation: vk:name[:action]


### PR DESCRIPTION
## Summary

- Thread device identity from OS input through the event pipeline to keyberon's switch evaluation
- Add `device_index: u8` field to `KeyEvent`, populated on Linux via mio `Token`-based device tracking
- Add `(device N)` switch condition that matches against the originating device's index
- Store `current_device: Option<u8>` on `Layout` (not in Event row) to preserve the row 0/1 real/virtual key invariant

## Motivation

Kanata currently discards device identity at the pipeline boundary — all events enter keyberon as `Event::Press(0, keycode)` regardless of which physical keyboard sent them. This makes it impossible to write per-device key mappings.

This PR adds the foundation for per-device behavior via a new `(device N)` switch condition. On Linux, each registered input device gets an index (assigned at registration order), and that index is available in switch expressions.

## Example

```
(defsrc a)
(deflayer base
  (switch
    ((device 0)) x break
    ((device 1)) y break
    () a break))
```

## Design decision

keyberon's `Event` row field (0 = real key, 1 = virtual key) is load-bearing throughout the layout state machine. Rather than repurposing or extending row, device identity is stored as `Layout.current_device: Option<u8>`, set before each event and passed into switch evaluation as a separate parameter.

## Changes

| Area | What |
|------|------|
| `src/oskbd/mod.rs` | `KeyEvent` gains `device_index: u8` field |
| `src/oskbd/linux.rs` | `KbdIn` tracks device index per mio Token, `read()` returns `Vec<(InputEvent, u8)>` |
| `src/kanata/linux.rs` | Event loop threads device index to KeyEvent |
| `src/kanata/mod.rs` | `handle_input_event` sets `layout.current_device` before processing |
| `keyberon/src/layout.rs` | `Layout` gains `current_device: Option<u8>` |
| `keyberon/src/action/switch.rs` | New `DEVICE_VAL` opcode, `OpCodeType::Device`, evaluation logic |
| `parser/src/cfg/switch.rs` | Parse `(device N)` syntax (N: 0-255) |
| All platforms | `device_index: 0` default on macOS, Windows, wasm, simulated |

## Known limitations

- **Linux only**: macOS and Windows default to `device_index: 0` — multi-device support on those platforms is future work
- **Tap-hold staleness**: `current_device` is set per-event and may be stale when switch evaluates inside tap-hold's `WaitingState` resolution from `tick()` — documented in code
- **Index stability**: Device indices are assigned by registration order and not stable across reboots/replug — stable indexing is future work

## Roadmap

This PR is the foundation. Planned follow-ups, each building on this PR's infrastructure:

1. **macOS/Windows multi-device support** — Real device identity via IOHIDManager and Interception
2. **Name-based matching + `(defdevice)`** — `(device "Kinesis")` instead of numeric indices
3. **Stable hot-plug indexing** — Device fingerprinting so indices survive replug/reboot
4. **Per-device layer stacks** — Independent layer state per physical device

## Tests

- 4 unit tests for OpCode encoding/decoding and `evaluate_boolean` with device context (match, and, not)
- Parser test asserting `(device 0)` and `(and (device 1) a)` produce correct OpCodes
- 2 integration sim tests using new `d0:`/`d1:` device-prefixed sim commands
- All 214 existing tests pass with no regressions