### PR TITLE
feat(macos): added support for JIS ¥ key

### DIFF
--- a/parser/src/keys/macos.rs
+++ b/parser/src/keys/macos.rs
@@ -536,6 +536,10 @@ impl TryFrom<OsCode> for PageCode {
                 page: 0x07,
                 code: 0x87,
             }),
+            OsCode::KEY_YEN => Ok(PageCode {
+                page: 0x07,
+                code: 0x89,
+            }),
             OsCode::KEY_HANGEUL => Ok(PageCode {
                 page: 0x07,
                 code: 0x90,
@@ -1215,6 +1219,10 @@ impl TryFrom<PageCode> for OsCode {
                 page: 0x07,
                 code: 0x87,
             } => Ok(OsCode::KEY_RO),
+            PageCode {
+                page: 0x07,
+                code: 0x89,
+            } => Ok(OsCode::KEY_YEN),
             PageCode {
                 page: 0x07,
                 code: 0x90,


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Map USB HID usage page 7, usage 0x89 (Keyboard International3, the JIS ¥ key)
to `OsCode::KEY_YEN` in both directions of parser/src/keys/macos.rs

The physical ¥ key on JIS keyboards sits above Enter, left of Backspace.
Previously kanata dropped it as unrecognized on macOS with a debug-log entry like:

    InputEvent { value: 137, page: 7, code: 4294967295 } is unrecognized!

This made the key invisible to defsrc and unusable for any remapping. The
companion key KEY_RO (HID International1, 0x87) was already supported, leaving
KEY_YEN as the last gap for JIS layouts on macOS.

No change is needed in parser/src/keys/mod.rs: KEY_YEN is already in the
OsCode enum and the Unicode "¥" already resolves to it in DEFAULT_MAPPINGS.

Manually tested on macOS 15 with a JIS Apple Magic Keyboard. Before the patch,
pressing ¥ produced "is unrecognized!" and bypassed the processing loop.
After the patch:

    sending KeyEvent { code: KEY_YEN (124), value: Press } to processing loop
    process recv ev KeyEvent { code: KEY_YEN (124), value: Press }

Related: #1621

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes, manual on macOS 15 / Apple Silicon / JIS Magic Keyboard