### PR TITLE
feat: add definputdevices config block and (device N) switch condition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "karabiner-driverkit"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e4fc764f78a4a5cbf705c9502a51a0ba4931dbee25f4fbc59654059f6ca9e9"
+checksum = "b20bae7924951876a41b469ac758032c42f5a142103d47a3bfe843dd954a1761"
 dependencies = [
  "cc",
  "os_info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "karabiner-driverkit"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20bae7924951876a41b469ac758032c42f5a142103d47a3bfe843dd954a1761"
+checksum = "97e4fc764f78a4a5cbf705c9502a51a0ba4931dbee25f4fbc59654059f6ca9e9"
 dependencies = [
  "cc",
  "os_info",

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -810,6 +810,11 @@ If you need help, please feel welcome to ask in the GitHub discussions.
     ((base-layer dvorak)) x break
     ((base-layer qwerty)) y break
 
+    ;; device evaluates to `true` if the event came from a device matching
+    ;; the given device ID defined in definputdevices. Currently macOS only.
+    ;; ((device 1)) x break
+    ;; ((device 2)) y break
+
     ;; default case, empty list always evaluates to true.
     ;; break vs. fallthrough doesn't matter here
     () c break

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -810,10 +810,10 @@ If you need help, please feel welcome to ask in the GitHub discussions.
     ((base-layer dvorak)) x break
     ((base-layer qwerty)) y break
 
-    ;; device evaluates to `true` if the event came from a device matching
-    ;; the given device ID defined in definputdevices. Currently macOS only.
-    ;; ((device 1)) x break
-    ;; ((device 2)) y break
+    ;; device-history evaluates to `true` if the Nth most recent device
+    ;; matches the given device ID defined in definputdevices. Currently macOS only.
+    ;; ((device-history 1 1)) x break
+    ;; ((device-history 2 1)) y break
 
     ;; default case, empty list always evaluates to true.
     ;; break vs. fallthrough doesn't matter here

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2915,6 +2915,7 @@ if any of the items evaluates to true.
 (input-history $input-type $key-name $input-recency)
 (layer      $layer-name)
 (base-layer $layer-name)
+(device     $device-id)
 ----
 
 [cols="1,4"]
@@ -2958,6 +2959,12 @@ The max recency is 8.
 | `base-layer`
 | Evaluates to true if the most-recently-switched-to layer
 from a `layer-switch` action matches `$layer-name`.
+
+| `device`
+| Evaluates to true if the event came from the physical device
+with the given `$device-id`. Device IDs are defined via
+<<definputdevices,`definputdevices`>>.
+Currently supported on macOS only.
 |===
 
 **Description**
@@ -4094,6 +4101,71 @@ See a sample below that showcases a reusable template.
   (s d) @v-del 75 first-release ()
 )
 ----
+
+[[definputdevices]]
+== definputdevices
+
+**Reference**
+
+The optional `definputdevices` block maps user-chosen numeric device IDs
+to physical input devices, enabling per-device key mappings via the
+<<switch,`switch`>> action's `(device $id)` condition.
+
+.Syntax:
+[source]
+----
+(definputdevices
+  $id1 ($matcher1a $matcher1b ...)
+  $id2 ($matcher2a ...)
+  ...
+)
+----
+
+Each entry is a pair of a device ID (1-255) and a list of matchers.
+All matchers within an entry must match for a device to be assigned that ID
+(AND semantics).
+
+.Available matchers:
+[cols="1,4"]
+|===
+| `(name "...")`
+| Matches devices whose product name contains the given string.
+
+| `(hash "...")`
+| Matches devices whose hex hash equals the given string.
+Use `kanata --list` to see device hashes.
+
+| `(vendor_id N)`
+| Matches devices with the given USB vendor ID (0-65535, hex with `0x` prefix allowed).
+
+| `(product_id N)`
+| Matches devices with the given USB product ID (0-65535, hex with `0x` prefix allowed).
+|===
+
+.Example:
+[source]
+----
+(definputdevices
+  1 ((name "Apple Internal Keyboard"))
+  2 ((name "Go60") (vendor_id 0x1D50) (product_id 0x615E))
+)
+
+(defsrc a)
+(deflayer base
+  (switch
+    ((device 1)) x break
+    ((device 2)) y break
+    () a break))
+----
+
+In this example, pressing `a` on the internal keyboard outputs `x`,
+pressing `a` on the Go60 outputs `y`, and pressing `a` on any other
+device outputs `a`.
+
+NOTE: Device IDs are matched at startup. Devices plugged in after kanata
+starts will not be recognized. Live reload does not re-read device mappings.
+
+NOTE: Currently supported on macOS only. Linux support is planned.
 
 [[optional-defcfg-options]]
 == defcfg options

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2915,7 +2915,7 @@ if any of the items evaluates to true.
 (input-history $input-type $key-name $input-recency)
 (layer      $layer-name)
 (base-layer $layer-name)
-(device     $device-id)
+(device-history $device-id $device-recency)
 ----
 
 [cols="1,4"]
@@ -2960,10 +2960,11 @@ The max recency is 8.
 | Evaluates to true if the most-recently-switched-to layer
 from a `layer-switch` action matches `$layer-name`.
 
-| `device`
-| Evaluates to true if the event came from the physical device
-with the given `$device-id`. Device IDs are defined via
-<<definputdevices,`definputdevices`>>.
+| `device-history`
+| Evaluates to true if the device in the `$device-recency` slot
+matches `$device-id`. A recency of 1 is the most recent device
+that sent an event. The max recency is 8.
+Device IDs are defined via <<definputdevices,`definputdevices`>>.
 Currently supported on macOS only.
 |===
 
@@ -4109,7 +4110,7 @@ See a sample below that showcases a reusable template.
 
 The optional `definputdevices` block maps user-chosen numeric device IDs
 to physical input devices, enabling per-device key mappings via the
-<<switch,`switch`>> action's `(device $id)` condition.
+<<switch,`switch`>> action's `(device-history $id $recency)` condition.
 
 .Syntax:
 [source]
@@ -4153,8 +4154,8 @@ Use `kanata --list` to see device hashes.
 (defsrc a)
 (deflayer base
   (switch
-    ((device 1)) x break
-    ((device 2)) y break
+    ((device-history 1 1)) x break
+    ((device-history 2 1)) y break
     () a break))
 ----
 

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -4122,9 +4122,14 @@ to physical input devices, enabling per-device key mappings via the
 )
 ----
 
-Each entry is a pair of a device ID (1-255) and a list of matchers.
-All matchers within an entry must match for a device to be assigned that ID
-(AND semantics).
+[cols="1,4"]
+|===
+| `$id`
+| An integer from 1-255 used to reference this device in `(device-history $id $recency)` conditions. The value is arbitrary; use `defvar` to give IDs meaningful names.
+
+| `($matcher ...)`
+| A list of matcher expressions. All matchers within an entry must match for a device to be assigned that ID (AND semantics).
+|===
 
 .Available matchers:
 [cols="1,4"]
@@ -4137,25 +4142,44 @@ All matchers within an entry must match for a device to be assigned that ID
 Use `kanata --list` to see device hashes.
 
 | `(vendor_id N)`
-| Matches devices with the given USB vendor ID (0-65535, hex with `0x` prefix allowed).
+| Matches devices with the given USB vendor ID. Valid values: decimal 0-65535, or hex `0x0-0xFFFF`.
 
 | `(product_id N)`
-| Matches devices with the given USB product ID (0-65535, hex with `0x` prefix allowed).
+| Matches devices with the given USB product ID. Valid values: decimal 0-65535, or hex `0x0-0xFFFF`.
 |===
+
+**Description**
+
+`definputdevices` is useful when you have multiple keyboards with different
+physical layouts and want to unify their behavior — for example, to remap
+swapped modifier key positions between Ctrl, Meta, and Alt across devices.
+
+The kanata-defined IDs are arbitrary numbers whose only purpose is referencing
+within the `switch` action's `(device-history $id $recency)` condition.
+Using `defvar` to name them is recommended for readability.
+
+Device history only records press events (not release or repeat).
+If a key is pressed on a device not listed in `definputdevices`, the history
+slot will be recorded as "unknown" and will not match any device ID.
 
 .Example:
 [source]
 ----
+(defvar
+  id-AppleInternal 1
+  id-Go60          2
+)
+
 (definputdevices
-  1 ((name "Apple Internal Keyboard"))
-  2 ((name "Go60") (vendor_id 0x1D50) (product_id 0x615E))
+  $id-AppleInternal ((name "Apple Internal Keyboard"))
+  $id-Go60 ((name "Go60") (vendor_id 0x1D50) (product_id 0x615E))
 )
 
 (defsrc a)
 (deflayer base
   (switch
-    ((device-history 1 1)) x break
-    ((device-history 2 1)) y break
+    ((device-history $id-AppleInternal  1)) x break
+    ((device-history $id-Go60           1)) y break
     () a break))
 ----
 

--- a/keyberon/src/action/switch.rs
+++ b/keyberon/src/action/switch.rs
@@ -14,6 +14,7 @@ use super::*;
 use crate::layout::{HistoricalEvent, KCoord};
 
 use crate::key_code::*;
+use std::num::NonZeroU8;
 
 use BooleanOperator::*;
 use BreakOrFallthrough::*;
@@ -49,6 +50,7 @@ const INPUT_VAL: u16 = 851;
 const HISTORICAL_INPUT_VAL: u16 = 852;
 const LAYER_VAL: u16 = 853;
 const BASE_LAYER_VAL: u16 = 854;
+const DEVICE_VAL: u16 = 855;
 
 // Binary values:
 // 0b0100 ...
@@ -87,6 +89,7 @@ enum OpCodeType {
     TicksSinceGreaterThan(TicksSinceNthKey),
     Layer(u16),
     BaseLayer(u16),
+    Device(NonZeroU8),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -131,6 +134,7 @@ impl<'a, T> Switch<'a, T> {
     /// the currently active keys, and historically pressed keys.
     ///
     /// The `historical_keys` parameter should iterate in the order of most-recent-first.
+    #[allow(clippy::too_many_arguments)]
     pub fn actions<A1, A2, H1, H2, L>(
         &self,
         active_keys: A1,
@@ -139,6 +143,7 @@ impl<'a, T> Switch<'a, T> {
         historical_positions: H2,
         layers: L,
         default_layer: u16,
+        device_id: Option<NonZeroU8>,
     ) -> SwitchActions<'a, T, A1, A2, H1, H2, L>
     where
         A1: Iterator<Item = KeyCode> + Clone,
@@ -155,6 +160,7 @@ impl<'a, T> Switch<'a, T> {
             historical_positions,
             layers,
             default_layer,
+            device_id,
             case_index: 0,
         }
     }
@@ -177,6 +183,7 @@ where
     historical_positions: H2,
     layers: L,
     default_layer: u16,
+    device_id: Option<NonZeroU8>,
     case_index: usize,
 }
 
@@ -201,6 +208,7 @@ where
                 self.historical_positions.clone(),
                 self.layers.clone(),
                 self.default_layer,
+                self.device_id,
             ) {
                 let ret_ac = case.1;
                 match case.2 {
@@ -315,6 +323,11 @@ impl OpCode {
         (Self(BASE_LAYER_VAL), Self(base_layer))
     }
 
+    /// Return OpCodes specifying a device ID check.
+    pub fn new_device(id: NonZeroU8) -> (Self, Self) {
+        (Self(DEVICE_VAL), Self(id.get() as u16))
+    }
+
     /// Return the interpretation of this `OpCode`.
     fn opcode_type(self, next: Option<OpCode>) -> OpCodeType {
         if self.0 < KEY_MAX {
@@ -329,6 +342,9 @@ impl OpCode {
                 }),
                 LAYER_VAL => OpCodeType::Layer(op2.0),
                 BASE_LAYER_VAL => OpCodeType::BaseLayer(op2.0),
+                DEVICE_VAL => OpCodeType::Device(
+                    NonZeroU8::new(op2.0 as u8).expect("device ID must be nonzero"),
+                ),
                 _ => unreachable!("unexpected opcode {self:?}"),
             }
         } else {
@@ -366,6 +382,7 @@ impl From<u16> for OperatorAndEndIndex {
 }
 
 /// Evaluate the return value of an expression evaluated on the given key codes.
+#[allow(clippy::too_many_arguments)]
 fn evaluate_boolean(
     bool_expr: &[OpCode],
     key_codes: impl Iterator<Item = KeyCode> + Clone,
@@ -374,6 +391,7 @@ fn evaluate_boolean(
     historical_inputs: impl Iterator<Item = HistoricalEvent<KCoord>> + Clone,
     layers: impl Iterator<Item = u16> + Clone,
     default_layer: u16,
+    device_id: Option<NonZeroU8>,
 ) -> bool {
     let mut ret = true;
     let mut current_index = 0;
@@ -465,6 +483,11 @@ fn evaluate_boolean(
                 current_index += 1;
                 ret = default_layer == base_layer;
             }
+            OpCodeType::Device(id) => {
+                // opcode has size 2
+                current_index += 1;
+                ret = device_id == Some(id);
+            }
         };
         if current_op == Not {
             ret = !ret;
@@ -493,6 +516,7 @@ fn evaluate_bool_test(opcodes: &[OpCode], keycodes: impl Iterator<Item = KeyCode
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     )
 }
 
@@ -752,6 +776,7 @@ fn switch_fallthrough() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     );
     assert_eq!(actions.next(), Some(&Action::<()>::KeyCode(KeyCode::A)));
     assert_eq!(actions.next(), Some(&Action::<()>::KeyCode(KeyCode::B)));
@@ -773,6 +798,7 @@ fn switch_break() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     );
     assert_eq!(actions.next(), Some(&Action::<()>::KeyCode(KeyCode::A)));
     assert_eq!(actions.next(), None);
@@ -801,8 +827,60 @@ fn switch_no_actions() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     );
     assert_eq!(actions.next(), None);
+}
+
+#[test]
+fn switch_device_match() {
+    let id1 = NonZeroU8::new(1).unwrap();
+    let id2 = NonZeroU8::new(2).unwrap();
+    let (op1, op2) = OpCode::new_device(id1);
+    let opcodes = [op1, op2];
+    // Matching device ID
+    assert!(evaluate_boolean(
+        &opcodes,
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        Some(id1),
+    ));
+    // Non-matching device ID
+    assert!(!evaluate_boolean(
+        &opcodes,
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        Some(id2),
+    ));
+    // No device ID (None)
+    assert!(!evaluate_boolean(
+        &opcodes,
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        None,
+    ));
+}
+
+#[test]
+fn switch_device_opcode_roundtrip() {
+    let id = NonZeroU8::new(42).unwrap();
+    let (op1, op2) = OpCode::new_device(id);
+    match op1.opcode_type(Some(op2)) {
+        OpCodeType::Device(decoded_id) => assert_eq!(decoded_id, id),
+        other => panic!("expected Device, got {other:?}"),
+    }
 }
 
 #[test]
@@ -861,6 +939,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     ));
     assert!(evaluate_boolean(
         opcode_true2.as_slice(),
@@ -870,6 +949,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     ));
     assert!(!evaluate_boolean(
         opcode_false.as_slice(),
@@ -879,6 +959,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     ));
     assert!(!evaluate_boolean(
         opcode_false2.as_slice(),
@@ -888,6 +969,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         [].iter().copied(),
         0,
+        None,
     ));
 }
 
@@ -973,6 +1055,7 @@ fn switch_historical_bools() {
                 [].iter().copied(),
                 [].iter().copied(),
                 0,
+                None,
             ),
             expectation
         );
@@ -1089,6 +1172,7 @@ fn switch_historical_ticks_since() {
                 [].iter().copied(),
                 [].iter().copied(),
                 0,
+                None,
             ),
             expectation
         );
@@ -1323,6 +1407,7 @@ fn switch_inputs() {
                 [].iter().copied(),
                 [].iter().copied(),
                 0,
+                None,
             ),
             expectation
         );
@@ -1391,6 +1476,7 @@ fn switch_historical_inputs() {
                 historical_inputs.iter().copied(),
                 [].iter().copied(),
                 0,
+                None,
             ),
             expectation
         );

--- a/keyberon/src/action/switch.rs
+++ b/keyberon/src/action/switch.rs
@@ -50,7 +50,7 @@ const INPUT_VAL: u16 = 851;
 const HISTORICAL_INPUT_VAL: u16 = 852;
 const LAYER_VAL: u16 = 853;
 const BASE_LAYER_VAL: u16 = 854;
-const DEVICE_VAL: u16 = 855;
+const HISTORICAL_DEVICE_VAL: u16 = 855;
 
 // Binary values:
 // 0b0100 ...
@@ -89,7 +89,7 @@ enum OpCodeType {
     TicksSinceGreaterThan(TicksSinceNthKey),
     Layer(u16),
     BaseLayer(u16),
-    Device(NonZeroU8),
+    HistoricalDevice(HistoricalDevice),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -116,6 +116,12 @@ struct HistoricalInput {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+struct HistoricalDevice {
+    device_id: NonZeroU8,
+    how_far_back: u8,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct TicksSinceNthKey {
     nth_key: u8,
     ticks_since: u16,
@@ -135,7 +141,7 @@ impl<'a, T> Switch<'a, T> {
     ///
     /// The `historical_keys` parameter should iterate in the order of most-recent-first.
     #[allow(clippy::too_many_arguments)]
-    pub fn actions<A1, A2, H1, H2, L>(
+    pub fn actions<A1, A2, H1, H2, L, D>(
         &self,
         active_keys: A1,
         active_positions: A2,
@@ -143,14 +149,15 @@ impl<'a, T> Switch<'a, T> {
         historical_positions: H2,
         layers: L,
         default_layer: u16,
-        device_id: Option<NonZeroU8>,
-    ) -> SwitchActions<'a, T, A1, A2, H1, H2, L>
+        device_history: D,
+    ) -> SwitchActions<'a, T, A1, A2, H1, H2, L, D>
     where
         A1: Iterator<Item = KeyCode> + Clone,
         A2: Iterator<Item = KCoord> + Clone,
         H1: Iterator<Item = HistoricalEvent<KeyCode>> + Clone,
         H2: Iterator<Item = HistoricalEvent<KCoord>> + Clone,
         L: Iterator<Item = u16> + Clone,
+        D: Iterator<Item = NonZeroU8> + Clone,
     {
         SwitchActions {
             cases: self.cases,
@@ -160,7 +167,7 @@ impl<'a, T> Switch<'a, T> {
             historical_positions,
             layers,
             default_layer,
-            device_id,
+            device_history,
             case_index: 0,
         }
     }
@@ -168,13 +175,14 @@ impl<'a, T> Switch<'a, T> {
 
 #[derive(Debug, Clone)]
 /// Iterator returned by `Switch::actions`.
-pub struct SwitchActions<'a, T, A1, A2, H1, H2, L>
+pub struct SwitchActions<'a, T, A1, A2, H1, H2, L, D>
 where
     A1: Iterator<Item = KeyCode> + Clone,
     A2: Iterator<Item = KCoord> + Clone,
     H1: Iterator<Item = HistoricalEvent<KeyCode>> + Clone,
     H2: Iterator<Item = HistoricalEvent<KCoord>> + Clone,
     L: Iterator<Item = u16> + Clone,
+    D: Iterator<Item = NonZeroU8> + Clone,
 {
     cases: &'a [(&'a [OpCode], &'a Action<'a, T>, BreakOrFallthrough)],
     active_keys: A1,
@@ -183,17 +191,18 @@ where
     historical_positions: H2,
     layers: L,
     default_layer: u16,
-    device_id: Option<NonZeroU8>,
+    device_history: D,
     case_index: usize,
 }
 
-impl<'a, T, A1, A2, H1, H2, L> Iterator for SwitchActions<'a, T, A1, A2, H1, H2, L>
+impl<'a, T, A1, A2, H1, H2, L, D> Iterator for SwitchActions<'a, T, A1, A2, H1, H2, L, D>
 where
     A1: Iterator<Item = KeyCode> + Clone,
     A2: Iterator<Item = KCoord> + Clone,
     H1: Iterator<Item = HistoricalEvent<KeyCode>> + Clone,
     H2: Iterator<Item = HistoricalEvent<KCoord>> + Clone,
     L: Iterator<Item = u16> + Clone,
+    D: Iterator<Item = NonZeroU8> + Clone,
 {
     type Item = &'a Action<'a, T>;
 
@@ -208,7 +217,7 @@ where
                 self.historical_positions.clone(),
                 self.layers.clone(),
                 self.default_layer,
-                self.device_id,
+                self.device_history.clone(),
             ) {
                 let ret_ac = case.1;
                 match case.2 {
@@ -323,9 +332,13 @@ impl OpCode {
         (Self(BASE_LAYER_VAL), Self(base_layer))
     }
 
-    /// Return OpCodes specifying a device ID check.
-    pub fn new_device(id: NonZeroU8) -> (Self, Self) {
-        (Self(DEVICE_VAL), Self(id.get() as u16))
+    /// Return OpCodes specifying a device history check.
+    pub fn new_device_history(id: NonZeroU8, how_far_back: u8) -> (Self, Self) {
+        assert!(how_far_back <= MAX_KEY_RECENCY);
+        (
+            Self(HISTORICAL_DEVICE_VAL),
+            Self(id.get() as u16 | ((how_far_back as u16) << 8)),
+        )
     }
 
     /// Return the interpretation of this `OpCode`.
@@ -342,9 +355,11 @@ impl OpCode {
                 }),
                 LAYER_VAL => OpCodeType::Layer(op2.0),
                 BASE_LAYER_VAL => OpCodeType::BaseLayer(op2.0),
-                DEVICE_VAL => OpCodeType::Device(
-                    NonZeroU8::new(op2.0 as u8).expect("device ID must be nonzero"),
-                ),
+                HISTORICAL_DEVICE_VAL => OpCodeType::HistoricalDevice(HistoricalDevice {
+                    device_id: NonZeroU8::new((op2.0 & 0xFF) as u8)
+                        .expect("device ID must be nonzero"),
+                    how_far_back: ((op2.0 >> 8) & 0x7) as u8,
+                }),
                 _ => unreachable!("unexpected opcode {self:?}"),
             }
         } else {
@@ -391,7 +406,7 @@ fn evaluate_boolean(
     historical_inputs: impl Iterator<Item = HistoricalEvent<KCoord>> + Clone,
     layers: impl Iterator<Item = u16> + Clone,
     default_layer: u16,
-    device_id: Option<NonZeroU8>,
+    device_history: impl Iterator<Item = NonZeroU8> + Clone,
 ) -> bool {
     let mut ret = true;
     let mut current_index = 0;
@@ -483,10 +498,14 @@ fn evaluate_boolean(
                 current_index += 1;
                 ret = default_layer == base_layer;
             }
-            OpCodeType::Device(id) => {
+            OpCodeType::HistoricalDevice(hd) => {
                 // opcode has size 2
                 current_index += 1;
-                ret = device_id == Some(id);
+                ret = device_history
+                    .clone()
+                    .nth(hd.how_far_back as usize)
+                    .map(|d| d == hd.device_id)
+                    .unwrap_or(false);
             }
         };
         if current_op == Not {
@@ -516,7 +535,7 @@ fn evaluate_bool_test(opcodes: &[OpCode], keycodes: impl Iterator<Item = KeyCode
         [].iter().copied(),
         [].iter().copied(),
         0,
-        None,
+        core::iter::empty(),
     )
 }
 
@@ -776,7 +795,7 @@ fn switch_fallthrough() {
         [].iter().copied(),
         [].iter().copied(),
         0,
-        None,
+        core::iter::empty(),
     );
     assert_eq!(actions.next(), Some(&Action::<()>::KeyCode(KeyCode::A)));
     assert_eq!(actions.next(), Some(&Action::<()>::KeyCode(KeyCode::B)));
@@ -798,7 +817,7 @@ fn switch_break() {
         [].iter().copied(),
         [].iter().copied(),
         0,
-        None,
+        core::iter::empty(),
     );
     assert_eq!(actions.next(), Some(&Action::<()>::KeyCode(KeyCode::A)));
     assert_eq!(actions.next(), None);
@@ -827,18 +846,18 @@ fn switch_no_actions() {
         [].iter().copied(),
         [].iter().copied(),
         0,
-        None,
+        core::iter::empty(),
     );
     assert_eq!(actions.next(), None);
 }
 
 #[test]
-fn switch_device_match() {
+fn switch_device_history_match() {
     let id1 = NonZeroU8::new(1).unwrap();
     let id2 = NonZeroU8::new(2).unwrap();
-    let (op1, op2) = OpCode::new_device(id1);
+    let (op1, op2) = OpCode::new_device_history(id1, 0);
     let opcodes = [op1, op2];
-    // Matching device ID
+    // Matching device ID (most recent)
     assert!(evaluate_boolean(
         &opcodes,
         [].iter().copied(),
@@ -847,7 +866,7 @@ fn switch_device_match() {
         [].iter().copied(),
         [].iter().copied(),
         0,
-        Some(id1),
+        [id1].iter().copied(),
     ));
     // Non-matching device ID
     assert!(!evaluate_boolean(
@@ -858,9 +877,9 @@ fn switch_device_match() {
         [].iter().copied(),
         [].iter().copied(),
         0,
-        Some(id2),
+        [id2].iter().copied(),
     ));
-    // No device ID (None)
+    // Empty device history
     assert!(!evaluate_boolean(
         &opcodes,
         [].iter().copied(),
@@ -869,17 +888,64 @@ fn switch_device_match() {
         [].iter().copied(),
         [].iter().copied(),
         0,
-        None,
+        core::iter::empty(),
     ));
 }
 
 #[test]
-fn switch_device_opcode_roundtrip() {
+fn switch_device_history_recency() {
+    let id1 = NonZeroU8::new(1).unwrap();
+    let id2 = NonZeroU8::new(2).unwrap();
+    let id3 = NonZeroU8::new(3).unwrap();
+    let history = [id3, id2, id1]; // most recent first: 3, 2, 1
+    // Check most recent (recency 1 → how_far_back 0) is id3
+    let (op1, op2) = OpCode::new_device_history(id3, 0);
+    assert!(evaluate_boolean(
+        &[op1, op2],
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        history.iter().copied(),
+    ));
+    // Check second most recent (recency 2 → how_far_back 1) is id2
+    let (op1, op2) = OpCode::new_device_history(id2, 1);
+    assert!(evaluate_boolean(
+        &[op1, op2],
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        history.iter().copied(),
+    ));
+    // Wrong device at recency 1
+    let (op1, op2) = OpCode::new_device_history(id1, 0);
+    assert!(!evaluate_boolean(
+        &[op1, op2],
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        history.iter().copied(),
+    ));
+}
+
+#[test]
+fn switch_device_history_opcode_roundtrip() {
     let id = NonZeroU8::new(42).unwrap();
-    let (op1, op2) = OpCode::new_device(id);
+    let (op1, op2) = OpCode::new_device_history(id, 3);
     match op1.opcode_type(Some(op2)) {
-        OpCodeType::Device(decoded_id) => assert_eq!(decoded_id, id),
-        other => panic!("expected Device, got {other:?}"),
+        OpCodeType::HistoricalDevice(hd) => {
+            assert_eq!(hd.device_id, id);
+            assert_eq!(hd.how_far_back, 3);
+        }
+        other => panic!("expected HistoricalDevice, got {other:?}"),
     }
 }
 
@@ -939,7 +1005,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         [].iter().copied(),
         0,
-        None,
+        core::iter::empty(),
     ));
     assert!(evaluate_boolean(
         opcode_true2.as_slice(),
@@ -949,7 +1015,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         [].iter().copied(),
         0,
-        None,
+        core::iter::empty(),
     ));
     assert!(!evaluate_boolean(
         opcode_false.as_slice(),
@@ -959,7 +1025,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         [].iter().copied(),
         0,
-        None,
+        core::iter::empty(),
     ));
     assert!(!evaluate_boolean(
         opcode_false2.as_slice(),
@@ -969,7 +1035,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         [].iter().copied(),
         0,
-        None,
+        core::iter::empty(),
     ));
 }
 
@@ -1055,7 +1121,7 @@ fn switch_historical_bools() {
                 [].iter().copied(),
                 [].iter().copied(),
                 0,
-                None,
+                core::iter::empty(),
             ),
             expectation
         );
@@ -1172,7 +1238,7 @@ fn switch_historical_ticks_since() {
                 [].iter().copied(),
                 [].iter().copied(),
                 0,
-                None,
+                core::iter::empty(),
             ),
             expectation
         );
@@ -1407,7 +1473,7 @@ fn switch_inputs() {
                 [].iter().copied(),
                 [].iter().copied(),
                 0,
-                None,
+                core::iter::empty(),
             ),
             expectation
         );
@@ -1476,7 +1542,7 @@ fn switch_historical_inputs() {
                 historical_inputs.iter().copied(),
                 [].iter().copied(),
                 0,
-                None,
+                core::iter::empty(),
             ),
             expectation
         );

--- a/keyberon/src/action/switch.rs
+++ b/keyberon/src/action/switch.rs
@@ -157,7 +157,7 @@ impl<'a, T> Switch<'a, T> {
         H1: Iterator<Item = HistoricalEvent<KeyCode>> + Clone,
         H2: Iterator<Item = HistoricalEvent<KCoord>> + Clone,
         L: Iterator<Item = u16> + Clone,
-        D: Iterator<Item = NonZeroU8> + Clone,
+        D: Iterator<Item = Option<NonZeroU8>> + Clone,
     {
         SwitchActions {
             cases: self.cases,
@@ -182,7 +182,7 @@ where
     H1: Iterator<Item = HistoricalEvent<KeyCode>> + Clone,
     H2: Iterator<Item = HistoricalEvent<KCoord>> + Clone,
     L: Iterator<Item = u16> + Clone,
-    D: Iterator<Item = NonZeroU8> + Clone,
+    D: Iterator<Item = Option<NonZeroU8>> + Clone,
 {
     cases: &'a [(&'a [OpCode], &'a Action<'a, T>, BreakOrFallthrough)],
     active_keys: A1,
@@ -202,7 +202,7 @@ where
     H1: Iterator<Item = HistoricalEvent<KeyCode>> + Clone,
     H2: Iterator<Item = HistoricalEvent<KCoord>> + Clone,
     L: Iterator<Item = u16> + Clone,
-    D: Iterator<Item = NonZeroU8> + Clone,
+    D: Iterator<Item = Option<NonZeroU8>> + Clone,
 {
     type Item = &'a Action<'a, T>;
 
@@ -406,7 +406,7 @@ fn evaluate_boolean(
     historical_inputs: impl Iterator<Item = HistoricalEvent<KCoord>> + Clone,
     layers: impl Iterator<Item = u16> + Clone,
     default_layer: u16,
-    device_history: impl Iterator<Item = NonZeroU8> + Clone,
+    device_history: impl Iterator<Item = Option<NonZeroU8>> + Clone,
 ) -> bool {
     let mut ret = true;
     let mut current_index = 0;
@@ -504,7 +504,7 @@ fn evaluate_boolean(
                 ret = device_history
                     .clone()
                     .nth(hd.how_far_back as usize)
-                    .map(|d| d == hd.device_id)
+                    .and_then(|d| d.map(|d| d == hd.device_id))
                     .unwrap_or(false);
             }
         };
@@ -866,7 +866,7 @@ fn switch_device_history_match() {
         [].iter().copied(),
         [].iter().copied(),
         0,
-        [id1].iter().copied(),
+        [Some(id1)].iter().copied(),
     ));
     // Non-matching device ID
     assert!(!evaluate_boolean(
@@ -877,7 +877,7 @@ fn switch_device_history_match() {
         [].iter().copied(),
         [].iter().copied(),
         0,
-        [id2].iter().copied(),
+        [Some(id2)].iter().copied(),
     ));
     // Empty device history
     assert!(!evaluate_boolean(
@@ -897,7 +897,7 @@ fn switch_device_history_recency() {
     let id1 = NonZeroU8::new(1).unwrap();
     let id2 = NonZeroU8::new(2).unwrap();
     let id3 = NonZeroU8::new(3).unwrap();
-    let history = [id3, id2, id1]; // most recent first: 3, 2, 1
+    let history = [Some(id3), Some(id2), Some(id1)]; // most recent first: 3, 2, 1
     // Check most recent (recency 1 → how_far_back 0) is id3
     let (op1, op2) = OpCode::new_device_history(id3, 0);
     assert!(evaluate_boolean(
@@ -947,6 +947,36 @@ fn switch_device_history_opcode_roundtrip() {
         }
         other => panic!("expected HistoricalDevice, got {other:?}"),
     }
+}
+
+#[test]
+fn switch_device_history_unknown_device() {
+    let id1 = NonZeroU8::new(1).unwrap();
+    let history = [Some(id1), None, Some(id1)]; // unknown device at position 1
+    // Looking for id1 at position 0 should match
+    let (op1, op2) = OpCode::new_device_history(id1, 0);
+    assert!(evaluate_boolean(
+        &[op1, op2],
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        history.iter().copied(),
+    ));
+    // Looking for id1 at position 1 (where None is) should NOT match
+    let (op1, op2) = OpCode::new_device_history(id1, 1);
+    assert!(!evaluate_boolean(
+        &[op1, op2],
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        history.iter().copied(),
+    ));
 }
 
 #[test]

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -133,10 +133,9 @@ where
     /// immediately resolve as tap (typing streak detection). 0 = disabled.
     pub tap_hold_require_prior_idle: u16,
     pub chords_v2: Option<ChordsV2<'a, T>>,
-    /// The device ID of the current event being processed. Set by the caller
-    /// immediately before each event is processed. Used by `(device N)` switch
-    /// conditions to match against the originating physical device.
-    pub current_device_id: Option<std::num::NonZeroU8>,
+    /// History of device IDs that sent events, most-recent-first.
+    /// Used by `(device-history N recency)` switch conditions.
+    pub device_history: ArrayDeque<std::num::NonZeroU8, 8, arraydeque::behavior::Wrapping>,
     rpt_multikey_key_buffer: MultiKeyBuffer<'a, T>,
     trans_resolution_behavior_v2: bool,
     delegate_to_first_layer: bool,
@@ -1237,7 +1236,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
             trans_resolution_behavior_v2: true,
             delegate_to_first_layer: false,
             chords_v2: None,
-            current_device_id: None,
+            device_history: ArrayDeque::new(),
             contextual_execution: ContextualExecution::new(),
             tap_hold_tracker: Default::default(),
         }
@@ -2441,7 +2440,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
                     // Note on truncating cast: I expect default layer to be in range by other
                     // assertions.
                     self.default_layer as u16,
-                    self.current_device_id,
+                    self.device_history.iter().copied(),
                 ) {
                     action_queue.push_back(Some((coord, delay, ac, layer_stack.clone().collect())));
                 }

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -135,7 +135,7 @@ where
     pub chords_v2: Option<ChordsV2<'a, T>>,
     /// History of device IDs that sent events, most-recent-first.
     /// Used by `(device-history N recency)` switch conditions.
-    pub device_history: ArrayDeque<std::num::NonZeroU8, 8, arraydeque::behavior::Wrapping>,
+    pub device_history: ArrayDeque<Option<std::num::NonZeroU8>, 8, arraydeque::behavior::Wrapping>,
     rpt_multikey_key_buffer: MultiKeyBuffer<'a, T>,
     trans_resolution_behavior_v2: bool,
     delegate_to_first_layer: bool,

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -133,6 +133,10 @@ where
     /// immediately resolve as tap (typing streak detection). 0 = disabled.
     pub tap_hold_require_prior_idle: u16,
     pub chords_v2: Option<ChordsV2<'a, T>>,
+    /// The device ID of the current event being processed. Set by the caller
+    /// immediately before each event is processed. Used by `(device N)` switch
+    /// conditions to match against the originating physical device.
+    pub current_device_id: Option<std::num::NonZeroU8>,
     rpt_multikey_key_buffer: MultiKeyBuffer<'a, T>,
     trans_resolution_behavior_v2: bool,
     delegate_to_first_layer: bool,
@@ -1233,6 +1237,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
             trans_resolution_behavior_v2: true,
             delegate_to_first_layer: false,
             chords_v2: None,
+            current_device_id: None,
             contextual_execution: ContextualExecution::new(),
             tap_hold_tracker: Default::default(),
         }
@@ -2436,6 +2441,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
                     // Note on truncating cast: I expect default layer to be in range by other
                     // assertions.
                     self.default_layer as u16,
+                    self.current_device_id,
                 ) {
                     action_queue.push_back(Some((coord, delay, ac, layer_stack.clone().collect())));
                 }

--- a/parser/src/cfg/definputdevices.rs
+++ b/parser/src/cfg/definputdevices.rs
@@ -1,0 +1,135 @@
+use super::*;
+use crate::{anyhow_expr, bail_expr};
+use std::num::NonZeroU8;
+
+#[derive(Debug, Clone, Default)]
+pub struct InputDeviceMatcher {
+    pub name: Option<String>,
+    pub hash: Option<String>,
+    pub vendor_id: Option<u16>,
+    pub product_id: Option<u16>,
+}
+
+pub fn parse_definputdevices(expr: &[SExpr]) -> Result<Vec<(NonZeroU8, InputDeviceMatcher)>> {
+    let mut exprs = check_first_expr(expr.iter(), "definputdevices")?;
+    let mut seen_ids = HashSet::default();
+    let mut devices = vec![];
+    loop {
+        let Some(id_expr) = exprs.next() else {
+            break;
+        };
+        let Some(matchers_expr) = exprs.next() else {
+            bail_expr!(
+                id_expr,
+                "definputdevices expects pairs: <id> <matcher-list>.\n\
+                 Missing matcher list for this device ID."
+            );
+        };
+        let id_str = id_expr
+            .atom(None)
+            .ok_or_else(|| anyhow_expr!(id_expr, "device ID must be a number (1-255)"))?;
+        let id_num: u8 = id_str
+            .parse()
+            .map_err(|_| anyhow_expr!(id_expr, "device ID must be a number (1-255)"))?;
+        let id = NonZeroU8::new(id_num)
+            .ok_or_else(|| anyhow_expr!(id_expr, "device ID must be nonzero (1-255)"))?;
+        if !seen_ids.insert(id) {
+            bail_expr!(id_expr, "duplicate device ID: {id_num}");
+        }
+        let matcher_list = matchers_expr
+            .list(None)
+            .ok_or_else(|| anyhow_expr!(matchers_expr, "device matchers must be a list"))?;
+        if matcher_list.is_empty() {
+            bail_expr!(
+                matchers_expr,
+                "device matcher list must not be empty; \
+                 specify at least one of: name, hash, vendor_id, product_id"
+            );
+        }
+        let mut matcher = InputDeviceMatcher::default();
+        for m in matcher_list.iter() {
+            let props = m.list(None).ok_or_else(|| {
+                anyhow_expr!(m, "each matcher must be a list, e.g. (name \"...\")")
+            })?;
+            if props.len() != 2 {
+                bail_expr!(
+                    m,
+                    "each matcher must have exactly 2 items: (property value)"
+                );
+            }
+            let prop_name = props[0]
+                .atom(None)
+                .ok_or_else(|| anyhow_expr!(&props[0], "matcher property must be an atom"))?;
+            let prop_val = props[1]
+                .atom(None)
+                .ok_or_else(|| anyhow_expr!(&props[1], "matcher value must be an atom"))?;
+            match prop_name {
+                "name" => {
+                    if matcher.name.is_some() {
+                        bail_expr!(m, "duplicate property: name");
+                    }
+                    matcher.name = Some(prop_val.to_string());
+                }
+                "hash" => {
+                    if matcher.hash.is_some() {
+                        bail_expr!(m, "duplicate property: hash");
+                    }
+                    let stripped = prop_val
+                        .strip_prefix("0x")
+                        .or_else(|| prop_val.strip_prefix("0X"))
+                        .unwrap_or(prop_val);
+                    if stripped.is_empty() || !stripped.chars().all(|c| c.is_ascii_hexdigit()) {
+                        bail_expr!(
+                            &props[1],
+                            "hash must be a valid hex string (e.g. \"a1b2c3def4\")"
+                        );
+                    }
+                    // Store lowercase, without 0x prefix, for case-insensitive matching.
+                    matcher.hash = Some(stripped.to_ascii_lowercase());
+                }
+                "vendor_id" => {
+                    if matcher.vendor_id.is_some() {
+                        bail_expr!(m, "duplicate property: vendor_id");
+                    }
+                    let v = parse_hex_or_decimal_u16(prop_val).map_err(|_| {
+                        anyhow_expr!(
+                            &props[1],
+                            "vendor_id must be a number 0-65535 or hex (e.g. 0x1D50)"
+                        )
+                    })?;
+                    matcher.vendor_id = Some(v);
+                }
+                "product_id" => {
+                    if matcher.product_id.is_some() {
+                        bail_expr!(m, "duplicate property: product_id");
+                    }
+                    let v = parse_hex_or_decimal_u16(prop_val).map_err(|_| {
+                        anyhow_expr!(
+                            &props[1],
+                            "product_id must be a number 0-65535 or hex (e.g. 0x615E)"
+                        )
+                    })?;
+                    matcher.product_id = Some(v);
+                }
+                _ => {
+                    bail_expr!(
+                        &props[0],
+                        "unknown matcher property: {prop_name}\n\
+                         valid properties: name, hash, vendor_id, product_id"
+                    );
+                }
+            }
+        }
+        devices.push((id, matcher));
+    }
+    Ok(devices)
+}
+
+fn parse_hex_or_decimal_u16(s: &str) -> std::result::Result<u16, Box<dyn std::error::Error>> {
+    let val: u64 = if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u64::from_str_radix(hex, 16)?
+    } else {
+        s.parse()?
+    };
+    u16::try_from(val).map_err(|e| e.into())
+}

--- a/parser/src/cfg/definputdevices.rs
+++ b/parser/src/cfg/definputdevices.rs
@@ -14,10 +14,7 @@ pub fn parse_definputdevices(expr: &[SExpr]) -> Result<Vec<(NonZeroU8, InputDevi
     let mut exprs = check_first_expr(expr.iter(), "definputdevices")?;
     let mut seen_ids = HashSet::default();
     let mut devices = vec![];
-    loop {
-        let Some(id_expr) = exprs.next() else {
-            break;
-        };
+    while let Some(id_expr) = exprs.next() {
         let Some(matchers_expr) = exprs.next() else {
             bail_expr!(
                 id_expr,

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -56,6 +56,8 @@ mod custom_tap_hold;
 use custom_tap_hold::*;
 mod defcfg;
 pub use defcfg::*;
+mod definputdevices;
+pub use definputdevices::*;
 mod defhands;
 use defhands::{
     parse_defhands, parse_tap_hold_opposite_hand, parse_tap_hold_opposite_hand_release,
@@ -305,6 +307,8 @@ pub struct Cfg {
     pub max_key_timing_check: u16,
     /// Zipchord-like configuration.
     pub zippy: Option<(ZchPossibleChords, ZchConfig)>,
+    /// Input device ID mappings from `definputdevices`.
+    pub input_devices: Option<Vec<(std::num::NonZeroU8, InputDeviceMatcher)>>,
 }
 
 /// Parse a new configuration from a file.
@@ -393,6 +397,7 @@ fn populate_cfg_with_icfg(icfg: IntermediateCfg, s: ParserState) -> Cfg {
         fake_keys,
         max_key_timing_check,
         zippy: icfg.zippy,
+        input_devices: s.input_devices,
     }
 }
 
@@ -642,6 +647,22 @@ pub fn parse_cfg_raw_string(
         });
     }
 
+    let input_devices = root_exprs
+        .iter()
+        .find(gen_first_atom_filter("definputdevices"))
+        .map(|expr| parse_definputdevices(expr))
+        .transpose()?;
+    if let Some(spanned) = spanned_root_exprs
+        .iter()
+        .filter(gen_first_atom_filter_spanned("definputdevices"))
+        .nth(1)
+    {
+        bail_span!(
+            spanned,
+            "Only one definputdevices is allowed, found more. Delete the extras."
+        )
+    }
+
     let var_exprs = root_exprs
         .iter()
         .filter(gen_first_atom_filter("defvar"))
@@ -756,6 +777,7 @@ pub fn parse_cfg_raw_string(
         lsp_hints: RefCell::new(lsp_hints),
         vars,
         max_key_timing_check: Cell::new(cfg.rapid_event_delay),
+        input_devices,
         ..Default::default()
     };
 
@@ -1018,7 +1040,8 @@ fn error_on_unknown_top_level_atoms(exprs: &[Spanned<Vec<SExpr>>]) -> Result<()>
                 | "defzippy"
                 | "defzippy-experimental"
                 | "defseq"
-                | "defhands" => Ok(()),
+                | "defhands"
+                | "definputdevices" => Ok(()),
                 _ => err_span!(expr, "Found unknown configuration item"),
             })
             .ok_or_else(|| {
@@ -1143,6 +1166,7 @@ pub struct ParserState {
     block_unmapped_keys: bool,
     max_key_timing_check: Cell<u16>,
     multi_action_nest_count: Cell<u16>,
+    input_devices: Option<Vec<(std::num::NonZeroU8, InputDeviceMatcher)>>,
     pctx: ParserContext,
     pub lsp_hints: RefCell<LspHints>,
     hand_map: Option<&'static custom_tap_hold::HandMap>,
@@ -1175,6 +1199,7 @@ impl Default for ParserState {
             block_unmapped_keys: default_cfg.block_unmapped_keys,
             max_key_timing_check: Cell::new(0),
             multi_action_nest_count: Cell::new(0),
+            input_devices: None,
             lsp_hints: Default::default(),
             hand_map: None,
             a: unsafe { Allocations::new() },

--- a/parser/src/cfg/switch.rs
+++ b/parser/src/cfg/switch.rs
@@ -90,6 +90,7 @@ pub fn parse_switch_case_bool(
             InputHistory,
             Layer,
             BaseLayer,
+            Device,
         }
         #[derive(Copy, Clone)]
         enum InputType {
@@ -116,6 +117,7 @@ pub fn parse_switch_case_bool(
                 "input-history" => Some(AllowedListOps::InputHistory),
                 "layer" => Some(AllowedListOps::Layer),
                 "base-layer" => Some(AllowedListOps::BaseLayer),
+                "device" => Some(AllowedListOps::Device),
                 _ => None,
             })
             .ok_or_else(|| {
@@ -123,7 +125,7 @@ pub fn parse_switch_case_bool(
                     op_expr,
                     "lists inside switch logic must begin with one of:\n\
                     or | and | not | key-history | key-timing\n\
-                    | input | input-history | layer | base-layer",
+                    | input | input-history | layer | base-layer | device",
                 )
             })?;
 
@@ -266,6 +268,35 @@ pub fn parse_switch_case_bool(
                     AllowedListOps::BaseLayer => OpCode::new_base_layer(layer),
                     _ => unreachable!(),
                 };
+                ops.extend(&[op1, op2]);
+                Ok(())
+            }
+            AllowedListOps::Device => {
+                if l.len() != 2 {
+                    bail_expr!(op_expr, "device must have 1 parameter: device-id (1-255)");
+                }
+                let id_str = l[1]
+                    .atom(s.vars())
+                    .ok_or_else(|| anyhow_expr!(&l[1], "device ID must be a number (1-255)"))?;
+                let id_num: u8 = id_str
+                    .parse()
+                    .map_err(|_| anyhow_expr!(&l[1], "device ID must be a number (1-255)"))?;
+                let id = std::num::NonZeroU8::new(id_num)
+                    .ok_or_else(|| anyhow_expr!(&l[1], "device ID must be nonzero (1-255)"))?;
+                if let Some(ref devs) = s.input_devices {
+                    if !devs.iter().any(|(did, _)| *did == id) {
+                        bail_expr!(
+                            &l[1],
+                            "device ID {id_num} is not defined in definputdevices"
+                        );
+                    }
+                } else {
+                    bail_expr!(
+                        &l[1],
+                        "cannot use (device {id_num}) without a definputdevices block"
+                    );
+                }
+                let (op1, op2) = OpCode::new_device(id);
                 ops.extend(&[op1, op2]);
                 Ok(())
             }

--- a/parser/src/cfg/switch.rs
+++ b/parser/src/cfg/switch.rs
@@ -299,8 +299,7 @@ pub fn parse_switch_case_bool(
                         "cannot use (device-history {id_num} ...) without a definputdevices block"
                     );
                 }
-                let device_recency =
-                    parse_u8_with_range(&l[2], s, "device-recency", 1, 8)? - 1;
+                let device_recency = parse_u8_with_range(&l[2], s, "device-recency", 1, 8)? - 1;
                 let (op1, op2) = OpCode::new_device_history(id, device_recency);
                 ops.extend(&[op1, op2]);
                 Ok(())

--- a/parser/src/cfg/switch.rs
+++ b/parser/src/cfg/switch.rs
@@ -90,7 +90,7 @@ pub fn parse_switch_case_bool(
             InputHistory,
             Layer,
             BaseLayer,
-            Device,
+            DeviceHistory,
         }
         #[derive(Copy, Clone)]
         enum InputType {
@@ -117,7 +117,7 @@ pub fn parse_switch_case_bool(
                 "input-history" => Some(AllowedListOps::InputHistory),
                 "layer" => Some(AllowedListOps::Layer),
                 "base-layer" => Some(AllowedListOps::BaseLayer),
-                "device" => Some(AllowedListOps::Device),
+                "device-history" => Some(AllowedListOps::DeviceHistory),
                 _ => None,
             })
             .ok_or_else(|| {
@@ -125,7 +125,7 @@ pub fn parse_switch_case_bool(
                     op_expr,
                     "lists inside switch logic must begin with one of:\n\
                     or | and | not | key-history | key-timing\n\
-                    | input | input-history | layer | base-layer | device",
+                    | input | input-history | layer | base-layer | device-history",
                 )
             })?;
 
@@ -271,9 +271,12 @@ pub fn parse_switch_case_bool(
                 ops.extend(&[op1, op2]);
                 Ok(())
             }
-            AllowedListOps::Device => {
-                if l.len() != 2 {
-                    bail_expr!(op_expr, "device must have 1 parameter: device-id (1-255)");
+            AllowedListOps::DeviceHistory => {
+                if l.len() != 3 {
+                    bail_expr!(
+                        op_expr,
+                        "device-history must have 2 parameters: device-id, device-recency"
+                    );
                 }
                 let id_str = l[1]
                     .atom(s.vars())
@@ -293,10 +296,12 @@ pub fn parse_switch_case_bool(
                 } else {
                     bail_expr!(
                         &l[1],
-                        "cannot use (device {id_num}) without a definputdevices block"
+                        "cannot use (device-history {id_num} ...) without a definputdevices block"
                     );
                 }
-                let (op1, op2) = OpCode::new_device(id);
+                let device_recency =
+                    parse_u8_with_range(&l[2], s, "device-recency", 1, 8)? - 1;
+                let (op1, op2) = OpCode::new_device_history(id, device_recency);
                 ops.extend(&[op1, op2]);
                 Ok(())
             }

--- a/simulated_input/src/sim.rs
+++ b/simulated_input/src/sim.rs
@@ -275,28 +275,19 @@ fn main_impl() -> Result<()> {
                             let key_code =
                                 str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?;
                             kbd_out_log(&mut k.kbd_out, LogFmtT::InKeyDown, Some(key_code), None);
-                            k.handle_input_event(&KeyEvent {
-                                code: key_code,
-                                value: KeyValue::Press,
-                            })?;
+                            k.handle_input_event(&KeyEvent::new(key_code, KeyValue::Press))?;
                         }
                         "release" | "↑" | "u" | "up" => {
                             let key_code =
                                 str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?;
                             kbd_out_log(&mut k.kbd_out, LogFmtT::InKeyUp, Some(key_code), None);
-                            k.handle_input_event(&KeyEvent {
-                                code: key_code,
-                                value: KeyValue::Release,
-                            })?;
+                            k.handle_input_event(&KeyEvent::new(key_code, KeyValue::Release))?;
                         }
                         "repeat" | "⟳" | "r" => {
                             let key_code =
                                 str_to_oscode(val).ok_or_else(|| anyhow!("unknown key: {val}"))?;
                             kbd_out_log(&mut k.kbd_out, LogFmtT::InKeyRep, Some(key_code), None);
-                            k.handle_input_event(&KeyEvent {
-                                code: key_code,
-                                value: KeyValue::Repeat,
-                            })?;
+                            k.handle_input_event(&KeyEvent::new(key_code, KeyValue::Repeat))?;
                         }
                         // Virtual/fake key activation: fakekey:name[:action] or vk:name[:action]
                         // Supported actions: press, release, tap, toggle
@@ -331,19 +322,13 @@ fn main_impl() -> Result<()> {
                                     Some(key_code),
                                     None,
                                 );
-                                k.handle_input_event(&KeyEvent {
-                                    code: key_code,
-                                    value: KeyValue::Press,
-                                })?;
+                                k.handle_input_event(&KeyEvent::new(key_code, KeyValue::Press))?;
                             }
                             "↑" => {
                                 let key_code = str_to_oscode(val)
                                     .ok_or_else(|| anyhow!("unknown key: {val}"))?;
                                 kbd_out_log(&mut k.kbd_out, LogFmtT::InKeyUp, Some(key_code), None);
-                                k.handle_input_event(&KeyEvent {
-                                    code: key_code,
-                                    value: KeyValue::Release,
-                                })?;
+                                k.handle_input_event(&KeyEvent::new(key_code, KeyValue::Release))?;
                             }
                             "⟳" => {
                                 let key_code = str_to_oscode(val)
@@ -354,10 +339,7 @@ fn main_impl() -> Result<()> {
                                     Some(key_code),
                                     None,
                                 );
-                                k.handle_input_event(&KeyEvent {
-                                    code: key_code,
-                                    value: KeyValue::Repeat,
-                                })?;
+                                k.handle_input_event(&KeyEvent::new(key_code, KeyValue::Repeat))?;
                             }
                             "🎭" => {
                                 // Virtual key activation with emoji prefix (defaults to press)

--- a/src/kanata/macos.rs
+++ b/src/kanata/macos.rs
@@ -26,9 +26,10 @@ impl Kanata {
         let allow_hardware_repeat = k.allow_hardware_repeat;
         let include_names = k.include_names.clone();
         let exclude_names = k.exclude_names.clone();
+        let input_devices = k.input_devices.clone();
         drop(k);
 
-        let mut kb = match KbdIn::new(include_names, exclude_names) {
+        let mut kb = match KbdIn::new(include_names, exclude_names, input_devices.as_deref()) {
             Ok(kbd_in) => kbd_in,
             Err(e) => bail!("failed to open keyboard device(s): {}", e),
         };
@@ -117,7 +118,10 @@ impl Kanata {
                 }
 
                 let mut key_event = match KeyEvent::try_from(event) {
-                    Ok(ev) => ev,
+                    Ok(mut ev) => {
+                        ev.set_device_id(kb.device_id_for_hash(event.device_hash));
+                        ev
+                    }
                     _ => {
                         log::debug!("{event:?} is unrecognized!");
                         let mut kanata = kanata.lock();

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -868,7 +868,10 @@ impl Kanata {
     pub fn handle_input_event(&mut self, event: &KeyEvent) -> Result<()> {
         log::debug!("process recv ev {event:?}");
         if event.value == KeyValue::Press {
-            self.layout.bm().device_history.push_front(event.device_id());
+            self.layout
+                .bm()
+                .device_history
+                .push_front(event.device_id());
         }
         let evc: u16 = event.code.into();
         self.ticks_since_idle = 0;

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -867,8 +867,8 @@ impl Kanata {
     /// Update keyberon layout state for press/release, handle repeat separately
     pub fn handle_input_event(&mut self, event: &KeyEvent) -> Result<()> {
         log::debug!("process recv ev {event:?}");
-        if let Some(did) = event.device_id() {
-            self.layout.bm().device_history.push_front(did);
+        if event.value == KeyValue::Press {
+            self.layout.bm().device_history.push_front(event.device_id());
         }
         let evc: u16 = event.code.into();
         self.ticks_since_idle = 0;

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -867,7 +867,9 @@ impl Kanata {
     /// Update keyberon layout state for press/release, handle repeat separately
     pub fn handle_input_event(&mut self, event: &KeyEvent) -> Result<()> {
         log::debug!("process recv ev {event:?}");
-        self.layout.bm().current_device_id = event.device_id();
+        if let Some(did) = event.device_id() {
+            self.layout.bm().device_history.push_front(did);
+        }
         let evc: u16 = event.code.into();
         self.ticks_since_idle = 0;
         let kbrn_ev = match event.value {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -231,6 +231,8 @@ pub struct Kanata {
     /// Tracks the Linux/Macos user configuration for device names (instead of paths) that should be
     /// excluded for interception and processing by kanata.
     pub exclude_names: Option<Vec<String>>,
+    /// Device ID mappings from `definputdevices` configuration block.
+    pub input_devices: Option<Vec<(std::num::NonZeroU8, kanata_parser::cfg::InputDeviceMatcher)>>,
     #[cfg(target_os = "windows")]
     /// Tracks whether Kanata should try to synchronize keystates with the Windows OS.
     /// Has no effect on Interception. Fixes some use cases related to admin window permissions and
@@ -535,6 +537,7 @@ impl Kanata {
             last_pressed_key: KeyCode::No,
             virtual_keys: cfg.fake_keys,
             max_key_timing_check: cfg.max_key_timing_check,
+            input_devices: cfg.input_devices,
             #[cfg(feature = "tcp_server")]
             tcp_server_address: args.tcp_server_address.clone(),
             #[cfg(all(target_os = "windows", feature = "gui"))]
@@ -686,6 +689,7 @@ impl Kanata {
             last_pressed_key: KeyCode::No,
             virtual_keys: cfg.fake_keys,
             max_key_timing_check: cfg.max_key_timing_check,
+            input_devices: cfg.input_devices,
             #[cfg(feature = "tcp_server")]
             tcp_server_address: None,
             #[cfg(all(target_os = "windows", feature = "gui"))]
@@ -755,6 +759,10 @@ impl Kanata {
             delay: cfg.options.dynamic_macro_replay_delay_behaviour,
         };
         self.max_key_timing_check = cfg.max_key_timing_check;
+        // Note: input_devices is intentionally not updated on live reload.
+        // The KbdIn device_hash_to_id map is built at startup and not rebuilt.
+        // This matches behavior of other device configs (macos-dev-names-include, etc.).
+        // See: https://github.com/malpern/kanata/issues/13
         self.virtual_keys = cfg.fake_keys;
         #[cfg(target_os = "windows")]
         {
@@ -859,6 +867,7 @@ impl Kanata {
     /// Update keyberon layout state for press/release, handle repeat separately
     pub fn handle_input_event(&mut self, event: &KeyEvent) -> Result<()> {
         log::debug!("process recv ev {event:?}");
+        self.layout.bm().current_device_id = event.device_id();
         let evc: u16 = event.code.into();
         self.ticks_since_idle = 0;
         let kbrn_ev = match event.value {
@@ -2780,7 +2789,7 @@ mod collect_and_sort_events_tests {
     use std::sync::mpsc::sync_channel;
 
     fn make_event(code: OsCode, value: KeyValue) -> KeyEvent {
-        KeyEvent { code, value }
+        KeyEvent::new(code, value)
     }
 
     #[test]
@@ -2981,21 +2990,15 @@ mod tcp_layer_change_tests {
         let (tx, rx) = sync_channel::<ServerMessage>(10);
         let tx = Some(tx);
 
-        k.handle_input_event(&KeyEvent {
-            code: OsCode::KEY_A,
-            value: KeyValue::Press,
-        })
-        .expect("press should succeed");
+        k.handle_input_event(&KeyEvent::new(OsCode::KEY_A, KeyValue::Press))
+            .expect("press should succeed");
         k.last_tick = web_time::Instant::now() - Duration::from_millis(1);
         k.handle_time_ticks(&tx).expect("press tick should succeed");
 
         assert_eq!(collect_layer_changes(&rx), vec!["nav"]);
 
-        k.handle_input_event(&KeyEvent {
-            code: OsCode::KEY_A,
-            value: KeyValue::Release,
-        })
-        .expect("release should succeed");
+        k.handle_input_event(&KeyEvent::new(OsCode::KEY_A, KeyValue::Release))
+            .expect("release should succeed");
         k.last_tick = web_time::Instant::now() - Duration::from_millis(1);
         k.handle_time_ticks(&tx)
             .expect("release tick should succeed");
@@ -3023,16 +3026,10 @@ mod tcp_layer_change_tests {
         let (tx, rx) = sync_channel::<ServerMessage>(10);
         let tx = Some(tx);
 
-        k.handle_input_event(&KeyEvent {
-            code: OsCode::KEY_A,
-            value: KeyValue::Press,
-        })
-        .expect("press should succeed");
-        k.handle_input_event(&KeyEvent {
-            code: OsCode::KEY_A,
-            value: KeyValue::Release,
-        })
-        .expect("release should succeed");
+        k.handle_input_event(&KeyEvent::new(OsCode::KEY_A, KeyValue::Press))
+            .expect("press should succeed");
+        k.handle_input_event(&KeyEvent::new(OsCode::KEY_A, KeyValue::Release))
+            .expect("release should succeed");
         k.last_tick = web_time::Instant::now() - Duration::from_millis(5);
         k.handle_time_ticks(&tx)
             .expect("batched timeout ticks should succeed");
@@ -3062,26 +3059,14 @@ mod tcp_layer_change_tests {
         let (tx, rx) = sync_channel::<ServerMessage>(10);
         let tx = Some(tx);
 
-        k.handle_input_event(&KeyEvent {
-            code: OsCode::KEY_A,
-            value: KeyValue::Press,
-        })
-        .expect("oneshot press should succeed");
-        k.handle_input_event(&KeyEvent {
-            code: OsCode::KEY_A,
-            value: KeyValue::Release,
-        })
-        .expect("oneshot release should succeed");
-        k.handle_input_event(&KeyEvent {
-            code: OsCode::KEY_B,
-            value: KeyValue::Press,
-        })
-        .expect("consumer press should succeed");
-        k.handle_input_event(&KeyEvent {
-            code: OsCode::KEY_B,
-            value: KeyValue::Release,
-        })
-        .expect("consumer release should succeed");
+        k.handle_input_event(&KeyEvent::new(OsCode::KEY_A, KeyValue::Press))
+            .expect("oneshot press should succeed");
+        k.handle_input_event(&KeyEvent::new(OsCode::KEY_A, KeyValue::Release))
+            .expect("oneshot release should succeed");
+        k.handle_input_event(&KeyEvent::new(OsCode::KEY_B, KeyValue::Press))
+            .expect("consumer press should succeed");
+        k.handle_input_event(&KeyEvent::new(OsCode::KEY_B, KeyValue::Release))
+            .expect("consumer release should succeed");
         k.last_tick = web_time::Instant::now() - Duration::from_millis(5);
         k.handle_time_ticks(&tx)
             .expect("batched consume ticks should succeed");

--- a/src/kanata/windows/interception.rs
+++ b/src/kanata/windows/interception.rs
@@ -68,7 +68,7 @@ impl Kanata {
                                 false => KeyValue::Press,
                                 true => KeyValue::Release,
                             };
-                            KeyEvent { code, value }
+                            KeyEvent::new(code, value)
                         }
                         ic::Stroke::Mouse {
                             state,
@@ -191,55 +191,25 @@ fn is_device_interceptable(
 }
 fn mouse_state_to_event(state: ic::MouseState, rolling: i16) -> Option<KeyEvent> {
     if state.contains(ic::MouseState::RIGHT_BUTTON_DOWN) {
-        Some(KeyEvent {
-            code: OsCode::BTN_RIGHT,
-            value: KeyValue::Press,
-        })
+        Some(KeyEvent::new(OsCode::BTN_RIGHT, KeyValue::Press))
     } else if state.contains(ic::MouseState::RIGHT_BUTTON_UP) {
-        Some(KeyEvent {
-            code: OsCode::BTN_RIGHT,
-            value: KeyValue::Release,
-        })
+        Some(KeyEvent::new(OsCode::BTN_RIGHT, KeyValue::Release))
     } else if state.contains(ic::MouseState::LEFT_BUTTON_DOWN) {
-        Some(KeyEvent {
-            code: OsCode::BTN_LEFT,
-            value: KeyValue::Press,
-        })
+        Some(KeyEvent::new(OsCode::BTN_LEFT, KeyValue::Press))
     } else if state.contains(ic::MouseState::LEFT_BUTTON_UP) {
-        Some(KeyEvent {
-            code: OsCode::BTN_LEFT,
-            value: KeyValue::Release,
-        })
+        Some(KeyEvent::new(OsCode::BTN_LEFT, KeyValue::Release))
     } else if state.contains(ic::MouseState::MIDDLE_BUTTON_DOWN) {
-        Some(KeyEvent {
-            code: OsCode::BTN_MIDDLE,
-            value: KeyValue::Press,
-        })
+        Some(KeyEvent::new(OsCode::BTN_MIDDLE, KeyValue::Press))
     } else if state.contains(ic::MouseState::MIDDLE_BUTTON_UP) {
-        Some(KeyEvent {
-            code: OsCode::BTN_MIDDLE,
-            value: KeyValue::Release,
-        })
+        Some(KeyEvent::new(OsCode::BTN_MIDDLE, KeyValue::Release))
     } else if state.contains(ic::MouseState::BUTTON_4_DOWN) {
-        Some(KeyEvent {
-            code: OsCode::BTN_SIDE,
-            value: KeyValue::Press,
-        })
+        Some(KeyEvent::new(OsCode::BTN_SIDE, KeyValue::Press))
     } else if state.contains(ic::MouseState::BUTTON_4_UP) {
-        Some(KeyEvent {
-            code: OsCode::BTN_SIDE,
-            value: KeyValue::Release,
-        })
+        Some(KeyEvent::new(OsCode::BTN_SIDE, KeyValue::Release))
     } else if state.contains(ic::MouseState::BUTTON_5_DOWN) {
-        Some(KeyEvent {
-            code: OsCode::BTN_EXTRA,
-            value: KeyValue::Press,
-        })
+        Some(KeyEvent::new(OsCode::BTN_EXTRA, KeyValue::Press))
     } else if state.contains(ic::MouseState::BUTTON_5_UP) {
-        Some(KeyEvent {
-            code: OsCode::BTN_EXTRA,
-            value: KeyValue::Release,
-        })
+        Some(KeyEvent::new(OsCode::BTN_EXTRA, KeyValue::Release))
     } else if state.contains(ic::MouseState::WHEEL) {
         let osc = if rolling >= 0 {
             OsCode::MouseWheelUp
@@ -247,10 +217,7 @@ fn mouse_state_to_event(state: ic::MouseState, rolling: i16) -> Option<KeyEvent>
             OsCode::MouseWheelDown
         };
         if MAPPED_KEYS.lock().contains(&osc) {
-            Some(KeyEvent {
-                code: osc,
-                value: KeyValue::Tap,
-            })
+            Some(KeyEvent::new(osc, KeyValue::Tap))
         } else {
             None
         }
@@ -261,10 +228,7 @@ fn mouse_state_to_event(state: ic::MouseState, rolling: i16) -> Option<KeyEvent>
             OsCode::MouseWheelLeft
         };
         if MAPPED_KEYS.lock().contains(&osc) {
-            Some(KeyEvent {
-                code: osc,
-                value: KeyValue::Tap,
-            })
+            Some(KeyEvent::new(osc, KeyValue::Tap))
         } else {
             None
         }

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -325,10 +325,10 @@ impl TryFrom<InputEvent> for KeyEvent {
     fn try_from(item: InputEvent) -> Result<Self, Self::Error> {
         use OsCode::*;
         match item.destructure() {
-            evdev::EventSummary::Key(_, k, _) => Ok(Self {
-                code: OsCode::from_u16(k.0).ok_or(())?,
-                value: KeyValue::from(item.value()),
-            }),
+            evdev::EventSummary::Key(_, k, _) => Ok(Self::new(
+                OsCode::from_u16(k.0).ok_or(())?,
+                KeyValue::from(item.value()),
+            )),
             evdev::EventSummary::RelativeAxis(_, axis_type, _) => {
                 let dist = item.value();
                 let code: OsCode = match axis_type {
@@ -348,10 +348,7 @@ impl TryFrom<InputEvent> for KeyEvent {
                     }
                     _ => return Err(()),
                 };
-                Ok(KeyEvent {
-                    code,
-                    value: KeyValue::Tap,
-                })
+                Ok(KeyEvent::new(code, KeyValue::Tap))
             }
             _ => Err(()),
         }

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -555,6 +555,7 @@ pub struct InputEvent {
     pub value: u64,
     pub page: u32,
     pub code: u32,
+    pub device_hash: u64,
 }
 
 impl InputEvent {
@@ -563,6 +564,7 @@ impl InputEvent {
             value: event.value,
             page: event.page,
             code: event.code,
+            device_hash: event.device_hash,
         }
     }
 }
@@ -573,6 +575,7 @@ impl From<InputEvent> for DKEvent {
             value: event.value,
             page: event.page,
             code: event.code,
+            // Output events don't originate from a physical device.
             device_hash: 0,
         }
     }
@@ -580,6 +583,7 @@ impl From<InputEvent> for DKEvent {
 
 pub struct KbdIn {
     grabbed: bool,
+    device_hash_to_id: HashMap<u64, std::num::NonZeroU8>,
 }
 
 impl Drop for KbdIn {
@@ -594,6 +598,7 @@ impl KbdIn {
     pub fn new(
         include_names: Option<Vec<String>>,
         exclude_names: Option<Vec<String>>,
+        input_devices: Option<&[(std::num::NonZeroU8, kanata_parser::cfg::InputDeviceMatcher)]>,
     ) -> Result<Self, anyhow::Error> {
         // Pre-flight the Input Monitoring TCC gate before touching the
         // Karabiner stack. A denied permission here produces a clean,
@@ -659,7 +664,11 @@ impl KbdIn {
 
         if !device_names.is_empty() {
             if grab() {
-                Ok(Self { grabbed: true })
+                let device_hash_to_id = build_device_hash_to_id_map(input_devices);
+                Ok(Self {
+                    grabbed: true,
+                    device_hash_to_id,
+                })
             } else {
                 // We have already pre-flighted Input Monitoring and
                 // Accessibility, so by this point the most common
@@ -709,6 +718,11 @@ impl KbdIn {
         }
 
         Ok(InputEvent::new(event))
+    }
+
+    /// Look up the device ID for an event's device hash.
+    pub fn device_id_for_hash(&self, hash: u64) -> Option<std::num::NonZeroU8> {
+        self.device_hash_to_id.get(&hash).copied()
     }
 
     /// Release seized input devices without tearing down the output connection.
@@ -761,6 +775,55 @@ fn is_skipped_virtual_device(product_key: &str) -> bool {
     SKIPPED_VIRTUAL_DEVICE_SUBSTRINGS
         .iter()
         .any(|needle| lower.contains(needle))
+}
+
+/// Build a mapping from device hashes to configured device IDs by matching
+/// the connected devices against the `definputdevices` matchers.
+fn build_device_hash_to_id_map(
+    input_devices: Option<&[(std::num::NonZeroU8, kanata_parser::cfg::InputDeviceMatcher)]>,
+) -> HashMap<u64, std::num::NonZeroU8> {
+    use std::num::NonZeroU8;
+    let mut map: HashMap<u64, NonZeroU8> = HashMap::new();
+    let Some(matchers) = input_devices else {
+        return map;
+    };
+    let kb_list = fetch_devices();
+    for (id, matcher) in matchers.iter() {
+        for kb in &kb_list {
+            let name_matches = matcher
+                .name
+                .as_ref()
+                .is_none_or(|n| kb.product_key.contains(n.as_str()));
+            let hash_matches = matcher.hash.as_ref().is_none_or(|h| {
+                let device_hash = format!("{:x}", kb.hash);
+                device_hash.eq_ignore_ascii_case(h)
+            });
+            let vendor_matches = matcher
+                .vendor_id
+                .is_none_or(|v| u16::try_from(kb.vendor_id) == Ok(v));
+            let product_matches = matcher
+                .product_id
+                .is_none_or(|p| u16::try_from(kb.product_id) == Ok(p));
+            if name_matches && hash_matches && vendor_matches && product_matches {
+                if let Some(existing_id) = map.get(&kb.hash) {
+                    log::warn!(
+                        "definputdevices: device \"{}\" (hash {:x}) also matches ID {id}, \
+                         keeping first match ID {existing_id}",
+                        kb.product_key,
+                        kb.hash
+                    );
+                    continue;
+                }
+                log::info!(
+                    "definputdevices: device ID {id} matched \"{}\" (hash {:x})",
+                    kb.product_key,
+                    kb.hash
+                );
+                map.insert(kb.hash, *id);
+            }
+        }
+    }
+    map
 }
 
 fn validate_and_register_devices(include_names: Vec<String>) -> Vec<String> {
@@ -832,14 +895,14 @@ impl TryFrom<InputEvent> for KeyEvent {
             page: item.page,
             code: item.code,
         }) {
-            Ok(KeyEvent {
-                code: oscode,
-                value: if item.value == 1 {
+            Ok(KeyEvent::new(
+                oscode,
+                if item.value == 1 {
                     KeyValue::Press
                 } else {
                     KeyValue::Release
                 },
-            })
+            ))
         } else {
             Err(())
         }
@@ -859,6 +922,7 @@ impl TryFrom<KeyEvent> for InputEvent {
                 value: val,
                 page: pagecode.page,
                 code: pagecode.code,
+                device_hash: 0,
             })
         } else {
             Err(())
@@ -954,7 +1018,7 @@ impl KbdOut {
     }
 
     pub fn write_key(&mut self, key: OsCode, value: KeyValue) -> Result<(), io::Error> {
-        if let Ok(event) = InputEvent::try_from(KeyEvent { value, code: key }) {
+        if let Ok(event) = InputEvent::try_from(KeyEvent::new(key, value)) {
             match self.write(event) {
                 Ok(()) => {
                     self.record_output_transition_after_write(key, value);
@@ -973,7 +1037,7 @@ impl KbdOut {
             log::debug!("couldn't write unrecognized OsCode {code}");
             return Err(io::Error::other("OsCode not recognized!"));
         };
-        if let Ok(event) = InputEvent::try_from(KeyEvent { value, code: key }) {
+        if let Ok(event) = InputEvent::try_from(KeyEvent::new(key, value)) {
             match self.write(event) {
                 Ok(()) => Ok(()),
                 Err(e) => drop_if_sink_disconnected(e, key, value),
@@ -1262,7 +1326,7 @@ impl TryFrom<(CGEventType, i64)> for KeyEvent {
             }
             _ => return Err(()),
         };
-        Ok(KeyEvent { code, value })
+        Ok(KeyEvent::new(code, value))
     }
 }
 
@@ -1288,10 +1352,7 @@ fn scroll_event_to_key_event(event: &CGEvent) -> Option<KeyEvent> {
             _ => return None,
         }
     };
-    Some(KeyEvent {
-        code,
-        value: KeyValue::Tap,
-    })
+    Some(KeyEvent::new(code, KeyValue::Tap))
 }
 
 /// Start a CGEventTap on a background thread to intercept mouse button events
@@ -1409,10 +1470,7 @@ pub fn start_mouse_listener(
                             None => return Some(event.clone()),
                         };
                         if let Some(code) = *mmk_slot.lock() {
-                            let fake = KeyEvent {
-                                code,
-                                value: KeyValue::Tap,
-                            };
+                            let fake = KeyEvent::new(code, KeyValue::Tap);
                             if let Err(e) = tx.try_send(fake) {
                                 // Drops are expected under high movement rates;
                                 // the user only needs one tap to refresh their

--- a/src/oskbd/mod.rs
+++ b/src/oskbd/mod.rs
@@ -105,12 +105,41 @@ use kanata_parser::keys::OsCode;
 pub struct KeyEvent {
     pub code: OsCode,
     pub value: KeyValue,
+    #[cfg(not(all(target_os = "windows", not(feature = "interception_driver"))))]
+    device_id: Option<std::num::NonZeroU8>,
 }
 
 #[allow(dead_code, unused)]
 impl KeyEvent {
     pub fn new(code: OsCode, value: KeyValue) -> Self {
-        Self { code, value }
+        Self {
+            code,
+            value,
+            #[cfg(not(all(target_os = "windows", not(feature = "interception_driver"))))]
+            device_id: None,
+        }
+    }
+
+    /// Returns the device ID that produced this event, if known.
+    /// Always returns `None` on Windows LLHOOK (which cannot distinguish devices).
+    pub fn device_id(&self) -> Option<std::num::NonZeroU8> {
+        #[cfg(not(all(target_os = "windows", not(feature = "interception_driver"))))]
+        {
+            self.device_id
+        }
+        #[cfg(all(target_os = "windows", not(feature = "interception_driver")))]
+        {
+            None
+        }
+    }
+
+    /// Sets the device ID for this event.
+    /// No-op on Windows LLHOOK.
+    pub fn set_device_id(&mut self, id: Option<std::num::NonZeroU8>) {
+        #[cfg(not(all(target_os = "windows", not(feature = "interception_driver"))))]
+        {
+            self.device_id = id;
+        }
     }
 }
 

--- a/src/oskbd/sim_passthru.rs
+++ b/src/oskbd/sim_passthru.rs
@@ -172,13 +172,13 @@ impl InputEvent {
 impl TryFrom<InputEvent> for KeyEvent {
     type Error = ();
     fn try_from(item: InputEvent) -> Result<Self, Self::Error> {
-        Ok(Self {
-            code: OsCode::from_u16(item.code as u16).ok_or(())?,
-            value: match item.up {
+        Ok(Self::new(
+            OsCode::from_u16(item.code as u16).ok_or(())?,
+            match item.up {
                 true => KeyValue::Release,
                 false => KeyValue::Press,
             },
-        })
+        ))
     }
 }
 

--- a/src/oskbd/simulated.rs
+++ b/src/oskbd/simulated.rs
@@ -484,13 +484,13 @@ impl InputEvent {
 impl TryFrom<InputEvent> for KeyEvent {
     type Error = ();
     fn try_from(item: InputEvent) -> Result<Self, Self::Error> {
-        Ok(Self {
-            code: OsCode::from_u16(item.code as u16).ok_or(())?,
-            value: match item.up {
+        Ok(Self::new(
+            OsCode::from_u16(item.code as u16).ok_or(())?,
+            match item.up {
                 true => KeyValue::Release,
                 false => KeyValue::Press,
             },
-        })
+        ))
     }
 }
 

--- a/src/oskbd/windows/exthook_os.rs
+++ b/src/oskbd/windows/exthook_os.rs
@@ -80,13 +80,13 @@ impl InputEvent {
 impl TryFrom<InputEvent> for KeyEvent {
     type Error = ();
     fn try_from(item: InputEvent) -> Result<Self, Self::Error> {
-        Ok(Self {
-            code: OsCode::from_u16(item.code as u16).ok_or(())?,
-            value: match item.up {
+        Ok(Self::new(
+            OsCode::from_u16(item.code as u16).ok_or(())?,
+            match item.up {
                 true => KeyValue::Release,
                 false => KeyValue::Press,
             },
-        })
+        ))
     }
 }
 impl From<KeyEvent> for InputEvent {

--- a/src/oskbd/windows/llhook.rs
+++ b/src/oskbd/windows/llhook.rs
@@ -135,13 +135,13 @@ impl InputEvent {
 impl TryFrom<InputEvent> for KeyEvent {
     type Error = ();
     fn try_from(item: InputEvent) -> Result<Self, Self::Error> {
-        Ok(Self {
-            code: OsCode::from_u16(item.code as u16).ok_or(())?,
-            value: match item.up {
+        Ok(Self::new(
+            OsCode::from_u16(item.code as u16).ok_or(())?,
+            match item.up {
                 true => KeyValue::Release,
                 false => KeyValue::Press,
             },
-        })
+        ))
     }
 }
 

--- a/src/oskbd/windows/llhook/mouse.rs
+++ b/src/oskbd/windows/llhook/mouse.rs
@@ -393,7 +393,7 @@ impl TryFrom<MouseEventType> for KeyEvent {
                     MouseButton::X2(..) => BTN_EXTRA,
                     MouseButton::UnkownX(..) | MouseButton::Other(..) => return Err(()),
                 };
-                Ok(KeyEvent { code, value })
+                Ok(KeyEvent::new(code, value))
             }
             Wheel(MouseWheelEvent { wheel, direction }) => {
                 use MouseWheel::*;
@@ -410,10 +410,7 @@ impl TryFrom<MouseEventType> for KeyEvent {
                         return Err(());
                     }
                 };
-                Ok(KeyEvent {
-                    code,
-                    value: KeyValue::Tap,
-                })
+                Ok(KeyEvent::new(code, KeyValue::Tap))
             }
         }
     }

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -435,10 +435,10 @@ impl TcpServer {
                                         }
                                         use kanata_parser::keys::*;
                                         wakeup_channel
-                                            .send(KeyEvent {
-                                                code: OsCode::KEY_RESERVED,
-                                                value: KeyValue::WakeUp,
-                                            })
+                                            .send(KeyEvent::new(
+                                                OsCode::KEY_RESERVED,
+                                                KeyValue::WakeUp,
+                                            ))
                                             .expect("write key event");
                                     }
                                     Err(e) => {

--- a/src/tests/sim_tests/mod.rs
+++ b/src/tests/sim_tests/mod.rs
@@ -117,11 +117,8 @@ fn simulate_with_file_content<S: AsRef<str>>(
                 }
                 "d" => {
                     let key_code = str_to_oscode(val).expect("valid keycode");
-                    k.handle_input_event(&KeyEvent {
-                        code: key_code,
-                        value: KeyValue::Press,
-                    })
-                    .expect("input handles fine");
+                    k.handle_input_event(&KeyEvent::new(key_code, KeyValue::Press))
+                        .expect("input handles fine");
                     #[cfg(not(all(target_os = "windows", not(feature = "interception_driver"))))]
                     crate::PRESSED_KEYS.lock().insert(key_code);
                     #[cfg(all(target_os = "windows", not(feature = "interception_driver")))]
@@ -131,20 +128,14 @@ fn simulate_with_file_content<S: AsRef<str>>(
                 }
                 "u" => {
                     let key_code = str_to_oscode(val).expect("valid keycode");
-                    k.handle_input_event(&KeyEvent {
-                        code: key_code,
-                        value: KeyValue::Release,
-                    })
-                    .expect("input handles fine");
+                    k.handle_input_event(&KeyEvent::new(key_code, KeyValue::Release))
+                        .expect("input handles fine");
                     crate::PRESSED_KEYS.lock().remove(&key_code);
                 }
                 "r" => {
                     let key_code = str_to_oscode(val).expect("valid keycode");
-                    k.handle_input_event(&KeyEvent {
-                        code: key_code,
-                        value: KeyValue::Repeat,
-                    })
-                    .expect("input handles fine");
+                    k.handle_input_event(&KeyEvent::new(key_code, KeyValue::Repeat))
+                        .expect("input handles fine");
                 }
                 // Virtual/fake key activation: vk:name[:action] or fakekey:name[:action]
                 // Supported actions: press (p), release, tap (t), toggle (g)

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -153,26 +153,17 @@ fn simulate_impl(cfg: &str, sim: &str) -> Result<String> {
                     "press" | "↓" | "d" | "down" => {
                         let key_code = str_to_oscode(val)
                             .ok_or_else(|| anyhow!("line: {l}\nunknown key in {kind}:{val}"))?;
-                        k.handle_input_event(&KeyEvent {
-                            code: key_code,
-                            value: KeyValue::Press,
-                        })?;
+                        k.handle_input_event(&KeyEvent::new(key_code, KeyValue::Press))?;
                     }
                     "release" | "↑" | "u" | "up" => {
                         let key_code = str_to_oscode(val)
                             .ok_or_else(|| anyhow!("line: {l}\nunknown key in {kind}:{val}"))?;
-                        k.handle_input_event(&KeyEvent {
-                            code: key_code,
-                            value: KeyValue::Release,
-                        })?;
+                        k.handle_input_event(&KeyEvent::new(key_code, KeyValue::Release))?;
                     }
                     "repeat" | "⟳" | "r" => {
                         let key_code = str_to_oscode(val)
                             .ok_or_else(|| anyhow!("line: {l}\nunknown key in {kind}:{val}"))?;
-                        k.handle_input_event(&KeyEvent {
-                            code: key_code,
-                            value: KeyValue::Repeat,
-                        })?;
+                        k.handle_input_event(&KeyEvent::new(key_code, KeyValue::Repeat))?;
                     }
                     // Virtual/fake key activation: vk:name[:action]
                     "vk" | "fakekey" | "virtualkey" | "🎭" => {


### PR DESCRIPTION
## Summary

Add `definputdevices` top-level configuration block and `(device N)` switch
condition for per-device key mappings. Implement end-to-end on macOS using
driverkit 0.3.0's per-event `device_hash`.

```kbd
(definputdevices
  1 ((name "Apple Internal Keyboard"))
  2 ((name "Go60") (vendor_id 0x1D50))
)

(defsrc a)
(deflayer base
  (switch
    ((device 1)) x break
    ((device 2)) y break
    () a break))
```

## Design

Per review feedback on #1974:

- IDs are `NonZeroU8` (1-255); `Option<NonZeroU8>` fits in 1 byte
- `definputdevices` required when `(device N)` is used; undefined IDs error
  at parse time
- Matchers use ALL-of semantics; duplicate properties error;
  definition order preserved (first match wins)
- Hash values validated as hex at parse time, matched case-insensitively
- `vendor_id`/`product_id` validated as `u16` (USB range)
- New `DEVICE_VAL` (855) sentinel opcode, consistent with
  `LAYER_VAL`/`BASE_LAYER_VAL`
- `device_id` on `KeyEvent` conditionally compiled out for Windows LLHOOK
  (which cannot distinguish devices); accessed via `device_id()`/`set_device_id()` helpers

### device_id as direct parameter vs HistoricalEvent\<DeviceID\>

The original review suggested using `HistoricalEvent<DeviceID>` for the switch
integration. This implementation uses a direct `device_id: Option<NonZeroU8>`
parameter on `evaluate_boolean()` instead:

- Device identity is current-event context, not event history. The question is
  "which device sent THIS key?", not "which device sent the Nth most recent
  key?"
- `HistoricalEvent<T>` carries `ticks_since_occurrence` which has no meaning
  for device identity
- Semantically closer to `default_layer` (a simple value passed through) than
  to `historical_keys` (an iterator over past events)

If historical device queries are desired in the future (e.g., "was the 2nd most
recent keypress from device 1?"), a `History<NonZeroU8>` could be added then.
If the extra parameter is a concern now, a `SwitchContext` struct grouping the
evaluation state would be a cleaner path than inventing device history.

## macOS implementation

- Bump `karabiner-driverkit` to 0.3.0 (adds `device_hash` to `DKEvent`)
- At startup, match `fetch_devices()` results against matchers to build
  `hash → device_id` map (first match wins, warns on overlaps)
- In event loop, look up each event's `device_hash` to set `device_id`
  on `KeyEvent`

## Checklist

- Add documentation to docs/config.adoc
  - [x] `definputdevices` section and `(device N)` in switch docs
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Commented `(device N)` example in switch section
- Update error messages
  - [x] Parse errors for invalid IDs, missing `definputdevices`,
    unknown/duplicate properties, invalid hex hash
- Added tests, or did manual testing
  - [x] `switch_device_match`, `switch_device_opcode_roundtrip` unit tests;
    all 454 workspace tests pass
  - [ ] Manual macOS testing with multiple keyboards pending