### PR TITLE
fix(parser): don't panic when printing empty list

### DIFF
--- a/parser/src/cfg/sexpr.rs
+++ b/parser/src/cfg/sexpr.rs
@@ -222,14 +222,12 @@ impl std::fmt::Debug for SExpr {
         match self {
             SExpr::Atom(a) => write!(f, "{}", &a.t),
             SExpr::List(l) => {
-                write!(f, "(")?;
-                for i in 0..l.t.len() - 1 {
-                    write!(f, "{:?} ", &l.t[i])?;
-                }
-                if let Some(last) = &l.t.last() {
-                    write!(f, "{last:?}")?;
-                }
-                write!(f, ")")?;
+                let inner =
+                    l.t.iter()
+                        .map(|x| format!("{x:?}"))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                write!(f, "({inner})")?;
                 Ok(())
             }
         }


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Fix panic when printing empty list. 
A simple reproducer:
```sh
echo "(defsrc)(deflayer base)(defalias () a)" | cargo run -- --nodelay --cfg-stdin
```

before:
```
thread 'main' (246275) panicked at parser/src/cfg/sexpr.rs:226:29:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

after:
```
01:35:26.6836 [ERROR]   × Error in configuration
   ╭─[configuration:1:1]
 1 │ (defsrc)(deflayer base)(defalias () a)
   ·                                  ─┬
   ·                                   ╰── Error here
   ╰────
  help: Alias names cannot be lists. Invalid alias: ()
        
        For more info, see the configuration guide:
        https://github.com/jtroo/kanata/blob/main/docs/config.adoc
```

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes, manual testing
