### PR TITLE
feat(macos): add accessibility permission request flag

### DIFF
--- a/docs/setup-macos.md
+++ b/docs/setup-macos.md
@@ -64,16 +64,27 @@ cargo build --release
 sudo cp target/release/kanata /usr/local/bin/kanata
 ```
 
-### 4. Grant Input Monitoring permission
+### 4. Grant macOS privacy permissions
 
 kanata needs Input Monitoring permission in
-`System Settings > Privacy & Security > Input Monitoring`. The first time you
-run kanata as root, macOS will prompt you to add the binary; you can also
-pre-add `/usr/local/bin/kanata` (or wherever you installed it) by clicking the
-`+` button and selecting the binary.
+`System Settings > Privacy & Security > Input Monitoring` to read keyboard
+devices. The first time you run kanata as root, macOS will prompt you to add
+the binary; you can also pre-add `/usr/local/bin/kanata` (or wherever you
+installed it) by clicking the `+` button and selecting the binary.
 
-Mouse-button input additionally needs Accessibility or Input Monitoring
-permission for the same binary.
+kanata also needs Accessibility permission in
+`System Settings > Privacy & Security > Accessibility`. Installers can ask
+macOS to register/show the Accessibility prompt without starting the remap
+loop:
+
+```sh
+/usr/local/bin/kanata --macos-request-permissions || true
+open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+```
+
+When launched from Terminal, macOS can report the Terminal/responsible process
+as trusted. If kanata does not appear as its own item in Accessibility, add the
+installed kanata binary manually with the `+` button.
 
 ### 5. Smoke test from terminal
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,7 @@ mod cli {
     fn macos_current_executable_hint() -> String {
         std::env::current_exe()
             .map(|path| path.display().to_string())
-            .unwrap_or_else(|_| "/opt/homebrew/bin/kanata".to_string())
+            .unwrap_or_else(|_| "kanata".to_string())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,21 +41,6 @@ mod cli {
             std::process::exit(0);
         }
 
-        let config_string = if args.cfg_stdin {
-            use std::io::Read;
-            let mut buf = String::new();
-            std::io::stdin().read_to_string(&mut buf)?;
-            Some(buf)
-        } else {
-            None
-        };
-
-        let cfg_paths = if config_string.is_none() {
-            args.cfg.unwrap_or_else(default_cfg)
-        } else {
-            vec![]
-        };
-
         let log_lvl = match (args.debug, args.trace, args.quiet) {
             (_, true, false) => LevelFilter::Trace,
             (true, false, false) => LevelFilter::Debug,
@@ -84,6 +69,41 @@ mod cli {
         log::info!("using LLHOOK+SendInput for keyboard IO");
         #[cfg(all(feature = "interception_driver", target_os = "windows"))]
         log::info!("using the Interception driver for keyboard IO");
+
+        #[cfg(target_os = "macos")]
+        if args.macos_request_permissions {
+            match oskbd::request_accessibility_permission() {
+                Ok(oskbd::AccessibilityPermissionStatus::Trusted) => {
+                    println!(
+                        "macOS reported this process as trusted, but kanata may still not appear as a separate item when launched from Terminal. Add {} manually if it is not listed.",
+                        macos_current_executable_hint()
+                    );
+                    std::process::exit(0);
+                }
+                Ok(oskbd::AccessibilityPermissionStatus::Requested) => {
+                    println!(
+                        "kanata has requested macOS Accessibility permission. Enable kanata in System Settings -> Privacy & Security -> Accessibility, then restart kanata."
+                    );
+                }
+                Err(e) => eprintln!("failed to request macOS Accessibility permission: {e}"),
+            }
+            std::process::exit(1);
+        }
+
+        let config_string = if args.cfg_stdin {
+            use std::io::Read;
+            let mut buf = String::new();
+            std::io::stdin().read_to_string(&mut buf)?;
+            Some(buf)
+        } else {
+            None
+        };
+
+        let cfg_paths = if config_string.is_none() {
+            args.cfg.unwrap_or_else(default_cfg)
+        } else {
+            vec![]
+        };
 
         if config_string.is_none() {
             if let Some(config_file) = cfg_paths.first() {
@@ -209,6 +229,13 @@ mod cli {
         sd_notify::notify(true, &[sd_notify::NotifyState::Ready])?;
 
         Kanata::event_loop(kanata_arc, tx)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn macos_current_executable_hint() -> String {
+        std::env::current_exe()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|_| "/opt/homebrew/bin/kanata".to_string())
     }
 }
 

--- a/src/main_lib/args.rs
+++ b/src/main_lib/args.rs
@@ -122,6 +122,12 @@ kanata.kbd in the current working directory and
     #[cfg(target_os = "macos")]
     #[arg(long, verbatim_doc_comment)]
     pub release_grab_on_lock: bool,
+
+    /// Request/register macOS Accessibility permission and exit.
+    /// This does not read a config file, open keyboard devices, or start remapping.
+    #[cfg(target_os = "macos")]
+    #[arg(long, verbatim_doc_comment)]
+    pub macos_request_permissions: bool,
 }
 
 #[cfg(test)]
@@ -172,6 +178,22 @@ mod tests {
     fn release_grab_on_lock_enabled() {
         let args = Args::try_parse_from(["kanata", "--release-grab-on-lock"]).unwrap();
         assert!(args.release_grab_on_lock);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_request_permissions_enabled() {
+        let args = Args::try_parse_from(["kanata", "--macos-request-permissions"]).unwrap();
+        assert!(args.macos_request_permissions);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn help_mentions_macos_request_permissions() {
+        use clap::CommandFactory;
+
+        let help = Args::command().render_long_help().to_string();
+        assert!(help.contains("--macos-request-permissions"));
     }
 
     #[test]

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -11,7 +11,11 @@ use super::*;
 use crate::kanata::CalculatedMouseMove;
 use crate::oskbd::KeyEvent;
 use anyhow::anyhow;
+use core_foundation::base::{CFType, TCFType};
+use core_foundation::boolean::CFBoolean;
+use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::runloop::{CFRunLoop, kCFRunLoopCommonModes};
+use core_foundation::string::{CFString, CFStringRef};
 use core_graphics::base::CGFloat;
 use core_graphics::display::{CGDisplay, CGPoint};
 use core_graphics::event::{
@@ -205,18 +209,23 @@ unsafe extern "C" {
     fn IOHIDRequestAccess(request: u32) -> bool;
 }
 
-// ApplicationServices binding for the Accessibility TCC gate.
+// ApplicationServices bindings for the Accessibility TCC gate.
 // `AXIsProcessTrusted` reports whether the current process is trusted
-// for Accessibility without showing any system prompt — exactly what
-// we want for a pre-flight diagnostic. The symbol lives in the
-// HIServices subframework of ApplicationServices and is available on
-// every macOS version kanata supports. core-graphics (already a
-// dependency) links CoreGraphics, which transitively loads
+// for Accessibility without showing any system prompt. If it is not
+// trusted, `AXIsProcessTrustedWithOptions` with
+// `kAXTrustedCheckOptionPrompt = true` asks macOS to register/prompt
+// kanata so the user can flip the Accessibility toggle. The symbols
+// live in the HIServices subframework of ApplicationServices and are
+// available on every macOS version kanata supports. core-graphics
+// (already a dependency) links CoreGraphics, which transitively loads
 // ApplicationServices, but declare the framework link explicitly so
 // this does not silently break if that transitive link ever changes.
 #[link(name = "ApplicationServices", kind = "framework")]
 unsafe extern "C" {
+    static kAXTrustedCheckOptionPrompt: CFStringRef;
+
     fn AXIsProcessTrusted() -> bool;
+    fn AXIsProcessTrustedWithOptions(options: CFDictionaryRef) -> bool;
 }
 
 /// `IOHIDRequestType::kIOHIDRequestTypeListenEvent` from
@@ -227,6 +236,12 @@ const K_IOHID_REQUEST_TYPE_LISTEN_EVENT: u32 = 1;
 const K_IOHID_ACCESS_TYPE_GRANTED: u32 = 0;
 const K_IOHID_ACCESS_TYPE_DENIED: u32 = 1;
 const K_IOHID_ACCESS_TYPE_UNKNOWN: u32 = 2;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AccessibilityPermissionStatus {
+    Trusted,
+    Requested,
+}
 
 /// Pre-flight check for Input Monitoring permission. Returns `Ok(())`
 /// if kanata is allowed to observe events; otherwise returns an
@@ -283,27 +298,72 @@ fn ensure_input_monitoring_permission() -> Result<(), anyhow::Error> {
 /// the exact setting, instead of the generic "grab failed" users see
 /// otherwise.
 ///
-/// We deliberately call `AXIsProcessTrusted` (no options) rather than
-/// `AXIsProcessTrustedWithOptions` with `kAXTrustedCheckOptionPrompt`:
-/// a root LaunchDaemon context cannot display a UI prompt, and for a
-/// plain `sudo` invocation the prompt would race kanata's own startup
-/// output. The returned error message already tells the user where to
-/// grant it manually, mirroring the Input Monitoring branch.
-fn ensure_accessibility_permission() -> Result<(), anyhow::Error> {
-    // SAFETY: plain FFI call with no args; the symbol is present on
-    // every macOS version kanata supports (10.15+).
-    if unsafe { AXIsProcessTrusted() } {
-        Ok(())
+/// If the permission has not been granted yet, ask ApplicationServices
+/// to register/prompt kanata by calling `AXIsProcessTrustedWithOptions`
+/// with `kAXTrustedCheckOptionPrompt = true`. In root/LaunchDaemon
+/// contexts macOS may be unable to show UI, but the call still gives
+/// TCC a chance to create the System Settings entry for the current
+/// binary path.
+pub fn request_accessibility_permission() -> Result<AccessibilityPermissionStatus, anyhow::Error> {
+    // Important CLI UX caveat: Apple's public AX trust APIs only answer
+    // whether "the current process" is trusted; they do not let us ask
+    // about, or register, an arbitrary executable path. For a command-line
+    // tool launched from Terminal, macOS may attribute trust to Terminal (the
+    // responsible process), so this status must not be presented as proof
+    // that the kanata binary itself appears as a separate Accessibility item.
+    if unsafe {
+        // SAFETY: plain FFI call with no args; the symbol is present on
+        // every macOS version kanata supports (10.15+).
+        AXIsProcessTrusted()
+    } {
+        return Ok(AccessibilityPermissionStatus::Trusted);
+    }
+
+    log::info!(
+        "macOS Accessibility permission not yet granted; \
+         asking ApplicationServices to register/prompt kanata under System Settings"
+    );
+
+    let prompt_key = unsafe {
+        if kAXTrustedCheckOptionPrompt.is_null() {
+            return Err(anyhow!(
+                "macOS Accessibility permission request failed: \
+                 kAXTrustedCheckOptionPrompt was not available"
+            ));
+        }
+
+        // SAFETY: kAXTrustedCheckOptionPrompt is a process-global CFString
+        // owned by ApplicationServices. wrap_under_get_rule retains it for
+        // the temporary dictionary below.
+        CFString::wrap_under_get_rule(kAXTrustedCheckOptionPrompt)
+    };
+    let prompt_value = CFBoolean::true_value();
+    let options = CFDictionary::from_CFType_pairs(&[(prompt_key, prompt_value)]);
+
+    if unsafe {
+        // SAFETY: options is a valid CFDictionary containing the documented
+        // kAXTrustedCheckOptionPrompt -> true pair.
+        AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef())
+    } {
+        Ok(AccessibilityPermissionStatus::Trusted)
     } else {
-        Err(anyhow!(
-            "kanata needs macOS Accessibility permission. Enable kanata in \
-             System Settings -> Privacy & Security -> Accessibility, then \
-             re-run kanata. Note: if you moved, renamed, or upgraded the \
+        Ok(AccessibilityPermissionStatus::Requested)
+    }
+}
+
+fn ensure_accessibility_permission() -> Result<(), anyhow::Error> {
+    const HINT: &str = "kanata needs macOS Accessibility permission. Enable kanata in \
+         System Settings -> Privacy & Security -> Accessibility, then restart kanata.";
+
+    match request_accessibility_permission()? {
+        AccessibilityPermissionStatus::Trusted => Ok(()),
+        AccessibilityPermissionStatus::Requested => Err(anyhow!(
+            "{HINT} Note: if you moved, renamed, or upgraded the \
              kanata binary, macOS pins the old path and you must remove the \
              stale entry and re-add the current binary. This is the \
              commonly-missed second permission behind the `IOHIDDeviceOpen \
              error: (iokit/common) not permitted` failure (issue #1211)."
-        ))
+        )),
     }
 }
 
@@ -374,11 +434,6 @@ fn install_karabiner_abort_handler() {
 // closes raw FDs without poisoning them, so racing a poller-side
 // release against the event-loop's release/regrab could close FDs
 // that another kanata thread has reused.
-
-use core_foundation::base::{CFType, TCFType};
-use core_foundation::boolean::CFBoolean;
-use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
-use core_foundation::string::CFString;
 
 // Not exposed by `core-graphics`. Symbol lives in `CoreGraphics.framework`
 // (re-exported from SkyLight) which `core-graphics` already links.

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -352,13 +352,12 @@ pub fn request_accessibility_permission() -> Result<AccessibilityPermissionStatu
 }
 
 fn ensure_accessibility_permission() -> Result<(), anyhow::Error> {
-    const HINT: &str = "kanata needs macOS Accessibility permission. Enable kanata in \
-         System Settings -> Privacy & Security -> Accessibility, then restart kanata.";
-
     match request_accessibility_permission()? {
         AccessibilityPermissionStatus::Trusted => Ok(()),
         AccessibilityPermissionStatus::Requested => Err(anyhow!(
-            "{HINT} Note: if you moved, renamed, or upgraded the \
+            "kanata needs macOS Accessibility permission. Enable kanata in \
+             System Settings -> Privacy & Security -> Accessibility, then \
+             restart kanata. Note: if you moved, renamed, or upgraded the \
              kanata binary, macOS pins the old path and you must remove the \
              stale entry and re-add the current binary. This is the \
              commonly-missed second permission behind the `IOHIDDeviceOpen \


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add a macOS-only `--macos-request-permissions` flag that requests/registers Accessibility permission without reading a config, opening keyboard devices, touching Karabiner, or starting the remap loop.

Reuse the existing macOS Accessibility preflight code for both normal startup and the new installer-friendly CLI path. Avoid claiming that kanata definitely has its own Accessibility entry when macOS reports the current process as trusted, since CLI launches from Terminal may reflect Terminal/responsible-process trust instead. Print a clearer message telling users to add the kanata binary manually if it is not listed.

Document that Input Monitoring is still required for reading keyboard devices, and that `--macos-request-permissions` only helps with the Accessibility prompt/registration flow.

This code was written entirely by Codex and needs careful maintainer review.

Manual installer testing was done with this macOS Kanata installer script:
https://github.com/alenkimov/moonlander_msklc/blob/c767d241d443273b61462e59956dc6f1749b472c/MacOS/install-macos-kanata.sh#L40

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes
