### PR TITLE
feat(macos): added support for Non-US # key (non_us_pound)

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -390,6 +390,14 @@ or Interception when using key names according to the browser `event.code`.
 The default `kanata.exe` does not do mappings according to the browser `event.code`
 key names.
 
+NOTE: On macOS, the ISO "#" key to the left of Enter reports
+`event.code` as `Backslash` in the browser, but the operating system
+delivers it to kanata as a distinct HID usage that the regular
+`\`/`Backslash` name does not match. Use the name `non_us_pound`
+(aliases: `NonUSPound`, `nuhs`) for that physical key on macOS. If
+you want the same config to work on Linux as well, pair this with
+`deflocalkeys-linux` to map evdev code 43 to the same name.
+
 [[deflocalkeys]]
 === deflocalkeys
 

--- a/parser/src/keys/macos.rs
+++ b/parser/src/keys/macos.rs
@@ -199,7 +199,15 @@ impl TryFrom<OsCode> for PageCode {
                 page: 0x07,
                 code: 0x31,
             }),
-            // KeyboardNonUSPound                => 0x0732, todo
+            // Keyboard Non-US # and ~ (ISO layouts, key left of Enter labelled "#").
+            // Linux evdev folds this onto KEY_BACKSLASH (43); macOS exposes it as a
+            // distinct HID usage, so we reuse the otherwise-unused KEY_NUMERIC_POUND
+            // OsCode. Users who want a symmetric name across platforms can pair this
+            // with `deflocalkeys-linux` mapping 43 to the same name. See #1915.
+            OsCode::KEY_NUMERIC_POUND => Ok(PageCode {
+                page: 0x07,
+                code: 0x32,
+            }),
             OsCode::KEY_SEMICOLON => Ok(PageCode {
                 page: 0x07,
                 code: 0x33,
@@ -882,6 +890,11 @@ impl TryFrom<PageCode> for OsCode {
                 page: 0x07,
                 code: 0x31,
             } => Ok(OsCode::KEY_BACKSLASH),
+            // Keyboard Non-US # and ~. See the forward mapping above for rationale.
+            PageCode {
+                page: 0x07,
+                code: 0x32,
+            } => Ok(OsCode::KEY_NUMERIC_POUND),
             PageCode {
                 page: 0x07,
                 code: 0x33,

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -254,6 +254,11 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         "ssrq" | "sys" => OsCode::KEY_SYSRQ,
         // Typically the Non-US backslash, near the left shift key
         "IntlBackslash" | "102d" | "lsgt" | "nubs" | "nonusbslash" | "﹨" | "<" => OsCode::KEY_102ND,
+        // ISO "#" key to the left of Enter (USB HID page 7 usage 0x32, "Non-US # and ~").
+        // Distinct HID usage on macOS; folded onto Backslash by Linux evdev, so the name
+        // is gated to platforms where the physical key can actually produce it. See #1915.
+        #[cfg(any(target_os = "macos", target_os = "unknown"))]
+        "NonUSPound" | "non_us_pound" | "nuhs" => OsCode::KEY_NUMERIC_POUND,
         "ScrollLock" | "scrlck" | "slck" | "⇳🔒" => OsCode::KEY_SCROLLLOCK,
         "Pause" | "pause" | "break" | "brk" => OsCode::KEY_PAUSE,
         "WakeUp" | "wkup" => OsCode::KEY_WAKEUP,


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Mapped USB HID usage page 7, usage 0x32 (Keyboard Non-US # and ~) to the otherwise-unused `OsCode::KEY_NUMERIC_POUND` in both directions of parser/src/keys/macos.rs

Exposed it under the names "NonUSPound", "non_us_pound", and "nuhs" (QMK's short form) in parser/src/keys/mod.rs, gated to macOS and unknown (wasm) since Linux evdev already folded this physical key onto KEY_BACKSLASH and Windows has no VK for it

The key sits left of Enter on ISO layouts labelled "#". Previously kanata dropped it as unrecognized on macOS with a debug-log entry like:

    InputEvent { value: 50, page: 7, code: 4294967295 } is unrecognized!

Added a note to docs/config.adoc's Non-US keyboards section, since the browser event.code trick advertised there reports this key as "Backslash" and would otherwise have led users straight back into the bug

I verified the 0x32 constant by reading reading: the macOS SDK header IOHIDUsageTables.h (kHIDUsage_KeyboardNonUSPound = 0x32 on page 7), and karabiner-driverkit's vendored copy of pqrs-org/cpp-hid:

https://github.com/pqrs-org/cpp-hid/blob/4c642a820b93db4b4b9a0edefe5e16d7c36eaf49/include/pqrs/hid/usage.hpp#L123

Users who want the same name on both Linux and macOS can pair this with `deflocalkeys-linux` to remap evdev 43 to the same OsCode

Closes #1915

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes, manual
