### PR TITLE
fix missed layer-change notifications for layer-while-held

### DIFF
--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -2957,7 +2957,7 @@ mod collect_and_sort_events_tests {
 #[cfg(all(test, feature = "tcp_server"))]
 mod tcp_layer_change_tests {
     use super::*;
-    use std::sync::mpsc::{sync_channel, TryRecvError};
+    use std::sync::mpsc::{TryRecvError, sync_channel};
     use std::time::Duration;
 
     fn collect_layer_changes(rx: &Receiver<ServerMessage>) -> Vec<String> {


### PR DESCRIPTION
## problem

`LayerChange` was checked only once after `tick_ms()` finished.

That can miss momentary layer transitions when multiple internal ticks are processed in one batch, e.g.:

- `layer-while-held` activate
- `layer-while-held` deactivate on release
- one-shot layer deactivate on timeout
- one-shot layer deactivate when consumed

## fix

Move `check_handle_layer_change()` from `handle_time_ticks()` to `handle_keystate_changes()`.

This keeps the existing logic and message format the same, but checks for layer changes once per internal tick instead of once per batched time update.

## tests

Added tests for:

- direct `layer-while-held` press/release
- one-shot `layer-while-held` timeout in a batched tick window
- one-shot `layer-while-held` consume in a batched tick window
