### PR TITLE
doc: clarify tap-hold-release-keys in comment

### DIFF
--- a/cfg_samples/home-row-mod-advanced.kbd
+++ b/cfg_samples/home-row-mod-advanced.kbd
@@ -2,7 +2,7 @@
 ;; Some of the changes from the basic example:
 ;; - when a home row mod activates tap, the home row mods are disabled
 ;;   while continuing to type rapidly
-;; - tap-hold-release helps make the hold action more responsive
+;; - tap-hold-release-keys helps make the hold action more responsive
 ;; - pressing another key on the same half of the keyboard
 ;;   as the home row mod will activate an early tap action
 ;;


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Clarify that the `home-row-mod-advanced.kbd` sample config uses `tap-hold-release-keys`.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes or N/A
- Update error messages
  - [x] Yes or N/A
- Added tests, or did manual testing
  - [x] Yes
