### PR TITLE
feat(macos): release keyboard grab on lock screen and user switch

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -5467,6 +5467,24 @@ in case this is an issue impacting you.
 List keyboard names that can be used
 within defcfg and then exit.
 
+[[args-macos-release-grab-on-lock]]
+=== macOS only - Release grab on lock / user switch: `--release-grab-on-lock`
+
+By default, kanata's keyboard grab on macOS stays active even when
+the screen is locked or another user takes the console via fast user
+switching. This means anyone else at the keyboard (including you on
+the lock-screen prompt) types through your remap.
+
+Pass `--release-grab-on-lock` to make kanata poll its CGSession state
+and release the grab whenever the screen is locked
+(`CGSSessionScreenIsLocked`) or kanata's session loses the console
+(`kCGSSessionOnConsoleKey == false`). The grab is re-acquired once
+kanata's session is back on the console with the screen unlocked.
+
+This is useful on shared Macs where another user's lock-screen
+password or session should not be remapped. Off by default to
+preserve the historical always-grab behavior for single-user setups.
+
 == Advanced features[[advanced-features]]
 [[virtual-keys]]
 === Virtual keys

--- a/src/kanata/macos.rs
+++ b/src/kanata/macos.rs
@@ -74,12 +74,23 @@ impl Kanata {
             let _ = crate::oskbd::start_mouse_listener(tx.clone(), &mapped, mmk);
         }
 
+        // Toggles `is_screen_grab_paused()` on lock / fast-user-switch.
+        // See `oskbd::start_screen_lock_poller` for the design notes.
+        crate::oskbd::start_screen_lock_poller();
+
         loop {
             // --- Event processing loop ---
             let needs_recovery = loop {
                 // Check output health before blocking on input
                 if !kanata.lock().kbd_out.output_ready() {
                     log::warn!("output backend unavailable — releasing input devices");
+                    break true;
+                }
+
+                if crate::oskbd::is_screen_grab_paused() {
+                    log::info!(
+                        "console session paused (lock/user-switch) — releasing input devices"
+                    );
                     break true;
                 }
 
@@ -92,6 +103,18 @@ impl Kanata {
                     }
                     Err(e) => return Err(anyhow!("failed read: {}", e)),
                 };
+
+                // Re-check after the blocking read: the lock may have
+                // landed while we were inside `wait_key`, in which case
+                // this event is the first keystroke from the new user
+                // and must be dropped, not remapped. See the caveat in
+                // `oskbd::macos`.
+                if crate::oskbd::is_screen_grab_paused() {
+                    log::info!(
+                        "console session paused (lock/user-switch) — dropping read event and releasing input devices"
+                    );
+                    break true;
+                }
 
                 let mut key_event = match KeyEvent::try_from(event) {
                     Ok(ev) => ev,
@@ -160,22 +183,28 @@ impl Kanata {
 
             info!(
                 "Input devices released. Keyboard is usable (without remapping). \
-                 Waiting for the output backend to recover..."
+                 Waiting for the output backend and console session to recover..."
             );
 
-            // --- Wait for the output backend to re-establish the connection ---
+            // Re-grab once both the sink is healthy and the session is
+            // unpaused. Sleep explicitly when only the sink is ready,
+            // since `wait_until_ready` returns instantly in that case.
             loop {
-                if kanata
+                let sink_ready = kanata
                     .lock()
                     .kbd_out
-                    .wait_until_ready(Some(Duration::from_millis(500)))
-                {
+                    .wait_until_ready(Some(Duration::from_millis(500)));
+                let session_ready = !crate::oskbd::is_screen_grab_paused();
+                if sink_ready && session_ready {
                     // Let the direct DriverKit backend finish its callback sequence
                     // before we re-seize input devices. Seizing too early can race
                     // with IOKit enumeration triggered by those callbacks.
                     std::thread::sleep(Duration::from_secs(1));
-                    info!("output backend recovered — re-grabbing input devices");
+                    info!("output backend and console session ready — re-grabbing input devices");
                     break;
+                }
+                if sink_ready && !session_ready {
+                    std::thread::sleep(Duration::from_millis(500));
                 }
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,9 @@ mod cli {
             std::sync::atomic::Ordering::SeqCst,
         );
 
+        #[cfg(target_os = "macos")]
+        oskbd::set_release_grab_on_lock(args.release_grab_on_lock);
+
         Ok((
             ValidatedArgs {
                 paths: cfg_paths,

--- a/src/main_lib/args.rs
+++ b/src/main_lib/args.rs
@@ -113,6 +113,15 @@ kanata.kbd in the current working directory and
     /// treat emergency exit as a failure and restart.
     #[arg(long, default_value = "0", verbatim_doc_comment)]
     pub emergency_exit_code: i32,
+
+    /// Release the keyboard grab while the screen is locked or another user
+    /// holds the console (fast user switching), and re-grab once kanata's
+    /// session is back. Useful on shared Macs so the lock screen and other
+    /// users get an unmodified keyboard. Off by default to preserve the
+    /// historical always-grab behavior.
+    #[cfg(target_os = "macos")]
+    #[arg(long, verbatim_doc_comment)]
+    pub release_grab_on_lock: bool,
 }
 
 #[cfg(test)]
@@ -149,6 +158,20 @@ mod tests {
     fn emergency_exit_code_custom() {
         let args = Args::try_parse_from(["kanata", "--emergency-exit-code", "42"]).unwrap();
         assert_eq!(args.emergency_exit_code, 42);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn release_grab_on_lock_default_false() {
+        let args = Args::try_parse_from(["kanata"]).unwrap();
+        assert!(!args.release_grab_on_lock);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn release_grab_on_lock_enabled() {
+        let args = Args::try_parse_from(["kanata", "--release-grab-on-lock"]).unwrap();
+        assert!(args.release_grab_on_lock);
     }
 
     #[test]

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -210,6 +210,168 @@ fn install_karabiner_abort_handler() {
     }
 }
 
+// --- Console session lock / user-switch detection ---
+//
+// kanata on macOS must run as root, so its keyboard grab is global —
+// it stays active at the lock screen and during fast user switching.
+// That's hostile to anyone else at the keyboard, who is stuck with
+// the kanata user's remap (any layout swap, home-row mods, etc.)
+// when trying to type their own password or use their own session.
+// Flagged in issue #1743.
+//
+// Fix: poll `CGSessionCopyCurrentDictionary` from a small background
+// thread (~200ms) and toggle `SCREEN_GRAB_PAUSED` when either:
+//   - the screen is locked (`CGSSessionScreenIsLocked` boolean —
+//     undocumented but stable for many years; empirically the key
+//     is *absent* from the dict while unlocked and present-and-true
+//     while locked, so missing is treated as unlocked), OR
+//   - kanata's session is no longer on the console
+//     (`kCGSSessionOnConsoleKey` boolean is false; this one *is*
+//     documented in `<CoreGraphics/CGSession.h>`), i.e. another
+//     user has taken the console via fast user switching.
+//
+// Per `<CoreGraphics/CGSession.h>`, `CGSessionCopyCurrentDictionary`
+// returns the *caller's* session (not the active console session) or
+// NULL if the caller has no Quartz GUI session at all (e.g. root
+// LaunchDaemon started at boot before any login). That last case
+// matters: NULL must NOT pause, otherwise launchd-daemon installs
+// would never grab the keyboard. NULL therefore falls back to "do
+// not pause", preserving the historical behavior on that path.
+//
+// Caveat: `wait_key()` is a blocking `read(2)` on the pqrs pipe, so
+// the poller can't wake kanata mid-read. The new user's first
+// keystroke after a lock is still seized by IOKit and arrives through
+// the pipe; the event loop drops it (see `src/kanata/macos.rs`)
+// instead of running it through the layer. Net effect: one lost
+// keystroke, never a remapped one.
+//
+// We do *not* call `release_input_only` from the poller thread to
+// wake the read sooner. The C++ side joins the listener thread and
+// closes raw FDs without poisoning them, so racing a poller-side
+// release against the event-loop's release/regrab could close FDs
+// that another kanata thread has reused.
+
+use core_foundation::base::{CFType, TCFType};
+use core_foundation::boolean::CFBoolean;
+use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
+use core_foundation::string::CFString;
+
+// Not exposed by `core-graphics`. Symbol lives in `CoreGraphics.framework`
+// (re-exported from SkyLight) which `core-graphics` already links.
+// Returns a +1-retained dictionary or NULL.
+unsafe extern "C" {
+    fn CGSessionCopyCurrentDictionary() -> CFDictionaryRef;
+}
+
+fn copy_session_dict() -> Option<CFDictionary<CFString, CFType>> {
+    // SAFETY: CGSessionCopyCurrentDictionary returns NULL or a +1 retained
+    // CFDictionaryRef; wrap_under_create_rule takes ownership of that retain.
+    unsafe {
+        let raw = CGSessionCopyCurrentDictionary();
+        if raw.is_null() {
+            None
+        } else {
+            Some(CFDictionary::wrap_under_create_rule(raw))
+        }
+    }
+}
+
+/// True while kanata's keyboard grab should be paused — currently set
+/// when kanata's CGSession reports either `CGSSessionScreenIsLocked`
+/// or `kCGSSessionOnConsoleKey == false`.
+static SCREEN_GRAB_PAUSED: AtomicBool = AtomicBool::new(false);
+
+/// Opt-in flag, set from `--release-grab-on-lock`. When false (the
+/// default), `start_screen_lock_poller` is a no-op and
+/// `is_screen_grab_paused` always returns false, preserving the
+/// historical always-grab behavior for users who run kanata on a
+/// single-user Mac and want the remap active even at the lock screen.
+static RELEASE_GRAB_ON_LOCK_ENABLED: AtomicBool = AtomicBool::new(false);
+
+pub fn set_release_grab_on_lock(enabled: bool) {
+    RELEASE_GRAB_ON_LOCK_ENABLED.store(enabled, Ordering::Release);
+}
+
+pub fn is_screen_grab_paused() -> bool {
+    SCREEN_GRAB_PAUSED.load(Ordering::Acquire)
+}
+
+/// Look up a `CFBoolean`-valued key on the given session dictionary.
+/// Returns `None` if the key is missing or the value is the wrong type.
+fn dict_bool(dict: &CFDictionary<CFString, CFType>, key: &'static str) -> Option<bool> {
+    let key = CFString::from_static_string(key);
+    let value = dict.find(&key)?;
+    value.downcast::<CFBoolean>().map(bool::from)
+}
+
+/// Decide whether the keyboard grab should currently be paused, based
+/// on the live CGSession state for kanata's own session.
+fn should_pause_for_session() -> bool {
+    // No GUI session (launchd root daemon at boot) — preserve the
+    // historical "always grab" behavior. See module-level notes.
+    let Some(dict) = copy_session_dict() else {
+        return false;
+    };
+    if dict_bool(&dict, "CGSSessionScreenIsLocked").unwrap_or(false) {
+        return true;
+    }
+    // Missing OnConsole key (early-boot / loginwindow) → treat as
+    // still-on-console to avoid false pauses.
+    !dict_bool(&dict, "kCGSSessionOnConsoleKey").unwrap_or(true)
+}
+
+/// Spawn the screen-lock / user-switch poller thread once. The thread
+/// runs for the process lifetime, polling every 200ms. Idempotent.
+/// No-op unless `--release-grab-on-lock` was passed on the CLI.
+pub fn start_screen_lock_poller() {
+    if !RELEASE_GRAB_ON_LOCK_ENABLED.load(Ordering::Acquire) {
+        return;
+    }
+    static STARTED: AtomicBool = AtomicBool::new(false);
+    if STARTED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+
+    // Seed the flag synchronously before any read happens, so a
+    // kanata started while the screen is already locked won't get a
+    // free 200ms grab window before the first poll iteration.
+    let initial_paused = should_pause_for_session();
+    SCREEN_GRAB_PAUSED.store(initial_paused, Ordering::Release);
+    log::info!(
+        "screen-lock poller: starting (initial state: {})",
+        if initial_paused { "paused" } else { "active" },
+    );
+
+    if let Err(e) = std::thread::Builder::new()
+        .name("screen-lock-poller".into())
+        .spawn(move || {
+            let mut last_paused = initial_paused;
+            loop {
+                let now_paused = should_pause_for_session();
+                if now_paused != last_paused {
+                    SCREEN_GRAB_PAUSED.store(now_paused, Ordering::Release);
+                    if now_paused {
+                        log::info!(
+                            "screen lock or user-switch detected — keyboard grab will pause on next event"
+                        );
+                    } else {
+                        log::info!(
+                            "console session restored — keyboard grab will resume"
+                        );
+                    }
+                    last_paused = now_paused;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(200));
+            }
+        })
+    {
+        log::warn!("failed to spawn screen-lock poller thread: {e}");
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct InputEvent {
     pub value: u64,


### PR DESCRIPTION
Address #1743

Poll CGSession state from a small background thread and pause kanata's
global IOKit grab whenever the screen locks or kanata's session loses
the console. Resume the grab once the session recovers

Key the fast-user-switching check on `kCGSSessionOnConsoleKey`, since
`CGSessionCopyCurrentDictionary` returns the *caller's* session — a
username comparison against a launch-time snapshot would never trip.
Read the undocumented `CGSSessionScreenIsLocked` boolean for the lock
signal. Fall back to "do not pause" on a NULL dict so root LaunchDaemon
installs (no Quartz GUI session) keep working

Re-check the pause flag right after `kb.read()` returns, not just at the
top of the loop. `wait_key` blocks on a `read(2)`, so the typical lock
path catches kanata mid-read with the new user's first keystroke already
seized by IOKit. Drop that event without remapping or emitting it —
trade one lost keystroke for never producing a wrong one

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes, Manual

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/4883ecd7-f176-48e2-aa05-84f135e1e2ec" />
