### PR TITLE
docs: add a note about extra perms for mouse actions on macos

### DIFF
--- a/docs/platform-known-issues.adoc
+++ b/docs/platform-known-issues.adoc
@@ -93,6 +93,8 @@ and explicitly map keys in `defsrc` instead
   register itself under that pane so there is something to toggle on; if the
   permission has already been denied, kanata exits early with a message pointing
   you to the same setting instead of failing deeper in the driver stack.
+* In order to send mouse events/movements, it may be necessary to also add the kanata binary in
+  `System Settings > Privacy & Security > Accessibility` (discussed in https://github.com/jtroo/kanata/issues/1574[issue #1574]).
 * Once the mouse event tap is installed (on startup or via live-reload), it
   continues running for the lifetime of the process. Removing all mouse keys
   from `defsrc` then live-reloading does not stop the tap thread, though it


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add a note about the MacOS Accessibility permission for sending mouse events.

I encountered this issue, and this felt to me like a good addition to the platform issues page.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
