### PR TITLE
Feat/macos jis keys int lang

### DIFF
--- a/parser/src/keys/macos.rs
+++ b/parser/src/keys/macos.rs
@@ -536,9 +536,25 @@ impl TryFrom<OsCode> for PageCode {
                 page: 0x07,
                 code: 0x87,
             }),
+            OsCode::KEY_KATAKANAHIRAGANA => Ok(PageCode {
+                page: 0x07,
+                code: 0x88,
+            }),
             OsCode::KEY_YEN => Ok(PageCode {
                 page: 0x07,
                 code: 0x89,
+            }),
+            OsCode::KEY_HENKAN => Ok(PageCode {
+                page: 0x07,
+                code: 0x8A,
+            }),
+            OsCode::KEY_MUHENKAN => Ok(PageCode {
+                page: 0x07,
+                code: 0x8B,
+            }),
+            OsCode::KEY_KPJPCOMMA => Ok(PageCode {
+                page: 0x07,
+                code: 0x8C,
             }),
             OsCode::KEY_HANGEUL => Ok(PageCode {
                 page: 0x07,
@@ -547,6 +563,18 @@ impl TryFrom<OsCode> for PageCode {
             OsCode::KEY_HANJA => Ok(PageCode {
                 page: 0x07,
                 code: 0x91,
+            }),
+            OsCode::KEY_KATAKANA => Ok(PageCode {
+                page: 0x07,
+                code: 0x92,
+            }),
+            OsCode::KEY_HIRAGANA => Ok(PageCode {
+                page: 0x07,
+                code: 0x93,
+            }),
+            OsCode::KEY_ZENKAKUHANKAKU => Ok(PageCode {
+                page: 0x07,
+                code: 0x94,
             }),
             OsCode::KEY_ALTERASE => Ok(PageCode {
                 page: 0x07,
@@ -1225,8 +1253,24 @@ impl TryFrom<PageCode> for OsCode {
             } => Ok(OsCode::KEY_RO),
             PageCode {
                 page: 0x07,
+                code: 0x88,
+            } => Ok(OsCode::KEY_KATAKANAHIRAGANA),
+            PageCode {
+                page: 0x07,
                 code: 0x89,
             } => Ok(OsCode::KEY_YEN),
+            PageCode {
+                page: 0x07,
+                code: 0x8A,
+            } => Ok(OsCode::KEY_HENKAN),
+            PageCode {
+                page: 0x07,
+                code: 0x8B,
+            } => Ok(OsCode::KEY_MUHENKAN),
+            PageCode {
+                page: 0x07,
+                code: 0x8C,
+            } => Ok(OsCode::KEY_KPJPCOMMA),
             PageCode {
                 page: 0x07,
                 code: 0x90,
@@ -1235,6 +1279,18 @@ impl TryFrom<PageCode> for OsCode {
                 page: 0x07,
                 code: 0x91,
             } => Ok(OsCode::KEY_HANJA),
+            PageCode {
+                page: 0x07,
+                code: 0x92,
+            } => Ok(OsCode::KEY_KATAKANA),
+            PageCode {
+                page: 0x07,
+                code: 0x93,
+            } => Ok(OsCode::KEY_HIRAGANA),
+            PageCode {
+                page: 0x07,
+                code: 0x94,
+            } => Ok(OsCode::KEY_ZENKAKUHANKAKU),
             PageCode {
                 page: 0x07,
                 code: 0x99,


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Add bidirectional HID Usage ↔ `OsCode` mappings on macOS for seven JIS keys that were previously unhandled:

| HID Usage (page 0x07) | OsCode |
|---|---|
| `0x88` International2 | `KEY_KATAKANAHIRAGANA` |
| `0x8A` International4 | `KEY_HENKAN` (変換) |
| `0x8B` International5 | `KEY_MUHENKAN` (無変換) |
| `0x8C` International6 | `KEY_KPJPCOMMA` |
| `0x92` LANG3 | `KEY_KATAKANA` |
| `0x93` LANG4 | `KEY_HIRAGANA` |
| `0x94` LANG5 | `KEY_ZENKAKUHANKAKU` |

PC-style Japanese keyboards send these HID usages for 無変換 / 変換 / カタカナ-ひらがな / 半角-全角 etc. Before this change, `TryFrom<PageCode> for OsCode` and `TryFrom<OsCode> for PageCode` in `parser/src/keys/macos.rs` had no arms for them, so `KeyEvent::try_from(InputEvent)` returned `Err` and `src/kanata/macos.rs` fell into the `"{event:?} is unrecognized!"` branch, writing the raw event straight back to the output. As a result the keys could neither be remapped on input nor produced on output — `defsrc mhnk` etc. silently did nothing on macOS.

The fix is purely additive: only previously-`Err` arms gain `Ok` values, and the HID usage IDs are reserved by the USB HID spec for these exact JIS keys, so no existing mapping is affected. Keys not listed in the user's `defsrc` still take the unchanged passthrough path via the `MAPPED_KEYS` check.

The existing `0x90` / `0x91` (LANG1 / LANG2) entries that the JIS Eisu / Kana keys on Apple keyboards send are intentionally left as-is (mapped to `KEY_HANGEUL` / `KEY_HANJA` — the canonical Linux names for those HID usages, which Korean Hangul / Hanja also use).

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A — these key names (`mhnk`/`muhenkan`/`ncnv`, `hnk`/`henkan`, etc.) are already accepted by the parser and documented implicitly via the mapping tables; the change only makes the existing names actually function on macOS.
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A — same reason; no new config surface.
- Update error messages
  - [x] N/A — no user-facing error paths changed. The previous `"{event:?} is unrecognized!"` debug log was an internal symptom of the missing mappings and is no longer reached for these keys.
- Added tests, or did manual testing
  - [x] Yes — manual testing on Apple Silicon (macOS 15, M-series) with a PC-style Japanese keyboard: built `cargo build --release --target aarch64-apple-darwin`, installed over the running binary, and confirmed that `(defsrc mhnk)` / `(defsrc hnk)` mappings now fire and that the keys can also be emitted as output. Also ran `cargo test -p kanata-parser` — all 114 tests pass, including the existing `roundtrip_oscode_keycode`.
