### PR TITLE
feat: add tap-hold-opposite-hand-release action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "karabiner-driverkit"
-version = "0.3.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20bae7924951876a41b469ac758032c42f5a142103d47a3bfe843dd954a1761"
+checksum = "c900441e9c078ba7c0ffb0a3537475e4ad094e7b6d2e14e2d7b65a7fcfc10ef0"
 dependencies = [
  "cc",
  "os_info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "karabiner-driverkit"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900441e9c078ba7c0ffb0a3537475e4ad094e7b6d2e14e2d7b65a7fcfc10ef0"
+checksum = "b20bae7924951876a41b469ac758032c42f5a142103d47a3bfe843dd954a1761"
 dependencies = [
  "cc",
  "os_info",

--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -469,6 +469,13 @@ If you need help, please feel welcome to ask in the GitHub discussions.
 (defalias
   th1 (tap-hold $tt $ht caps lctl)
   th2 (tap-hold $tt $ht spc lsft)
+
+  ;; tap-hold-opposite-hand-release is a release-time variant of
+  ;; tap-hold-opposite-hand. It waits for the interrupting key to be pressed
+  ;; AND released before deciding, which avoids misfires on fast same-hand
+  ;; rolls. Requires defhands.
+  ;; actl (tap-hold-opposite-hand-release 200 a lctl
+  ;;   (same-hand tap) (unknown-hand hold) (timeout hold))
 )
 
 ;; defalias is used to declare a shortcut for a more complicated action to keep

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2018,6 +2018,7 @@ results in `$tap-action` activating.
 (tap-hold-except-keys $tap-repress-timeout $hold-timeout $tap-action $hold-action $tap-keys)
 (tap-hold-tap-keys $tap-repress-timeout $hold-timeout $tap-action $hold-action $tap-keys)
 (tap-hold-opposite-hand $timeout $tap-action $hold-action [options...])
+(tap-hold-opposite-hand-release $timeout $tap-action $hold-action [options...])
 (tap-hold-order $tap-repress-timeout $buffer-ms $tap-action $hold-action [options...])
 ----
 
@@ -2074,6 +2075,11 @@ This is useful for home row mods where fast typing should not trigger modifiers.
 | Resolves to `$hold-action` when a key from the opposite hand (per `defhands`) is pressed.
 Requires a `defhands` directive. Supports list-form options for fine-grained control.
 See <<defhands and tap-hold-opposite-hand>> below.
+
+| `tap-hold-opposite-hand-release`
+| Like `tap-hold-opposite-hand` but waits for the interrupting key to be pressed AND released
+before committing. This avoids misfires on fast same-hand rolls where keystrokes briefly overlap.
+Requires a `defhands` directive. Supports the same options as `tap-hold-opposite-hand`.
 
 | `tap-hold-order`
 | Resolves purely by key release order, with no timeout.

--- a/parser/src/cfg/custom_tap_hold.rs
+++ b/parser/src/cfg/custom_tap_hold.rs
@@ -230,3 +230,71 @@ pub(crate) fn custom_tap_hold_opposite_hand(
         },
     )
 }
+
+/// Like `custom_tap_hold_opposite_hand` but waits for the interrupting key's
+/// press+release before committing. This avoids misfires on fast same-hand
+/// rolls where keystrokes briefly overlap.
+pub(crate) fn custom_tap_hold_opposite_hand_release(
+    hand_map: &'static HandMap,
+    same_hand: DecisionBehavior,
+    neutral_behavior: DecisionBehavior,
+    unknown_hand: DecisionBehavior,
+    neutral_keys: &'static [OsCode],
+    a: &Allocations,
+) -> &'static CustomTapHoldFn {
+    a.sref(
+        move |mut queued: QueuedIter, coord: KCoord| -> (Option<WaitingAction>, bool) {
+            let (_row, col) = coord;
+            let waiting_hand = hand_map.get(col);
+
+            while let Some(q) = queued.next() {
+                if !q.event().is_press() {
+                    continue;
+                }
+                let (i, j) = q.event().coord();
+                if i != REAL_KEY_ROW {
+                    continue;
+                }
+
+                // Wait for the interrupting key's release before deciding.
+                let release = Event::Release(i, j);
+                if !queued.clone().copied().any(|q| q.event() == release) {
+                    continue;
+                }
+
+                // Check neutral-keys first (takes precedence over defhands)
+                if let Some(osc) = OsCode::from_u16(j) {
+                    if neutral_keys.contains(&osc) {
+                        match neutral_behavior {
+                            DecisionBehavior::Tap => return (Some(WaitingAction::Tap), false),
+                            DecisionBehavior::Hold => return (Some(WaitingAction::Hold), false),
+                            DecisionBehavior::Ignore => continue,
+                        }
+                    }
+                }
+
+                let pressed_hand = hand_map.get(j);
+
+                match (waiting_hand, pressed_hand) {
+                    (Hand::Left, Hand::Right) | (Hand::Right, Hand::Left) => {
+                        return (Some(WaitingAction::Hold), false);
+                    }
+                    (Hand::Left, Hand::Left) | (Hand::Right, Hand::Right) => match same_hand {
+                        DecisionBehavior::Tap => return (Some(WaitingAction::Tap), false),
+                        DecisionBehavior::Hold => return (Some(WaitingAction::Hold), false),
+                        DecisionBehavior::Ignore => continue,
+                    },
+                    _ => {
+                        // At least one key is Neutral (not in defhands)
+                        match unknown_hand {
+                            DecisionBehavior::Tap => return (Some(WaitingAction::Tap), false),
+                            DecisionBehavior::Hold => return (Some(WaitingAction::Hold), false),
+                            DecisionBehavior::Ignore => continue,
+                        }
+                    }
+                }
+            }
+            (None, false)
+        },
+    )
+}

--- a/parser/src/cfg/defhands.rs
+++ b/parser/src/cfg/defhands.rs
@@ -219,6 +219,154 @@ pub(super) fn parse_tap_hold_opposite_hand(
     }))))
 }
 
+pub(super) fn parse_tap_hold_opposite_hand_release(
+    ac_params: &[SExpr],
+    s: &ParserState,
+) -> Result<&'static KanataAction> {
+    use custom_tap_hold::{DecisionBehavior, custom_tap_hold_opposite_hand_release};
+
+    const ARITY_MSG: &str = "tap-hold-opposite-hand-release expects at least 3 items: \
+            <timeout> <tap> <hold> [options...]";
+    if ac_params.is_empty() {
+        bail!(ARITY_MSG);
+    }
+    if ac_params.len() < 3 {
+        bail_expr!(&ac_params[0], "{}", ARITY_MSG);
+    }
+    let hand_map = s.hand_map.ok_or_else(|| {
+        anyhow_expr!(
+            &ac_params[0],
+            "tap-hold-opposite-hand-release requires defhands to be defined"
+        )
+    })?;
+
+    let hold_timeout = parse_non_zero_u16(&ac_params[0], s, "timeout")?;
+    let tap_action = parse_action(&ac_params[1], s)?;
+    let hold_action = parse_action(&ac_params[2], s)?;
+    if matches!(tap_action, Action::HoldTap { .. }) {
+        bail_expr!(
+            &ac_params[1],
+            "tap-hold does not work in the tap-action of tap-hold"
+        );
+    }
+
+    let mut timeout_behavior = DecisionBehavior::Tap;
+    let mut same_hand = DecisionBehavior::Tap;
+    let mut neutral_behavior = DecisionBehavior::Ignore;
+    let mut unknown_hand = DecisionBehavior::Ignore;
+    let mut neutral_keys: Vec<OsCode> = Vec::new();
+    let mut require_prior_idle: Option<u16> = None;
+    let mut seen_options: HashSet<&str> = HashSet::default();
+
+    for option_expr in &ac_params[3..] {
+        let Some(option) = option_expr.list(s.vars()) else {
+            bail_expr!(
+                option_expr,
+                "expected option list, e.g. `(timeout hold)` or `(neutral-keys spc tab)`"
+            );
+        };
+        if option.is_empty() {
+            bail_expr!(option_expr, "option list cannot be empty");
+        }
+        let kw = option[0]
+            .atom(s.vars())
+            .ok_or_else(|| anyhow_expr!(&option[0], "option name must be a string"))?;
+        if !seen_options.insert(kw) {
+            bail_expr!(
+                &option[0],
+                "duplicate option '{}' in tap-hold-opposite-hand-release",
+                kw
+            );
+        }
+        match kw {
+            "timeout" => {
+                if option.len() != 2 {
+                    bail_expr!(
+                        option_expr,
+                        "option must contain exactly 2 items: `(name value)`"
+                    );
+                }
+                timeout_behavior = parse_decision_behavior_tap_hold(&option[1], s)?;
+            }
+            "same-hand" => {
+                if option.len() != 2 {
+                    bail_expr!(
+                        option_expr,
+                        "option must contain exactly 2 items: `(name value)`"
+                    );
+                }
+                same_hand = parse_decision_behavior(&option[1], s)?;
+            }
+            "neutral" => {
+                if option.len() != 2 {
+                    bail_expr!(
+                        option_expr,
+                        "option must contain exactly 2 items: `(name value)`"
+                    );
+                }
+                neutral_behavior = parse_decision_behavior(&option[1], s)?;
+            }
+            "unknown-hand" => {
+                if option.len() != 2 {
+                    bail_expr!(
+                        option_expr,
+                        "option must contain exactly 2 items: `(name value)`"
+                    );
+                }
+                unknown_hand = parse_decision_behavior(&option[1], s)?;
+            }
+            "neutral-keys" => {
+                if option.len() < 2 {
+                    bail_expr!(
+                        option_expr,
+                        "neutral-keys expects one or more key atoms, e.g. `(neutral-keys spc tab)`"
+                    );
+                }
+                neutral_keys = parse_key_atoms(&option[1..], s, "neutral-keys")?;
+            }
+            "require-prior-idle" => {
+                require_prior_idle = Some(tap_hold::parse_require_prior_idle_option(
+                    option,
+                    option_expr,
+                    s,
+                )?);
+            }
+            _ => bail_expr!(
+                &option[0],
+                "unknown option '{}' for tap-hold-opposite-hand-release. \
+                Valid options: timeout, same-hand, neutral, unknown-hand, neutral-keys, require-prior-idle",
+                kw
+            ),
+        }
+    }
+
+    let timeout_action = match timeout_behavior {
+        DecisionBehavior::Tap => tap_action,
+        DecisionBehavior::Hold => hold_action,
+        DecisionBehavior::Ignore => unreachable!(),
+    };
+
+    let neutral_keys_static = s.a.sref_vec(neutral_keys);
+
+    Ok(s.a.sref(Action::HoldTap(s.a.sref(HoldTapAction {
+        config: HoldTapConfig::Custom(custom_tap_hold_opposite_hand_release(
+            hand_map,
+            same_hand,
+            neutral_behavior,
+            unknown_hand,
+            neutral_keys_static,
+            &s.a,
+        )),
+        tap_hold_interval: 0,
+        timeout: hold_timeout,
+        tap: *tap_action,
+        hold: *hold_action,
+        timeout_action: *timeout_action,
+        on_press_reset_timeout_to: None,
+        require_prior_idle,
+    }))))
+}
+
 fn parse_key_atoms(exprs: &[SExpr], s: &ParserState, label: &str) -> Result<Vec<OsCode>> {
     exprs
         .iter()

--- a/parser/src/cfg/list_actions.rs
+++ b/parser/src/cfg/list_actions.rs
@@ -138,6 +138,7 @@ pub const CLIPBOARD_SAVE_CMD_SET: &str = "clipboard-save-cmd-set";
 pub const CLIPBOARD_SAVE_SWAP: &str = "clipboard-save-swap";
 pub const TAP_HOLD_ORDER: &str = "tap-hold-order";
 pub const TAP_HOLD_OPPOSITE_HAND: &str = "tap-hold-opposite-hand";
+pub const TAP_HOLD_OPPOSITE_HAND_RELEASE: &str = "tap-hold-opposite-hand-release";
 
 pub fn is_list_action(ac: &str) -> bool {
     const LIST_ACTIONS: &[&str] = &[
@@ -275,6 +276,7 @@ pub fn is_list_action(ac: &str) -> bool {
         CLIPBOARD_SAVE_SWAP,
         TAP_HOLD_ORDER,
         TAP_HOLD_OPPOSITE_HAND,
+        TAP_HOLD_OPPOSITE_HAND_RELEASE,
     ];
     LIST_ACTIONS.contains(&ac)
 }

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -57,7 +57,9 @@ use custom_tap_hold::*;
 mod defcfg;
 pub use defcfg::*;
 mod defhands;
-use defhands::{parse_defhands, parse_tap_hold_opposite_hand};
+use defhands::{
+    parse_defhands, parse_tap_hold_opposite_hand, parse_tap_hold_opposite_hand_release,
+};
 mod deflocalkeys;
 use deflocalkeys::*;
 mod defsrc;
@@ -1529,6 +1531,7 @@ fn parse_action_list(ac: &[SExpr], s: &ParserState) -> Result<&'static KanataAct
             parse_tap_hold_keys(&ac[1..], s, TAP_HOLD_TAP_KEYS, custom_tap_hold_tap_keys)
         }
         TAP_HOLD_OPPOSITE_HAND => parse_tap_hold_opposite_hand(&ac[1..], s),
+        TAP_HOLD_OPPOSITE_HAND_RELEASE => parse_tap_hold_opposite_hand_release(&ac[1..], s),
         MULTI => parse_multi(&ac[1..], s),
         MACRO => parse_macro(&ac[1..], s, RepeatMacro::No),
         MACRO_REPEAT | MACRO_REPEAT_A => parse_macro(&ac[1..], s, RepeatMacro::Yes),

--- a/src/tests/sim_tests/tap_hold_tests.rs
+++ b/src/tests/sim_tests/tap_hold_tests.rs
@@ -135,10 +135,6 @@ fn tap_hold_opposite_hand_release_basic() {
     // Opposite-hand key pressed + released → hold
     let result = simulate(cfg, "d:a t:20 d:j t:20 u:j t:100").to_ascii();
     assert_eq!("t:40ms dn:Y t:6ms dn:J t:1ms up:J", result);
-
-    // Same-hand key pressed + released → tap
-    // Note: 's' is same-hand but not in defsrc, use a key in defsrc.
-    // Actually, 'a' is the tap-hold key itself. Let me use a different config.
 }
 
 #[test]
@@ -248,6 +244,60 @@ fn tap_hold_opposite_hand_release_with_require_prior_idle() {
     // Quick typing should resolve as tap due to require-prior-idle
     let result = simulate(cfg, "d:s t:10 u:s t:10 d:a t:50 u:a t:100").to_ascii();
     assert_eq!("dn:S t:10ms up:S t:10ms dn:X t:50ms up:X", result);
+}
+
+#[test]
+fn tap_hold_opposite_hand_release_same_hand_hold() {
+    // (same-hand hold) should trigger hold when same-hand key is pressed+released
+    let cfg = "
+        (defhands
+          (left  a s d f)
+          (right j k l ;))
+        (defsrc a s j)
+        (deflayer l1
+         (tap-hold-opposite-hand-release 200 x y (same-hand hold) (unknown-hand hold))
+         s j
+        )
+    ";
+    let result = simulate(cfg, "d:a t:20 d:s t:20 u:s t:100").to_ascii();
+    assert_eq!("t:40ms dn:Y t:6ms dn:S t:1ms up:S", result);
+}
+
+#[test]
+fn tap_hold_opposite_hand_release_same_hand_ignore() {
+    // (same-hand ignore) should skip same-hand keys and wait for timeout
+    let cfg = "
+        (defhands
+          (left  a s d f)
+          (right j k l ;))
+        (defsrc a s j)
+        (deflayer l1
+         (tap-hold-opposite-hand-release 200 x y
+           (same-hand ignore) (unknown-hand hold) (timeout hold))
+         s j
+        )
+    ";
+    // Same-hand key pressed+released is ignored, timeout fires
+    let result = simulate(cfg, "d:a t:20 d:s t:20 u:s t:250").to_ascii();
+    assert_eq!("t:200ms dn:Y t:1ms dn:S t:1ms up:S", result);
+}
+
+#[test]
+fn tap_hold_opposite_hand_release_neutral_keys() {
+    let cfg = "
+        (defhands
+          (left  a s d f)
+          (right j k l ;))
+        (defsrc a spc j)
+        (deflayer l1
+         (tap-hold-opposite-hand-release 200 x y
+           (same-hand tap) (unknown-hand hold) (neutral-keys spc) (neutral tap))
+         spc j
+        )
+    ";
+    // spc is in neutral-keys with (neutral tap) → tap on press+release
+    let result = simulate(cfg, "d:a t:20 d:spc t:20 u:spc t:100").to_ascii();
+    assert_eq!("t:40ms dn:X t:6ms dn:Space t:1ms up:Space", result);
 }
 
 #[test]

--- a/src/tests/sim_tests/tap_hold_tests.rs
+++ b/src/tests/sim_tests/tap_hold_tests.rs
@@ -121,6 +121,136 @@ fn tap_hold_release_tap_keys_release() {
 }
 
 #[test]
+fn tap_hold_opposite_hand_release_basic() {
+    let cfg = "
+        (defhands
+          (left  a s d f)
+          (right j k l ;))
+        (defsrc a j k)
+        (deflayer l1
+         (tap-hold-opposite-hand-release 200 x y (same-hand tap) (unknown-hand hold))
+         j k
+        )
+    ";
+    // Opposite-hand key pressed + released → hold
+    let result = simulate(cfg, "d:a t:20 d:j t:20 u:j t:100").to_ascii();
+    assert_eq!("t:40ms dn:Y t:6ms dn:J t:1ms up:J", result);
+
+    // Same-hand key pressed + released → tap
+    // Note: 's' is same-hand but not in defsrc, use a key in defsrc.
+    // Actually, 'a' is the tap-hold key itself. Let me use a different config.
+}
+
+#[test]
+fn tap_hold_opposite_hand_release_same_hand_tap() {
+    let cfg = "
+        (defhands
+          (left  a s d f)
+          (right j k l ;))
+        (defsrc a s j)
+        (deflayer l1
+         (tap-hold-opposite-hand-release 200 x y (same-hand tap) (unknown-hand hold))
+         s j
+        )
+    ";
+    // Same-hand key pressed + released → tap
+    let result = simulate(cfg, "d:a t:20 d:s t:20 u:s t:100").to_ascii();
+    assert_eq!("t:40ms dn:X t:6ms dn:S t:1ms up:S", result);
+
+    // Same-hand key pressed but NOT released → no decision (waits for release)
+    // Eventually times out → timeout action (tap by default)
+    let result = simulate(cfg, "d:a t:20 d:s t:250").to_ascii();
+    assert_eq!("t:200ms dn:X t:1ms dn:S", result);
+}
+
+#[test]
+fn tap_hold_opposite_hand_release_no_interrupt() {
+    let cfg = "
+        (defhands
+          (left  a s d f)
+          (right j k l ;))
+        (defsrc a j)
+        (deflayer l1
+         (tap-hold-opposite-hand-release 200 x y (same-hand tap) (unknown-hand hold))
+         j
+        )
+    ";
+    // Released before timeout, no interrupt → tap
+    let result = simulate(cfg, "d:a t:50 u:a t:100").to_ascii();
+    assert_eq!("t:50ms dn:X t:6ms up:X", result);
+
+    // Timeout, no interrupt → timeout action (tap by default)
+    let result = simulate(cfg, "d:a t:250 u:a t:100").to_ascii();
+    assert_eq!("t:200ms dn:X t:50ms up:X", result);
+
+    // With (timeout hold), timeout → hold
+    let cfg_timeout_hold = "
+        (defhands
+          (left  a s d f)
+          (right j k l ;))
+        (defsrc a j)
+        (deflayer l1
+         (tap-hold-opposite-hand-release 200 x y (same-hand tap) (unknown-hand hold) (timeout hold))
+         j
+        )
+    ";
+    let result = simulate(cfg_timeout_hold, "d:a t:250 u:a t:100").to_ascii();
+    assert_eq!("t:200ms dn:Y t:50ms up:Y", result);
+}
+
+#[test]
+fn tap_hold_opposite_hand_release_vs_press() {
+    // Compare: press-time (existing) vs release-time (new)
+    // With press-time, opposite-hand key triggers hold immediately on press.
+    // With release-time, it waits for the key's release.
+    let cfg_press = "
+        (defhands
+          (left  a s d f)
+          (right j k l ;))
+        (defsrc a j)
+        (deflayer l1
+         (tap-hold-opposite-hand 200 x y (same-hand tap) (unknown-hand hold))
+         j
+        )
+    ";
+    let cfg_release = "
+        (defhands
+          (left  a s d f)
+          (right j k l ;))
+        (defsrc a j)
+        (deflayer l1
+         (tap-hold-opposite-hand-release 200 x y (same-hand tap) (unknown-hand hold))
+         j
+        )
+    ";
+    // Press-time: hold decides on press (before j is released)
+    let result = simulate(cfg_press, "d:a t:20 d:j t:100").to_ascii();
+    assert_eq!("t:20ms dn:Y t:6ms dn:J", result);
+
+    // Release-time: does NOT decide on press alone — waits for release
+    let result = simulate(cfg_release, "d:a t:20 d:j t:20 u:j t:100").to_ascii();
+    assert_eq!("t:40ms dn:Y t:6ms dn:J t:1ms up:J", result);
+}
+
+#[test]
+fn tap_hold_opposite_hand_release_with_require_prior_idle() {
+    let cfg = "
+        (defhands
+          (left  a s d f)
+          (right j k l ;))
+        (defsrc a s j)
+        (deflayer l1
+         (tap-hold-opposite-hand-release 200 x y
+           (same-hand tap) (unknown-hand hold) (require-prior-idle 200))
+         s j
+        )
+    ";
+    // Quick typing should resolve as tap due to require-prior-idle
+    let result = simulate(cfg, "d:s t:10 u:s t:10 d:a t:50 u:a t:100").to_ascii();
+    assert_eq!("dn:S t:10ms up:S t:10ms dn:X t:50ms up:X", result);
+}
+
+#[test]
 fn tap_hold_release_keys() {
     let cfg = "
         (defsrc a)


### PR DESCRIPTION
## Summary

Add `tap-hold-opposite-hand-release`, a release-time variant of
`tap-hold-opposite-hand`. Same signature, options, and defhands dependency.

The difference: instead of deciding on press, it waits for the interrupting
key's press+release before committing. This avoids misfires on fast same-hand
rolls where keystrokes briefly overlap.

Example:

    (tap-hold-opposite-hand-release 200 a lctl
      (same-hand tap) (unknown-hand hold) (timeout hold))

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes (8 sim tests)