### PR TITLE
feat(macos): add macos-continue-if-no-devs-found config option

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -5021,6 +5021,31 @@ Use `kanata -l` or `kanata --list` to list the available keyboards.
 )
 ----
 
+[[macos-only-macos-continue-if-no-devs-found]]
+=== macOS only: macos-continue-if-no-devs-found
+
+By default, kanata will exit with an error if no input devices matching
+the configured include list are found at startup. Setting
+`macos-continue-if-no-devs-found` changes this: kanata keeps running and
+waits for matching devices to connect, then grabs them automatically.
+
+This is useful for Bluetooth or USB keyboards that may not be connected
+at boot time. When the device later appears (e.g. Bluetooth pairs, USB
+plugged in), kanata captures it and begins remapping.
+
+Works with `macos-dev-names-include` and `definputdevices`. Has no
+effect when no device filter is configured (the default enumeration
+always finds the internal keyboard).
+
+.Example:
+[source]
+----
+(defcfg
+  macos-dev-names-include ("My BT Keyboard")
+  macos-continue-if-no-devs-found yes
+)
+----
+
 [[windows-only-windows-altgr]]
 === Windows only: windows-altgr
 

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -5035,7 +5035,7 @@ plugged in), kanata captures it and begins remapping.
 
 Works with `macos-dev-names-include` and `definputdevices`. Has no
 effect when no device filter is configured (the default enumeration
-always finds the internal keyboard).
+always finds the built-in keyboard on Mac laptops).
 
 .Example:
 [source]

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -5033,9 +5033,9 @@ This is useful for Bluetooth or USB keyboards that may not be connected
 at boot time. When the device later appears (e.g. Bluetooth pairs, USB
 plugged in), kanata captures it and begins remapping.
 
-Works with `macos-dev-names-include` and `definputdevices`. Has no
-effect when no device filter is configured (the default enumeration
-always finds the built-in keyboard on Mac laptops).
+Works with `macos-dev-names-include` and `definputdevices`.
+This has no effect with macOS laptops when no device filter is configured
+because the default enumeration always finds the built-in keyboard.
 
 .Example:
 [source]

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -69,6 +69,7 @@ pub enum LinuxCfgOutputBusType {
 pub struct CfgMacosOptions {
     pub macos_dev_names_include: Option<Vec<String>>,
     pub macos_dev_names_exclude: Option<Vec<String>>,
+    pub macos_continue_if_no_devs_found: bool,
 }
 
 #[cfg(any(
@@ -679,6 +680,13 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                                 log::warn!("macos-dev-names-exclude is empty");
                             }
                             cfg.macos_opts.macos_dev_names_exclude = Some(dev_names);
+                        }
+                    }
+                    "macos-continue-if-no-devs-found" => {
+                        #[cfg(any(target_os = "macos", target_os = "unknown"))]
+                        {
+                            cfg.macos_opts.macos_continue_if_no_devs_found =
+                                parse_defcfg_val_bool(val, label)?
                         }
                     }
                     "tray-icon" => {

--- a/src/kanata/macos.rs
+++ b/src/kanata/macos.rs
@@ -269,11 +269,13 @@ impl Kanata {
 
             // Re-seize input devices using regrab_input() which creates a fresh
             // pipe and listener thread without re-initializing the sink client.
-            if !kb.regrab_input() {
+            if kb.regrab_input() {
+                info!("keyboard grabbed, entering event processing loop");
+            } else if continue_if_no_devices {
+                info!("no devices grabbed after recovery, waiting for device connection...");
+            } else {
                 bail!("failed to re-grab keyboard devices after DriverKit recovery");
             }
-
-            info!("keyboard grabbed, entering event processing loop");
 
             // Back to the event processing loop.
         }

--- a/src/kanata/macos.rs
+++ b/src/kanata/macos.rs
@@ -41,9 +41,15 @@ impl Kanata {
         let include_names = k.include_names.clone();
         let exclude_names = k.exclude_names.clone();
         let input_devices = k.input_devices.clone();
+        let continue_if_no_devices = k.continue_if_no_devices;
         drop(k);
 
-        let mut kb = match KbdIn::new(include_names, exclude_names, input_devices.as_deref()) {
+        let mut kb = match KbdIn::new(
+            include_names,
+            exclude_names,
+            input_devices.as_deref(),
+            continue_if_no_devices,
+        ) {
             Ok(kbd_in) => kbd_in,
             Err(e) => bail!("failed to open keyboard device(s): {}", e),
         };
@@ -85,7 +91,11 @@ impl Kanata {
         // Karabiner hint would be actively misleading.
         crate::oskbd::mark_karabiner_startup_complete();
 
-        info!("keyboard grabbed, entering event processing loop");
+        if kb.is_grabbed() {
+            info!("keyboard grabbed, entering event processing loop");
+        } else {
+            info!("no devices grabbed yet, waiting for device connection...");
+        }
 
         // Start the mouse event tap on a background thread if any mouse buttons
         // are mapped in the config. Similar to the Windows mouse hook.

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -220,8 +220,8 @@ pub struct Kanata {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     /// Linux input paths in the user configuration.
     pub kbd_in_paths: Vec<String>,
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    /// Tracks the Linux user configuration to continue or abort if no devices are found.
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+    /// Tracks the user configuration to continue or abort if no devices are found.
     continue_if_no_devices: bool,
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
     /// Tracks the Linux/Macos user configuration for device names (instead of paths) that should be
@@ -481,6 +481,8 @@ impl Kanata {
             kbd_in_paths: cfg.options.linux_opts.linux_dev,
             #[cfg(any(target_os = "linux", target_os = "android"))]
             continue_if_no_devices: cfg.options.linux_opts.linux_continue_if_no_devs_found,
+            #[cfg(target_os = "macos")]
+            continue_if_no_devices: cfg.options.macos_opts.macos_continue_if_no_devs_found,
             #[cfg(any(target_os = "linux", target_os = "android"))]
             include_names: cfg.options.linux_opts.linux_dev_names_include,
             #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -633,6 +635,8 @@ impl Kanata {
             kbd_in_paths: cfg.options.linux_opts.linux_dev,
             #[cfg(any(target_os = "linux", target_os = "android"))]
             continue_if_no_devices: cfg.options.linux_opts.linux_continue_if_no_devs_found,
+            #[cfg(target_os = "macos")]
+            continue_if_no_devices: cfg.options.macos_opts.macos_continue_if_no_devs_found,
             #[cfg(any(target_os = "linux", target_os = "android"))]
             include_names: cfg.options.linux_opts.linux_dev_names_include,
             #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -774,7 +774,7 @@ impl KbdIn {
         loop {
             std::thread::sleep(std::time::Duration::from_secs(2));
             poll_count += 1;
-            if poll_count % 15 == 0 {
+            if poll_count.is_multiple_of(15) {
                 log::info!(
                     "Still waiting for device(s): {:?} ({}s elapsed)",
                     deferred_names,

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -588,9 +588,7 @@ pub struct KbdIn {
 
 impl Drop for KbdIn {
     fn drop(&mut self) {
-        if self.grabbed {
-            release();
-        }
+        release();
     }
 }
 
@@ -772,8 +770,17 @@ impl KbdIn {
         deferred_names: Vec<String>,
         input_devices: Option<&[(std::num::NonZeroU8, kanata_parser::cfg::InputDeviceMatcher)]>,
     ) -> Result<Self, anyhow::Error> {
+        let mut poll_count: u32 = 0;
         loop {
             std::thread::sleep(std::time::Duration::from_secs(2));
+            poll_count += 1;
+            if poll_count % 15 == 0 {
+                log::info!(
+                    "Still waiting for device(s): {:?} ({}s elapsed)",
+                    deferred_names,
+                    poll_count * 2
+                );
+            }
             let mut any_registered = false;
             for name in &deferred_names {
                 if device_matches(name) && register_device(name) {

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -599,6 +599,7 @@ impl KbdIn {
         include_names: Option<Vec<String>>,
         exclude_names: Option<Vec<String>>,
         input_devices: Option<&[(std::num::NonZeroU8, kanata_parser::cfg::InputDeviceMatcher)]>,
+        continue_if_no_devices: bool,
     ) -> Result<Self, anyhow::Error> {
         // Pre-flight the Input Monitoring TCC gate before touching the
         // Karabiner stack. A denied permission here produces a clean,
@@ -634,8 +635,12 @@ impl KbdIn {
 
         // Based on the definition of include and exclude names, they should never be used together.
         // Kanata config parser should probably enforce this.
-        let device_names = if let Some(included_names) = include_names {
-            validate_and_register_devices(included_names)
+        let (device_names, deferred_names) = if let Some(included_names) = include_names {
+            if continue_if_no_devices {
+                register_devices_with_deferred(included_names)
+            } else {
+                (validate_and_register_devices(included_names), vec![])
+            }
         } else {
             // No include list: enumerate every device the driverkit iterator
             // sees, drop any that are known-problematic (empty names, Sidecar
@@ -659,7 +664,7 @@ impl KbdIn {
                 })
                 .collect::<Vec<String>>();
 
-            validate_and_register_devices(devices_to_include)
+            (validate_and_register_devices(devices_to_include), vec![])
         };
 
         if !device_names.is_empty() {
@@ -690,6 +695,21 @@ impl KbdIn {
                      sudo or a LaunchDaemon) and that no other process is \
                      exclusively grabbing the keyboard."
                 ))
+            }
+        } else if continue_if_no_devices {
+            if grab() {
+                log::info!(
+                    "No devices currently connected but listener started. \
+                     Waiting for device connection via callback..."
+                );
+                let device_hash_to_id = build_device_hash_to_id_map(input_devices);
+                Ok(Self {
+                    grabbed: false,
+                    device_hash_to_id,
+                })
+            } else {
+                log::info!("No devices registered yet. Polling for device connection...");
+                Self::poll_for_devices(deferred_names, input_devices)
             }
         } else {
             Err(anyhow!(
@@ -728,10 +748,8 @@ impl KbdIn {
     /// Release seized input devices without tearing down the output connection.
     /// After this call, `read()` will return `UnexpectedEof`.
     pub fn release_input(&mut self) {
-        if self.grabbed {
-            release_input_only();
-            self.grabbed = false;
-        }
+        release_input_only();
+        self.grabbed = false;
     }
 
     /// Re-seize input devices after a previous `release_input()`.
@@ -749,6 +767,46 @@ impl KbdIn {
     pub fn is_grabbed(&self) -> bool {
         self.grabbed
     }
+
+    fn poll_for_devices(
+        deferred_names: Vec<String>,
+        input_devices: Option<&[(std::num::NonZeroU8, kanata_parser::cfg::InputDeviceMatcher)]>,
+    ) -> Result<Self, anyhow::Error> {
+        loop {
+            std::thread::sleep(std::time::Duration::from_secs(2));
+            let mut any_registered = false;
+            for name in &deferred_names {
+                if device_matches(name) && register_device(name) {
+                    log::info!("Device '{name}' appeared and was registered");
+                    any_registered = true;
+                }
+            }
+            if any_registered {
+                if grab() {
+                    let device_hash_to_id = build_device_hash_to_id_map(input_devices);
+                    return Ok(Self {
+                        grabbed: true,
+                        device_hash_to_id,
+                    });
+                }
+                log::warn!("Device appeared but grab failed, continuing to poll...");
+            }
+        }
+    }
+}
+
+fn register_devices_with_deferred(names: Vec<String>) -> (Vec<String>, Vec<String>) {
+    let mut registered = Vec::new();
+    let mut deferred = Vec::new();
+    for name in names {
+        if register_device(&name) {
+            registered.push(name);
+        } else {
+            log::info!("Device '{name}' not currently connected, deferring");
+            deferred.push(name);
+        }
+    }
+    (registered, deferred)
 }
 
 /// Device product-name patterns to skip in the default (no explicit

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -633,12 +633,8 @@ impl KbdIn {
 
         // Based on the definition of include and exclude names, they should never be used together.
         // Kanata config parser should probably enforce this.
-        let (device_names, deferred_names) = if let Some(included_names) = include_names {
-            if continue_if_no_devices {
-                register_devices_with_deferred(included_names)
-            } else {
-                (validate_and_register_devices(included_names), vec![])
-            }
+        let device_names = if let Some(ref included_names) = include_names {
+            validate_and_register_devices(included_names)
         } else {
             // No include list: enumerate every device the driverkit iterator
             // sees, drop any that are known-problematic (empty names, Sidecar
@@ -662,7 +658,7 @@ impl KbdIn {
                 })
                 .collect::<Vec<String>>();
 
-            (validate_and_register_devices(devices_to_include), vec![])
+            validate_and_register_devices(&devices_to_include)
         };
 
         if !device_names.is_empty() {
@@ -695,6 +691,7 @@ impl KbdIn {
                 ))
             }
         } else if continue_if_no_devices {
+            let names = include_names.unwrap_or_default();
             if grab() {
                 log::info!(
                     "No devices currently connected but listener started. \
@@ -707,7 +704,7 @@ impl KbdIn {
                 })
             } else {
                 log::info!("No devices registered yet. Polling for device connection...");
-                Self::poll_for_devices(deferred_names, input_devices)
+                Self::poll_for_devices(&names, input_devices)
             }
         } else {
             Err(anyhow!(
@@ -767,7 +764,7 @@ impl KbdIn {
     }
 
     fn poll_for_devices(
-        deferred_names: Vec<String>,
+        names: &[String],
         input_devices: Option<&[(std::num::NonZeroU8, kanata_parser::cfg::InputDeviceMatcher)]>,
     ) -> Result<Self, anyhow::Error> {
         let mut poll_count: u32 = 0;
@@ -777,12 +774,12 @@ impl KbdIn {
             if poll_count.is_multiple_of(15) {
                 log::info!(
                     "Still waiting for device(s): {:?} ({}s elapsed)",
-                    deferred_names,
+                    names,
                     poll_count * 2
                 );
             }
             let mut any_registered = false;
-            for name in &deferred_names {
+            for name in names {
                 if device_matches(name) && register_device(name) {
                     log::info!("Device '{name}' appeared and was registered");
                     any_registered = true;
@@ -800,20 +797,6 @@ impl KbdIn {
             }
         }
     }
-}
-
-fn register_devices_with_deferred(names: Vec<String>) -> (Vec<String>, Vec<String>) {
-    let mut registered = Vec::new();
-    let mut deferred = Vec::new();
-    for name in names {
-        if register_device(&name) {
-            registered.push(name);
-        } else {
-            log::info!("Device '{name}' not currently connected, deferring");
-            deferred.push(name);
-        }
-    }
-    (registered, deferred)
 }
 
 /// Device product-name patterns to skip in the default (no explicit
@@ -891,7 +874,7 @@ fn build_device_hash_to_id_map(
     map
 }
 
-fn validate_and_register_devices(include_names: Vec<String>) -> Vec<String> {
+fn validate_and_register_devices(include_names: &[String]) -> Vec<String> {
     include_names
         .iter()
         .filter_map(|dev| {


### PR DESCRIPTION
## Summary

- Adds `macos-continue-if-no-devs-found` defcfg option, the macOS equivalent of `linux-continue-if-no-devs-found`
- When enabled and no matching devices are found at startup, kanata keeps running and captures devices when they connect
- Essential for Bluetooth keyboards that aren't connected at boot time

## Implementation

Two capture paths depending on how devices are specified:

- **Hash-based IDs** (from `definputdevices` or hex names): `register_device_hash()` inserts unconditionally, `grab()` starts the listener thread, and `device_connected_callback` captures the device on connection via IOKit notifications
- **Name-based IDs** (from `macos-dev-names-include`): polls every 2s with `device_matches()` + `register_device()` until the device appears, then grabs

**Changes:**
- `parser/src/cfg/defcfg.rs` — Add `macos_continue_if_no_devs_found` field and parsing
- `src/kanata/mod.rs` — Widen `continue_if_no_devices` cfg gate to include macOS
- `src/kanata/macos.rs` — Thread the parameter through the event loop, adjust startup log messages
- `src/oskbd/macos.rs` — Core logic: `register_devices_with_deferred()`, `poll_for_devices()`, deferred grab state
- `docs/config.adoc` — New documentation section with example

## Test plan

- [x] All 237 existing tests pass
- [x] `cargo fmt` and `cargo clippy` clean
- [x] Builds on macOS (release mode with cmd,tcp_server features)
- [ ] Manual: start kanata with `macos-dev-names-include` pointing to a disconnected BT keyboard, verify it waits and grabs on connection
- [ ] Manual: verify normal operation (device connected at startup) is unaffected with flag both on and off

Relates to #1982