### PR TITLE
docs(macos): fix VHID daemon setup for standalone DriverKit installs

### DIFF
--- a/cfg_samples/karabiner-vhid-daemon.plist
+++ b/cfg_samples/karabiner-vhid-daemon.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LaunchDaemon for the Karabiner VirtualHIDDevice daemon.
+
+  Required only when using the standalone Karabiner-DriverKit-VirtualHIDDevice
+  package without Karabiner-Elements (which manages the daemon itself).
+
+  Install:
+    sudo cp cfg_samples/karabiner-vhid-daemon.plist \
+      /Library/LaunchDaemons/org.pqrs.Karabiner-VirtualHIDDevice-Daemon.plist
+    sudo chown root:wheel \
+      /Library/LaunchDaemons/org.pqrs.Karabiner-VirtualHIDDevice-Daemon.plist
+    sudo launchctl bootstrap system \
+      /Library/LaunchDaemons/org.pqrs.Karabiner-VirtualHIDDevice-Daemon.plist
+
+  Uninstall:
+    sudo launchctl bootout system/org.pqrs.Karabiner-VirtualHIDDevice-Daemon
+    sudo rm /Library/LaunchDaemons/org.pqrs.Karabiner-VirtualHIDDevice-Daemon.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>org.pqrs.Karabiner-VirtualHIDDevice-Daemon</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice/Applications/Karabiner-VirtualHIDDevice-Daemon.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Daemon</string>
+    </array>
+
+    <key>UserName</key>
+    <string>root</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/var/log/karabiner-vhid-daemon.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/var/log/karabiner-vhid-daemon.log</string>
+</dict>
+</plist>

--- a/docs/setup-macos.md
+++ b/docs/setup-macos.md
@@ -36,14 +36,44 @@ Open `System Settings > General > Login Items & Extensions > Driver Extensions`
 and toggle on the entry for `org.pqrs.Karabiner-DriverKit-VirtualHIDDevice`.
 A reboot may be required if you previously ran `deactivate`.
 
-Verify the daemon is running:
+Verify the system extension is activated:
 
 ```sh
 sudo launchctl list | grep org.pqrs
 ```
 
-You should see `org.pqrs.service.daemon.Karabiner-VirtualHIDDevice-Daemon`
-listed.
+If you have **Karabiner-Elements** installed, you should see
+`org.pqrs.service.daemon.Karabiner-VirtualHIDDevice-Daemon` listed — KE
+manages the daemon automatically and you can skip ahead to Step 3.
+
+If you installed **only** the standalone DriverKit package (no
+Karabiner-Elements), the daemon will not start on its own. You need to
+launch it manually or install a LaunchDaemon so it starts at boot.
+
+**Quick test (won't survive reboot):**
+
+```sh
+sudo "/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice/Applications/Karabiner-VirtualHIDDevice-Daemon.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Daemon" &
+```
+
+**Persistent (LaunchDaemon):** use the included plist to run the daemon at boot:
+
+```sh
+sudo cp cfg_samples/karabiner-vhid-daemon.plist \
+  /Library/LaunchDaemons/org.pqrs.Karabiner-VirtualHIDDevice-Daemon.plist
+sudo chown root:wheel \
+  /Library/LaunchDaemons/org.pqrs.Karabiner-VirtualHIDDevice-Daemon.plist
+sudo launchctl bootstrap system \
+  /Library/LaunchDaemons/org.pqrs.Karabiner-VirtualHIDDevice-Daemon.plist
+```
+
+Verify it started:
+
+```sh
+sudo launchctl list | grep org.pqrs
+```
+
+You should now see the daemon listed.
 
 ### 3. Install the kanata binary
 
@@ -150,6 +180,13 @@ sudo launchctl bootout system/dev.kanata.kanata
 sudo rm /Library/LaunchDaemons/dev.kanata.kanata.plist
 ```
 
+If you installed the VHID daemon plist (standalone DriverKit only):
+
+```sh
+sudo launchctl bootout system/org.pqrs.Karabiner-VirtualHIDDevice-Daemon
+sudo rm /Library/LaunchDaemons/org.pqrs.Karabiner-VirtualHIDDevice-Daemon.plist
+```
+
 Remove the kanata binary:
 
 ```sh
@@ -173,6 +210,10 @@ You may then delete the `Karabiner-VirtualHIDDevice-Manager.app` from
   is not approved, (3) another process is already grabbing the keyboard
   exclusively. The kanata process prints this same hint to stderr right before
   it aborts.
+- **`connect_failed asio.system:2` in a loop**: the Karabiner VirtualHIDDevice
+  daemon is not running. This happens when using the standalone DriverKit
+  package without Karabiner-Elements. See Step 2 above for how to start the
+  daemon manually or install it as a LaunchDaemon.
 - **A remapped key fires but nothing types**: confirm the kanata binary has
   Input Monitoring permission in `System Settings > Privacy & Security`. If
   you reinstalled the binary in place, macOS sometimes invalidates the


### PR DESCRIPTION
## Summary

Fixes #2050.

- Updates `docs/setup-macos.md` Step 2 to distinguish between Karabiner-Elements (daemon auto-managed) and standalone DriverKit installs (daemon must be started manually)
- Adds `cfg_samples/karabiner-vhid-daemon.plist` LaunchDaemon for persistent daemon startup without KE
- Adds troubleshooting entry for the `connect_failed asio.system:2` error
- Adds VHID daemon plist cleanup to the uninstall section

## Test plan

- [ ] Fresh macOS install with standalone Karabiner-DriverKit-VirtualHIDDevice 6.2.0 (no KE): follow updated Step 2, confirm daemon starts and kanata connects
- [ ] macOS install with Karabiner-Elements: confirm docs correctly tell user to skip the manual daemon step