### PR TITLE
fix(macos): elevate thread QoS to prevent duplicate keystrokes under CPU load

### DIFF
--- a/src/kanata/macos.rs
+++ b/src/kanata/macos.rs
@@ -22,6 +22,20 @@ impl Kanata {
     pub fn event_loop(kanata: Arc<Mutex<Self>>, tx: Sender<KeyEvent>) -> Result<()> {
         info!("entering the event loop");
 
+        {
+            let rc = unsafe {
+                libc::pthread_set_qos_class_self_np(
+                    libc::qos_class_t::QOS_CLASS_USER_INTERACTIVE,
+                    0,
+                )
+            };
+            if rc == 0 {
+                info!("macOS: event loop thread QoS set to USER_INTERACTIVE");
+            } else {
+                log::warn!("macOS: failed to set event loop thread QoS (rc={rc})");
+            }
+        }
+
         let k = kanata.lock();
         let allow_hardware_repeat = k.allow_hardware_repeat;
         let include_names = k.include_names.clone();

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -2196,6 +2196,26 @@ impl Kanata {
     ) {
         info!("entering the processing loop");
         std::thread::spawn(move || {
+            // Elevate the processing thread to the highest QoS class so that
+            // CPU-intensive background work (compilation, indexing, etc.) does
+            // not starve the 1 ms tick loop. Without this, delayed key-release
+            // processing causes the OS to autorepeat keys that the user has
+            // already released physically. Windows does the equivalent with
+            // REALTIME_PRIORITY_CLASS (see new() above).
+            #[cfg(target_os = "macos")]
+            {
+                let rc = unsafe {
+                    libc::pthread_set_qos_class_self_np(
+                        libc::qos_class_t::QOS_CLASS_USER_INTERACTIVE,
+                        0,
+                    )
+                };
+                if rc == 0 {
+                    info!("macOS: processing thread QoS set to USER_INTERACTIVE");
+                } else {
+                    log::warn!("macOS: failed to set processing thread QoS (rc={rc})");
+                }
+            }
             if !nodelay {
                 info!("Init: catching only releases and sending immediately");
                 for _ in 0..500 {


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Set `QOS_CLASS_USER_INTERACTIVE` on the processing thread and event loop
thread on macOS via `pthread_set_qos_class_self_np()`. This is the macOS
equivalent of the existing Windows `REALTIME_PRIORITY_CLASS` elevation in
`Kanata::new()`.

Under heavy CPU load (e.g. compiling a large project), the processing
thread can be starved for 100-275ms. During this window the key release
is not posted to the Karabiner virtual HID, so macOS sees the key as
still held and triggers OS-level autorepeat, producing duplicate
characters the user did not type. This only manifests with `tap-hold`
configurations because tap-hold intentionally extends the virtual
key-down duration while decisions are pending (the mechanism documented
in discussion #422 and issue #1441).

Controlled A/B test on an M4 MacBook Air running macOS 26:

- **No tap-hold config, under build load:** clean output
- **tap-hold config, under build load, without patch:** duplicate
  characters (`thee`, `brrrrown`, `fiveeeeee`)
- **tap-hold config, under build load, with patch:** clean output across
  two consecutive runs, zero `is_autorepeat` anomalies

The `libc` crate (already a dependency) exposes
`pthread_set_qos_class_self_np` and `qos_class_t::QOS_CLASS_USER_INTERACTIVE`.
No new dependencies.

Related: #422, #1441, #450

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes, manual — physical keyboard typing under SwiftPM build load (100+ concurrent compiler processes), before/after comparison