### PR TITLE
fix(macos): prevent crash and stuck keys when typing during startup

### DIFF
--- a/src/kanata/macos.rs
+++ b/src/kanata/macos.rs
@@ -45,6 +45,24 @@ impl Kanata {
             }
         }
 
+        // Clear any stale key state left on the virtual HID by a previous
+        // kanata process. The Karabiner driver retains the keyboard report
+        // across client reconnections, so keys that were pressed when the old
+        // process died remain "held" until explicitly released. Posting a
+        // release for a no-op key forces an async_post_report with the new
+        // process's empty keyboard.keys set, clearing all stale keys.
+        {
+            let mut kanata = kanata.lock();
+            if kanata.kbd_out.output_ready() {
+                use kanata_parser::keys::OsCode;
+                if let Err(e) = kanata.kbd_out.release_key(OsCode::KEY_F24) {
+                    log::warn!("failed to clear stale virtual HID state: {e}");
+                } else {
+                    info!("cleared stale virtual HID keyboard state");
+                }
+            }
+        }
+
         // Startup is done. Stop decorating future `SIGABRT`s with the
         // Karabiner setup hint — any abort from here on is almost
         // certainly a dispatcher/CoreFoundation teardown race (e.g. the
@@ -171,7 +189,12 @@ impl Kanata {
                     }
                     _ => {}
                 }
-                tx.try_send(key_event)?;
+                if let Err(std::sync::mpsc::TrySendError::Full(ke)) = tx.try_send(key_event) {
+                    log::warn!("channel full, blocking until processing thread drains");
+                    if let Err(e) = tx.send(ke) {
+                        bail!("failed to send key event: channel disconnected: {e}");
+                    }
+                }
             };
 
             if !needs_recovery {


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Fix two issues that occur when the user is typing while kanata starts or restarts on macOS.

**1. Channel overflow crash (keyboard freeze)**

`tx.try_send(key_event)?` in the event loop propagates `TrySendError::Full` as a fatal error, crashing kanata. The `sync_channel(100)` fills up during the 500ms init phase because the processing thread only drains releases at 1 event/ms while the event loop pushes all incoming key events. With the keyboard seized and no process reading input, the keyboard freezes.

Fix: fall back to blocking `send()` when the channel is full. The pipe buffers HID input from the kernel during the brief block, so no events are lost. Only crash on genuine channel disconnection (processing thread panic), which is unrecoverable anyway.

**2. Stuck keys after restart**

When kanata is killed (`launchctl kickstart -k`, `kill`, crash), the Karabiner virtual HID driver retains the keyboard report from the old process. Keys that were physically pressed when the old process died remain "held" on the virtual keyboard. The new kanata process starts with an empty `keyboard.keys` set in C++ but the driver still has the stale state. Nobody sends releases for those keys, so macOS autorepeat fires indefinitely.

Observed: a single 'j' key remained stuck repeating for 8 seconds after a restart, producing `jujjjjmjpjjjjjejjjjdjj jjjjjover the lazy dog`.

Fix: after `wait_until_ready()`, post a no-op release (`KEY_F24`) which calls `async_post_report()` with the new process's empty keyboard set. This overwrites the driver's stale report, clearing all stuck keys.

Both fixes are macOS-only (`src/kanata/macos.rs`). No new dependencies.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes, manual — physical keyboard typing during cold restart (`launchctl kickstart -k`), before/after comparison