### PR TITLE
doc: clarify tap-hold-release-tap-keys-release arguments

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2218,6 +2218,12 @@ It accepts a second list that activates the eager tap
 if the any key listed within is pressed then released;
 as opposed to only on a press.
 
+The keys in the 5th and 6th parameters correspond to the physical input keys,
+or in other words the key that corresponds to `defsrc`.
+This is in contrast to the `fork` and `switch` actions
+which operates on outputted keys, or in other words the outputs
+that are in `deflayer`, `defalias`, etc. for the corresponding `defsrc` key.
+
 .Example:
 [source]
 ----


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add detail explaining the last parameters (i.e., the lists of keys) correspond to the physical input keys for `tap-hold-release-tap-keys-release`.

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [ ] Yes
