### PR TITLE
feat: support tap-repress-timeout for tap-hold-opposite-hand variants

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2366,6 +2366,7 @@ Internally it uses the same `HoldTapConfig::Custom` machinery as `tap-hold-relea
 | `(neutral-keys key ...)` | one or more key names | (empty) | Keys treated as neutral, overriding their `defhands` assignment.
 | `(neutral <value>)` | `tap`, `hold`, `ignore` | `ignore` | Action when a `neutral-keys` key is pressed.
 | `(unknown-hand <value>)` | `tap`, `hold`, `ignore` | `ignore` | Action when a key not in `defhands` is pressed.
+| `(tap-repress-timeout <ms>)` | `0`–`65535` | `0` | If the same key is re-pressed within this many ms after a tap, immediately tap again instead of entering the hold decision. `0` disables (every press enters the hold decision). See <<allow-hardware-repeat,tap repress timeout>> for details.
 |===
 
 When a value is `ignore`, that key press is skipped and the action

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2366,7 +2366,8 @@ Internally it uses the same `HoldTapConfig::Custom` machinery as `tap-hold-relea
 | `(neutral-keys key ...)` | one or more key names | (empty) | Keys treated as neutral, overriding their `defhands` assignment.
 | `(neutral <value>)` | `tap`, `hold`, `ignore` | `ignore` | Action when a `neutral-keys` key is pressed.
 | `(unknown-hand <value>)` | `tap`, `hold`, `ignore` | `ignore` | Action when a key not in `defhands` is pressed.
-| `(tap-repress-timeout <ms>)` | `0`–`65535` | `0` | If the same key is re-pressed within this many ms after a tap, immediately tap again instead of entering the hold decision. `0` disables (every press enters the hold decision). See <<allow-hardware-repeat,tap repress timeout>> for details.
+| `(require-prior-idle <ms>)` | `0`–`65535` | (disabled) | If a key was pressed within this many ms before the tap-hold key, resolve as tap immediately. Useful for avoiding accidental holds during fast typing.
+| `(tap-repress-timeout <ms>)` | `0`–`65535` | `0` | If the same key is re-pressed within this many ms after a tap, immediately tap again instead of entering the hold decision. `0` disables (every press enters the hold decision). See <<tap-hold,tap repress timeout>> for details.
 |===
 
 When a value is `ignore`, that key press is skipped and the action

--- a/parser/src/cfg/defhands.rs
+++ b/parser/src/cfg/defhands.rs
@@ -185,14 +185,8 @@ pub(super) fn parse_tap_hold_opposite_hand(
                 )?);
             }
             "tap-repress-timeout" => {
-                if option.len() != 2 {
-                    bail_expr!(
-                        option_expr,
-                        "tap-repress-timeout option expects exactly 2 items: \
-                        `(tap-repress-timeout <ms>)`"
-                    );
-                }
-                tap_repress_timeout = parse_u16(&option[1], s, "tap-repress-timeout")?;
+                tap_repress_timeout =
+                    tap_hold::parse_tap_repress_timeout_option(option, option_expr, s)?;
             }
             _ => bail_expr!(
                 &option[0],
@@ -345,14 +339,8 @@ pub(super) fn parse_tap_hold_opposite_hand_release(
                 )?);
             }
             "tap-repress-timeout" => {
-                if option.len() != 2 {
-                    bail_expr!(
-                        option_expr,
-                        "tap-repress-timeout option expects exactly 2 items: \
-                        `(tap-repress-timeout <ms>)`"
-                    );
-                }
-                tap_repress_timeout = parse_u16(&option[1], s, "tap-repress-timeout")?;
+                tap_repress_timeout =
+                    tap_hold::parse_tap_repress_timeout_option(option, option_expr, s)?;
             }
             _ => bail_expr!(
                 &option[0],

--- a/parser/src/cfg/defhands.rs
+++ b/parser/src/cfg/defhands.rs
@@ -108,6 +108,7 @@ pub(super) fn parse_tap_hold_opposite_hand(
     let mut unknown_hand = DecisionBehavior::Ignore;
     let mut neutral_keys: Vec<OsCode> = Vec::new();
     let mut require_prior_idle: Option<u16> = None;
+    let mut tap_repress_timeout: u16 = 0;
     let mut seen_options: HashSet<&str> = HashSet::default();
 
     for option_expr in &ac_params[3..] {
@@ -183,10 +184,21 @@ pub(super) fn parse_tap_hold_opposite_hand(
                     s,
                 )?);
             }
+            "tap-repress-timeout" => {
+                if option.len() != 2 {
+                    bail_expr!(
+                        option_expr,
+                        "tap-repress-timeout option expects exactly 2 items: \
+                        `(tap-repress-timeout <ms>)`"
+                    );
+                }
+                tap_repress_timeout = parse_u16(&option[1], s, "tap-repress-timeout")?;
+            }
             _ => bail_expr!(
                 &option[0],
                 "unknown option '{}' for tap-hold-opposite-hand. \
-                Valid options: timeout, same-hand, neutral, unknown-hand, neutral-keys, require-prior-idle",
+                Valid options: timeout, same-hand, neutral, unknown-hand, neutral-keys, \
+                require-prior-idle, tap-repress-timeout",
                 kw
             ),
         }
@@ -209,7 +221,7 @@ pub(super) fn parse_tap_hold_opposite_hand(
             neutral_keys_static,
             &s.a,
         )),
-        tap_hold_interval: 0,
+        tap_hold_interval: tap_repress_timeout,
         timeout: hold_timeout,
         tap: *tap_action,
         hold: *hold_action,
@@ -256,6 +268,7 @@ pub(super) fn parse_tap_hold_opposite_hand_release(
     let mut unknown_hand = DecisionBehavior::Ignore;
     let mut neutral_keys: Vec<OsCode> = Vec::new();
     let mut require_prior_idle: Option<u16> = None;
+    let mut tap_repress_timeout: u16 = 0;
     let mut seen_options: HashSet<&str> = HashSet::default();
 
     for option_expr in &ac_params[3..] {
@@ -331,10 +344,21 @@ pub(super) fn parse_tap_hold_opposite_hand_release(
                     s,
                 )?);
             }
+            "tap-repress-timeout" => {
+                if option.len() != 2 {
+                    bail_expr!(
+                        option_expr,
+                        "tap-repress-timeout option expects exactly 2 items: \
+                        `(tap-repress-timeout <ms>)`"
+                    );
+                }
+                tap_repress_timeout = parse_u16(&option[1], s, "tap-repress-timeout")?;
+            }
             _ => bail_expr!(
                 &option[0],
                 "unknown option '{}' for tap-hold-opposite-hand-release. \
-                Valid options: timeout, same-hand, neutral, unknown-hand, neutral-keys, require-prior-idle",
+                Valid options: timeout, same-hand, neutral, unknown-hand, neutral-keys, \
+                require-prior-idle, tap-repress-timeout",
                 kw
             ),
         }
@@ -357,7 +381,7 @@ pub(super) fn parse_tap_hold_opposite_hand_release(
             neutral_keys_static,
             &s.a,
         )),
-        tap_hold_interval: 0,
+        tap_hold_interval: tap_repress_timeout,
         timeout: hold_timeout,
         tap: *tap_action,
         hold: *hold_action,

--- a/parser/src/cfg/tap_hold.rs
+++ b/parser/src/cfg/tap_hold.rs
@@ -10,6 +10,22 @@ pub(crate) struct TapHoldOptions {
     pub(crate) require_prior_idle: Option<u16>,
 }
 
+/// Parse the value of a `(tap-repress-timeout <ms>)` option list.
+pub(crate) fn parse_tap_repress_timeout_option(
+    option: &[SExpr],
+    option_expr: &SExpr,
+    s: &ParserState,
+) -> Result<u16> {
+    if option.len() != 2 {
+        bail_expr!(
+            option_expr,
+            "tap-repress-timeout option expects exactly 2 items: \
+            `(tap-repress-timeout <ms>)`"
+        );
+    }
+    parse_u16(&option[1], s, "tap-repress-timeout")
+}
+
 /// Parse the value of a `(require-prior-idle <ms>)` option list.
 /// Validates that the list has exactly 2 items and the value is a u16.
 pub(crate) fn parse_require_prior_idle_option(

--- a/src/tests/sim_tests/tap_hold_tests.rs
+++ b/src/tests/sim_tests/tap_hold_tests.rs
@@ -938,6 +938,51 @@ fn tap_hold_require_prior_idle_with_opposite_hand() {
 }
 
 #[test]
+fn tap_repress_timeout_opposite_hand() {
+    let cfg = "
+(defhands (left a s d f) (right j k l ;))
+(defsrc f j)
+(deflayer base @f j)
+(defalias f (tap-hold-opposite-hand 200 f lctl (tap-repress-timeout 100)))
+    ";
+    // Re-press within tap-repress-timeout → immediate tap (no hold decision)
+    let result = simulate(cfg, "d:f t:30 u:f t:30 d:f t:300 u:f t:50").to_ascii();
+    assert_eq!("t:30ms dn:F t:6ms up:F t:24ms dn:F t:300ms up:F", result);
+    // Re-press after tap-repress-timeout expires → enters hold decision, timeout → tap
+    let result = simulate(cfg, "d:f t:30 u:f t:200 d:f t:300 u:f t:50").to_ascii();
+    assert_eq!("t:30ms dn:F t:6ms up:F t:394ms dn:F t:100ms up:F", result);
+}
+
+#[test]
+fn tap_repress_timeout_opposite_hand_release() {
+    let cfg = "
+(defhands (left a s d f) (right j k l ;))
+(defsrc f j)
+(deflayer base @f j)
+(defalias f (tap-hold-opposite-hand-release 200 f lctl (tap-repress-timeout 100)))
+    ";
+    // Re-press within tap-repress-timeout → immediate tap
+    let result = simulate(cfg, "d:f t:30 u:f t:30 d:f t:300 u:f t:50").to_ascii();
+    assert_eq!("t:30ms dn:F t:6ms up:F t:24ms dn:F t:300ms up:F", result);
+    // Re-press after tap-repress-timeout expires → enters hold decision, timeout → tap
+    let result = simulate(cfg, "d:f t:30 u:f t:200 d:f t:300 u:f t:50").to_ascii();
+    assert_eq!("t:30ms dn:F t:6ms up:F t:394ms dn:F t:100ms up:F", result);
+}
+
+#[test]
+fn tap_repress_timeout_opposite_hand_zero_disables() {
+    let cfg = "
+(defhands (left a s d f) (right j k l ;))
+(defsrc f j)
+(deflayer base @f j)
+(defalias f (tap-hold-opposite-hand 200 f lctl (tap-repress-timeout 0)))
+    ";
+    // tap-repress-timeout 0 → every press enters hold decision (same as no option)
+    let result = simulate(cfg, "d:f t:30 u:f t:30 d:f t:300 u:f t:50").to_ascii();
+    assert_eq!("t:30ms dn:F t:6ms up:F t:224ms dn:F t:100ms up:F", result);
+}
+
+#[test]
 fn tap_hold_require_prior_idle_with_tap_hold_interval() {
     // tap-hold-require-prior-idle check runs before tap-hold-interval (quick re-press).
     // Both should work together: typing streak → tap immediately,


### PR DESCRIPTION
## Summary

- Adds `(tap-repress-timeout <ms>)` as an optional parameter for `tap-hold-opposite-hand` and `tap-hold-opposite-hand-release`
- When set, a quick re-press of the same key within the timeout window immediately fires the tap action without entering the hold decision
- Brings parity with all other tap-hold variants which already support this via a positional parameter

## Implementation

The `HoldTapAction` struct already has the `tap_hold_interval` field and the keyberon layout engine handles it correctly — it was just hardcoded to `0` for the opposite-hand variants. This PR wires it through the parser as an option keyword, consistent with the existing option-based syntax these variants use.

**Changes:**
- `parser/src/cfg/defhands.rs` — Parse `(tap-repress-timeout <ms>)` option in both functions, pass to `tap_hold_interval`
- `parser/src/cfg/tap_hold.rs` — Shared `parse_tap_repress_timeout_option()` helper
- `docs/config.adoc` — Add `tap-repress-timeout` and `require-prior-idle` to the options table
- `src/tests/sim_tests/tap_hold_tests.rs` — 3 new tests covering both variants + zero-disables baseline

## Test plan

- [x] All 240 existing tests pass
- [x] New test: re-press within timeout → immediate tap (both variants)
- [x] New test: re-press after timeout expires → enters hold decision
- [x] New test: `(tap-repress-timeout 0)` behaves identically to no option (baseline)
- [x] `cargo fmt` and `cargo clippy` clean

Closes #2063