### PR TITLE
chore: remove itertools dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,12 +409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
 name = "embed-resource"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,15 +685,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,7 +800,6 @@ dependencies = [
  "anyhow",
  "bitflags 2.9.1",
  "bytemuck",
- "itertools",
  "kanata-keyberon",
  "log",
  "miette",

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2021"
 anyhow = "1"
 bitflags = "2.5.0"
 bytemuck = "1.15.0"
-itertools = "0.12"
 log = { version = "0.4.8", default-features = false }
 miette = { version = "5.7.0", features = ["fancy"] }
 once_cell = "1"

--- a/parser/src/cfg/chord.rs
+++ b/parser/src/cfg/chord.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use kanata_keyberon::chord::{ChordV2, ChordsForKey, ChordsForKeys, ReleaseBehaviour};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -48,7 +47,7 @@ pub(crate) fn parse_defchordv2(
                     let chunk = chord_translation.translate_chord(chord_def);
                     parse_single_chord(&chunk, s, &mut all_participating_key_sets)
                 });
-                Ok::<_, ParseError>(processed.collect_vec())
+                Ok::<_, ParseError>(processed.collect::<Vec<_>>())
             }
             _ => Ok(vec![parse_single_chord(
                 chunk,
@@ -66,7 +65,10 @@ pub(crate) fn parse_defchordv2(
         return Err((*e).clone());
     }
 
-    let successful = all_chords.into_iter().filter_map(Result::ok).collect_vec();
+    let successful = all_chords
+        .into_iter()
+        .filter_map(Result::ok)
+        .collect::<Vec<_>>();
     for chord in successful {
         for pkey in chord.participating_keys.iter().copied() {
             //log::trace!("chord for key:{pkey:?} > {chord:?}");
@@ -308,7 +310,7 @@ impl<'a> ChordTranslation<'a> {
         let mut action_strings = action
             .chars()
             .map(|c| self.post_process(&c.to_string()))
-            .collect_vec();
+            .collect::<Vec<_>>();
         // Wait 50ms for one-shot Shift to release
         // TODO: This would be better handled by a (multi (release-key lsft)(release-key rsft))
         // but I haven't gotten that to work yet.


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Remove itertools dependency.
It was used in just 3 places, all of which can be replaced with
functions from stdlib.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] N/A
