### PR TITLE
fix: handle PRESSED_KEYS type difference in clean_state

### DIFF
--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -2627,6 +2627,9 @@ pub fn clean_state(kanata: &Arc<Mutex<Kanata>>, tick: u128) -> Result<()> {
     {
         let mut k_pressed = PRESSED_KEYS.lock();
         for key_os in k_pressed.clone() {
+            #[cfg(not(all(target_os = "windows", not(feature = "interception_driver"))))]
+            k.kbd_out.release_key(key_os)?;
+            #[cfg(all(target_os = "windows", not(feature = "interception_driver")))]
             k.kbd_out.release_key(key_os.0)?;
         }
         k_pressed.clear();


### PR DESCRIPTION
## Summary

- Fixes a compile error on macOS (and Windows with `interception_driver`) in the `clean_state` function (`src/kanata/mod.rs:2620`)
- `PRESSED_KEYS` is `HashSet<OsCode>` on macOS but `HashMap<OsCode, Instant>` on Windows (no interception), so iterating yields different types — `OsCode` vs `(OsCode, Instant)`
- The existing `key_os.0` is correct for the HashMap case but invalid for the HashSet case; this adds cfg-conditional `release_key` calls matching each type

## Details

The `clean_state` function (behind `#[cfg(feature = "passthru_ahk")]`) iterates `PRESSED_KEYS` to release all held keys. The `.0` tuple field access assumed HashMap iteration, but on macOS `PRESSED_KEYS` is a `HashSet<OsCode>` whose iterator yields `OsCode` directly.

This was likely never caught because:
1. The function is gated behind `passthru_ahk` feature
2. The block is `cfg`-gated out on Linux/Android, so standard CI wouldn't hit it
3. macOS CI (if any) may not enable `passthru_ahk`

The fix uses the same cfg pattern as `sim_tests/mod.rs` to handle both types.

## Test plan

- [x] `cargo check` passes (default features)
- [x] `cargo check --features passthru_ahk` passes
- [x] `cargo test` — all 34 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)