### PR TITLE
fix(macos): add missing reverse HID mapping for ContextMenu key

### DIFF
--- a/parser/src/keys/macos.rs
+++ b/parser/src/keys/macos.rs
@@ -1101,6 +1101,10 @@ impl TryFrom<PageCode> for OsCode {
             } => Ok(OsCode::KEY_102ND),
             PageCode {
                 page: 0x07,
+                code: 0x65,
+            } => Ok(OsCode::KEY_COMPOSE),
+            PageCode {
+                page: 0x07,
                 code: 0x66,
             } => Ok(OsCode::KEY_POWER),
             PageCode {


### PR DESCRIPTION
## Summary

Fixes #2052.

The forward mapping (`OsCode::KEY_COMPOSE` → HID usage `0x07/0x65`) existed so kanata could *output* the key, but the reverse mapping (`PageCode` → `OsCode`) was missing — it jumped from `0x64` (KEY_102ND) to `0x66` (KEY_POWER). When a third-party keyboard sends the ContextMenu/Application key, the HID event arrived but was silently dropped because it couldn't be converted back to an OsCode.

One-line fix: add the missing `0x65 → KEY_COMPOSE` entry in the reverse mapping table.

## Test plan

- [ ] macOS with a third-party keyboard that has a ContextMenu/Application key: put `menu` in `defsrc`, confirm the key is now intercepted and remapped