### PR TITLE
fix(macos): use IOHIDSetModifierLockState exclusively for caps lock output

### DIFF
--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -1065,9 +1065,9 @@ impl KbdOut {
         })
     }
 
-    fn write_caps_lock(&mut self, value: u64) -> Result<(), io::Error> {
+    fn sync_caps_lock_led(&mut self, value: u64) {
         if value != KeyValue::Press as u64 {
-            return Ok(());
+            return;
         }
 
         let next_state = self.caps_lock_state.unwrap_or_else(|| {
@@ -1079,15 +1079,17 @@ impl KbdOut {
             })
         }) ^ true;
 
-        set_hid_caps_lock_state(next_state)?;
-        self.caps_lock_state = Some(next_state);
-        Ok(())
+        if let Err(e) = set_hid_caps_lock_state(next_state) {
+            log::warn!("failed to sync Caps Lock LED: {e}");
+        } else {
+            self.caps_lock_state = Some(next_state);
+        }
     }
 
     pub fn write(&mut self, event: InputEvent) -> Result<(), io::Error> {
         if event.page == 0x07 && event.code == 0x39 {
-            log::debug!("Attempting to set Caps Lock state from {event:?}");
-            return self.write_caps_lock(event.value);
+            log::debug!("Attempting to sync Caps Lock LED from {event:?}");
+            self.sync_caps_lock_led(event.value);
         }
 
         let mut devent = event.into();

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -1065,31 +1065,28 @@ impl KbdOut {
         })
     }
 
-    fn sync_caps_lock_led(&mut self, value: u64) {
+    fn write_caps_lock(&mut self, value: u64) -> Result<(), io::Error> {
         if value != KeyValue::Press as u64 {
-            return;
+            return Ok(());
         }
 
-        let next_state = self.caps_lock_state.unwrap_or_else(|| {
-            get_hid_caps_lock_state().unwrap_or_else(|| {
-                log::warn!(
-                    "could not read current Caps Lock state before toggle; assuming it is off"
-                );
-                false
-            })
-        }) ^ true;
+        let next_state = !self.caps_lock_state.unwrap_or(false);
 
-        if let Err(e) = set_hid_caps_lock_state(next_state) {
-            log::warn!("failed to sync Caps Lock LED: {e}");
-        } else {
-            self.caps_lock_state = Some(next_state);
-        }
+        // Use IOHIDSetModifierLockState instead of the VirtualHID path for caps
+        // lock. macOS sends LED output reports to the originating HID device;
+        // the DriverKit virtual keyboard has no physical LED, so the physical
+        // keyboard LED would never update. IOHIDSetModifierLockState sets both
+        // the system modifier state (so apps see correct case) and drives the
+        // LED on the physical keyboard.
+        set_hid_caps_lock_state(next_state)?;
+        self.caps_lock_state = Some(next_state);
+        Ok(())
     }
 
     pub fn write(&mut self, event: InputEvent) -> Result<(), io::Error> {
         if event.page == 0x07 && event.code == 0x39 {
-            log::debug!("Attempting to sync Caps Lock LED from {event:?}");
-            self.sync_caps_lock_led(event.value);
+            log::debug!("Caps Lock output: using IOHIDSetModifierLockState path for {event:?}");
+            return self.write_caps_lock(event.value);
         }
 
         let mut devent = event.into();


### PR DESCRIPTION
## Summary

- Fixes a regression from #2069 where caps lock remapping stopped working on macOS
- The caps lock LED sync in `write()` was missing an early return, causing caps lock events to be sent through both `IOHIDSetModifierLockState` and VirtualHID — the double-send toggled state twice, effectively making caps lock a no-op
- Now caps lock output events early-return through `IOHIDSetModifierLockState` only, which correctly drives both the system modifier state and the physical keyboard LED

## Why IOHIDSetModifierLockState instead of VirtualHID?

macOS routes LED output reports to the originating HID device. Since the DriverKit virtual keyboard has no physical LED, the physical keyboard LED never updates via the VirtualHID path. `IOHIDSetModifierLockState` sets both the modifier state (so apps see correct case) and drives the LED on the physical keyboard.

## Test plan

- [x] Verified `IOHIDSetModifierLockState` controls the physical LED with a standalone C test program
- [x] `(defsrc caps) (deflayer base caps)` — caps lock toggles LED and produces uppercase
- [x] `(defsrc caps) (deflayer base esc)` — produces escape, LED does not toggle
- [x] `(defsrc a) (deflayer base b)` with `process-unmapped-keys yes` — basic sanity check