### PR TITLE
feat: last-cmd-status operator in switch

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2976,6 +2976,10 @@ matches `$device-id`. A recency of 1 is the most recent device
 that sent an event. The max recency is 8.
 Device IDs are defined via <<definputdevices,`definputdevices`>>.
 Currently supported on macOS only.
+
+| `last-cmd-status`
+| Evaluates to true if the last cmd returned given `status-code`.
+Currently works only with `cmd-output-keys` and doesn't work with `cmd` and `cmd-log`.
 |===
 
 **Description**

--- a/keyberon/src/action.rs
+++ b/keyberon/src/action.rs
@@ -413,6 +413,8 @@ where
     /// Disregard the entire layer stack, i.e. the current base layer and any while-held layers,
     /// and select the action from `Layout.src_keys`.
     Src,
+    /// Keyberon version of cmd.
+    CmdBlocking(&'a [&'a str]),
 }
 
 impl<T> Action<'_, T> {

--- a/keyberon/src/action/switch.rs
+++ b/keyberon/src/action/switch.rs
@@ -46,11 +46,13 @@ const OR_VAL: u16 = 0x1000;
 const AND_VAL: u16 = 0x2000;
 const NOT_VAL: u16 = 0x3000;
 
+// Values above KEY_MAX
 const INPUT_VAL: u16 = 851;
 const HISTORICAL_INPUT_VAL: u16 = 852;
 const LAYER_VAL: u16 = 853;
 const BASE_LAYER_VAL: u16 = 854;
 const HISTORICAL_DEVICE_VAL: u16 = 855;
+const LAST_CMD_STATUS: u16 = 856;
 
 // Binary values:
 // 0b0100 ...
@@ -90,6 +92,7 @@ enum OpCodeType {
     Layer(u16),
     BaseLayer(u16),
     HistoricalDevice(HistoricalDevice),
+    LastCmdStatus(u16),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -150,6 +153,7 @@ impl<'a, T> Switch<'a, T> {
         layers: L,
         default_layer: u16,
         device_history: D,
+        last_cmd_status: Option<i32>,
     ) -> SwitchActions<'a, T, A1, A2, H1, H2, L, D>
     where
         A1: Iterator<Item = KeyCode> + Clone,
@@ -169,11 +173,12 @@ impl<'a, T> Switch<'a, T> {
             default_layer,
             device_history,
             case_index: 0,
+            last_cmd_status,
         }
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 /// Iterator returned by `Switch::actions`.
 pub struct SwitchActions<'a, T, A1, A2, H1, H2, L, D>
 where
@@ -193,6 +198,7 @@ where
     default_layer: u16,
     device_history: D,
     case_index: usize,
+    last_cmd_status: Option<i32>,
 }
 
 impl<'a, T, A1, A2, H1, H2, L, D> Iterator for SwitchActions<'a, T, A1, A2, H1, H2, L, D>
@@ -218,6 +224,7 @@ where
                 self.layers.clone(),
                 self.default_layer,
                 self.device_history.clone(),
+                self.last_cmd_status,
             ) {
                 let ret_ac = case.1;
                 match case.2 {
@@ -341,6 +348,11 @@ impl OpCode {
         )
     }
 
+    /// Return OpCodes specifying last-cmd-status check.
+    pub fn new_last_cmd_status(status_code: u16) -> (Self, Self) {
+        (Self(LAST_CMD_STATUS), Self(status_code))
+    }
+
     /// Return the interpretation of this `OpCode`.
     fn opcode_type(self, next: Option<OpCode>) -> OpCodeType {
         if self.0 < KEY_MAX {
@@ -360,6 +372,7 @@ impl OpCode {
                         .expect("device ID must be nonzero"),
                     how_far_back: ((op2.0 >> 8) & 0x7) as u8,
                 }),
+                LAST_CMD_STATUS => OpCodeType::LastCmdStatus(op2.0),
                 _ => unreachable!("unexpected opcode {self:?}"),
             }
         } else {
@@ -407,6 +420,7 @@ fn evaluate_boolean(
     layers: impl Iterator<Item = u16> + Clone,
     default_layer: u16,
     device_history: impl Iterator<Item = Option<NonZeroU8>> + Clone,
+    last_cmd_status: Option<i32>,
 ) -> bool {
     let mut ret = true;
     let mut current_index = 0;
@@ -507,6 +521,19 @@ fn evaluate_boolean(
                     .and_then(|d| d.map(|d| d == hd.device_id))
                     .unwrap_or(false);
             }
+            OpCodeType::LastCmdStatus(status) => {
+                // opcode has size 2
+                current_index += 1;
+                ret = match last_cmd_status {
+                    Some(last_status_i32) => {
+                        match std::convert::TryInto::<u16>::try_into(last_status_i32) {
+                            Ok(last_status_u16) => last_status_u16 == status,
+                            Err(_) => false,
+                        }
+                    }
+                    None => false,
+                }
+            }
         };
         if current_op == Not {
             ret = !ret;
@@ -536,6 +563,7 @@ fn evaluate_bool_test(opcodes: &[OpCode], keycodes: impl Iterator<Item = KeyCode
         [].iter().copied(),
         0,
         core::iter::empty(),
+        None,
     )
 }
 
@@ -796,6 +824,7 @@ fn switch_fallthrough() {
         [].iter().copied(),
         0,
         core::iter::empty(),
+        None,
     );
     assert_eq!(actions.next(), Some(&Action::<()>::KeyCode(KeyCode::A)));
     assert_eq!(actions.next(), Some(&Action::<()>::KeyCode(KeyCode::B)));
@@ -818,6 +847,7 @@ fn switch_break() {
         [].iter().copied(),
         0,
         core::iter::empty(),
+        None,
     );
     assert_eq!(actions.next(), Some(&Action::<()>::KeyCode(KeyCode::A)));
     assert_eq!(actions.next(), None);
@@ -847,6 +877,7 @@ fn switch_no_actions() {
         [].iter().copied(),
         0,
         core::iter::empty(),
+        None,
     );
     assert_eq!(actions.next(), None);
 }
@@ -867,6 +898,7 @@ fn switch_device_history_match() {
         [].iter().copied(),
         0,
         [Some(id1)].iter().copied(),
+        None,
     ));
     // Non-matching device ID
     assert!(!evaluate_boolean(
@@ -878,6 +910,7 @@ fn switch_device_history_match() {
         [].iter().copied(),
         0,
         [Some(id2)].iter().copied(),
+        None,
     ));
     // Empty device history
     assert!(!evaluate_boolean(
@@ -889,6 +922,7 @@ fn switch_device_history_match() {
         [].iter().copied(),
         0,
         core::iter::empty(),
+        None,
     ));
 }
 
@@ -909,6 +943,7 @@ fn switch_device_history_recency() {
         [].iter().copied(),
         0,
         history.iter().copied(),
+        None,
     ));
     // Check second most recent (recency 2 → how_far_back 1) is id2
     let (op1, op2) = OpCode::new_device_history(id2, 1);
@@ -921,6 +956,7 @@ fn switch_device_history_recency() {
         [].iter().copied(),
         0,
         history.iter().copied(),
+        None,
     ));
     // Wrong device at recency 1
     let (op1, op2) = OpCode::new_device_history(id1, 0);
@@ -933,6 +969,7 @@ fn switch_device_history_recency() {
         [].iter().copied(),
         0,
         history.iter().copied(),
+        None,
     ));
 }
 
@@ -964,6 +1001,7 @@ fn switch_device_history_unknown_device() {
         [].iter().copied(),
         0,
         history.iter().copied(),
+        None,
     ));
     // Looking for id1 at position 1 (where None is) should NOT match
     let (op1, op2) = OpCode::new_device_history(id1, 1);
@@ -976,6 +1014,7 @@ fn switch_device_history_unknown_device() {
         [].iter().copied(),
         0,
         history.iter().copied(),
+        None,
     ));
 }
 
@@ -1036,6 +1075,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         0,
         core::iter::empty(),
+        None,
     ));
     assert!(evaluate_boolean(
         opcode_true2.as_slice(),
@@ -1046,6 +1086,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         0,
         core::iter::empty(),
+        None,
     ));
     assert!(!evaluate_boolean(
         opcode_false.as_slice(),
@@ -1056,6 +1097,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         0,
         core::iter::empty(),
+        None,
     ));
     assert!(!evaluate_boolean(
         opcode_false2.as_slice(),
@@ -1066,6 +1108,7 @@ fn switch_historical_1() {
         [].iter().copied(),
         0,
         core::iter::empty(),
+        None,
     ));
 }
 
@@ -1152,6 +1195,7 @@ fn switch_historical_bools() {
                 [].iter().copied(),
                 0,
                 core::iter::empty(),
+                None,
             ),
             expectation
         );
@@ -1269,6 +1313,7 @@ fn switch_historical_ticks_since() {
                 [].iter().copied(),
                 0,
                 core::iter::empty(),
+                None,
             ),
             expectation
         );
@@ -1504,6 +1549,7 @@ fn switch_inputs() {
                 [].iter().copied(),
                 0,
                 core::iter::empty(),
+                None,
             ),
             expectation
         );
@@ -1573,6 +1619,7 @@ fn switch_historical_inputs() {
                 [].iter().copied(),
                 0,
                 core::iter::empty(),
+                None,
             ),
             expectation
         );
@@ -1583,4 +1630,46 @@ fn switch_historical_inputs() {
     test(&opcodes_false_or, false);
     test(&opcodes_true_or1, true);
     test(&opcodes_true_or2, true);
+}
+
+#[test]
+fn switch_last_cmd_status() {
+    let (op1, op2) = OpCode::new_last_cmd_status(1);
+    let opcodes = [op1, op2];
+    // matching
+    assert!(evaluate_boolean(
+        &opcodes,
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        core::iter::empty(),
+        Some(1),
+    ));
+    // not matching
+    assert!(!evaluate_boolean(
+        &opcodes,
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        core::iter::empty(),
+        Some(3),
+    ));
+    // 2nd not matching
+    assert!(!evaluate_boolean(
+        &opcodes,
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        [].iter().copied(),
+        0,
+        core::iter::empty(),
+        Some(0),
+    ));
 }

--- a/keyberon/src/cmd.rs
+++ b/keyberon/src/cmd.rs
@@ -1,0 +1,29 @@
+// const LP: &str = "cmd-out:";
+
+// #[cfg(not(feature = "simulated_output"))]
+pub(super) fn cmd_run_and_check_status(cmd_and_args: &[&str]) -> i32 {
+    let mut args = cmd_and_args.iter();
+    let mut cmd = std::process::Command::new(
+        args.next()
+            .expect("parsing should have forbidden empty cmd"),
+    );
+    for arg in args {
+        cmd.arg(arg);
+    }
+    let output = match cmd.output() {
+        Ok(o) => o,
+        Err(_e) => {
+            // log::error!("Failed to execute cmd: {e}");
+            return -1;
+        }
+    };
+    // log::debug!("{LP} stdout: {}", String::from_utf8_lossy(&output.stderr));
+    // log::debug!("{LP} stderr: {}", String::from_utf8_lossy(&output.stderr));
+    output.status.code().unwrap_or(-1)
+}
+
+// #[cfg(feature = "simulated_output")]
+// pub(super) fn keys_for_cmd_output(cmd_and_args: &[&str]) -> impl Iterator<Item = Item> {
+//     println!("cmd-keys:{cmd_and_args:?}");
+//     [].iter().copied()
+// }

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -28,6 +28,7 @@ use contextual_execution::*;
 use std::num::NonZeroU16;
 
 use crate::chord::*;
+use crate::cmd::cmd_run_and_check_status;
 use crate::key_code::KeyCode;
 use crate::{action::*, multikey_buffer::MultiKeyBuffer};
 use arraydeque::ArrayDeque;
@@ -2460,6 +2461,11 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
 
                 self.rpt_action = Some(action);
                 return custom;
+            }
+            CmdBlocking(cmd_with_args) => {
+                let status_code = cmd_run_and_check_status(cmd_with_args);
+                // log::debug!("status_code: {status_code}");
+                self.last_cmd_status = Some(status_code);
             }
         }
         CustomEvent::NoEvent

--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -144,6 +144,7 @@ where
     /// Only stores data when the `tap_hold_tracker` feature is enabled;
     /// otherwise this is a zero-sized no-op.
     pub tap_hold_tracker: crate::tap_hold_tracker::TapHoldTracker,
+    pub last_cmd_status: Option<i32>,
 }
 
 pub use crate::tap_hold_tracker::{HoldActivatedInfo, TapActivatedInfo};
@@ -269,13 +270,11 @@ pub enum CustomEvent<'a, T: 'a> {
 impl<T> CustomEvent<'_, T> {
     /// Update an event according to a new event.
     ///
-    ///The event can only be modified in the order `NoEvent < Press <
-    /// Release`
+    /// The event can only be updated in the following direction: `NoEvent -> Press -> Release`
     fn update(&mut self, e: Self) {
         use CustomEvent::*;
         match (&e, &self) {
-            (Release(_), NoEvent) | (Release(_), Press(_)) => *self = e,
-            (Press(_), NoEvent) => *self = e,
+            (Release(_), NoEvent) | (Release(_), Press(_)) | (Press(_), NoEvent) => *self = e,
             _ => (),
         }
     }
@@ -1239,6 +1238,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
             device_history: ArrayDeque::new(),
             contextual_execution: ContextualExecution::new(),
             tap_hold_tracker: Default::default(),
+            last_cmd_status: Default::default(),
         }
     }
     pub fn new_with_trans_action_settings(
@@ -2429,6 +2429,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
                 let historical_coords = self.historical_inputs.iter_hevents();
                 let layers = self.trans_resolution_layer_order().into_iter();
                 let mut action_queue: ActionQueue<T> = Default::default();
+
                 for ac in sw.actions(
                     active_keys,
                     active_coords,
@@ -2439,6 +2440,7 @@ impl<'a, const C: usize, const R: usize, T: 'a + Copy + std::fmt::Debug> Layout<
                     // assertions.
                     self.default_layer as u16,
                     self.device_history.iter().copied(),
+                    self.last_cmd_status,
                 ) {
                     action_queue.push_back(Some((coord, delay, ac, layer_stack.clone().collect())));
                 }

--- a/keyberon/src/lib.rs
+++ b/keyberon/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod action;
 pub mod chord;
+pub mod cmd;
 pub mod key_code;
 pub mod layout;
 mod multikey_buffer;

--- a/parser/src/cfg/chord_v1.rs
+++ b/parser/src/cfg/chord_v1.rs
@@ -201,6 +201,7 @@ pub(crate) fn find_chords_coords(
         | Action::CancelSequences
         | Action::ReleaseState(_)
         | Action::OneShotIgnoreEventsTicks(_)
+        | Action::CmdBlocking(_)
         | Action::Custom(_) => {}
         Action::HoldTap(HoldTapAction { tap, hold, .. }) => {
             find_chords_coords(chord_groups, coord, tap);
@@ -257,6 +258,7 @@ pub(crate) fn fill_chords(
         | Action::CancelSequences
         | Action::ReleaseState(_)
         | Action::OneShotIgnoreEventsTicks(_)
+        | Action::CmdBlocking(_)
         | Action::Custom(_) => None,
         Action::HoldTap(&hta @ HoldTapAction { tap, hold, .. }) => {
             let new_tap = fill_chords(chord_groups, &tap, s);

--- a/parser/src/cfg/cmd.rs
+++ b/parser/src/cfg/cmd.rs
@@ -14,6 +14,8 @@ pub(crate) enum CmdType {
     /// Execute command and set clipboard save id to output.
     /// Clipboard save id content is passed as stdin to the command.
     ClipboardSaveSet,
+    // In-keyberon blocking cmd.
+    KeyberonBlocking,
 }
 
 // Parse cmd, but there are 2 arguments before specifying normal log and error log
@@ -98,15 +100,13 @@ pub(crate) fn parse_cmd(
         }
         let cmds = cmd.into_iter().map(|v| s.a.sref_str(v)).collect();
         let cmds = s.a.sref_vec(cmds);
-        custom(
-            match cmd_type {
-                CmdType::Standard => CustomAction::Cmd(cmds),
-                CmdType::OutputKeys => CustomAction::CmdOutputKeys(cmds),
-                CmdType::ClipboardSet => CustomAction::ClipboardCmdSet(cmds),
-                CmdType::ClipboardSaveSet => unreachable!(),
-            },
-            &s.a,
-        )
+        match cmd_type {
+            CmdType::Standard => custom(CustomAction::Cmd(cmds), &s.a),
+            CmdType::OutputKeys => custom(CustomAction::CmdOutputKeys(cmds), &s.a),
+            CmdType::KeyberonBlocking => Ok(s.a.sref(Action::CmdBlocking(s.a.sref(cmds)))),
+            CmdType::ClipboardSet => custom(CustomAction::ClipboardCmdSet(cmds), &s.a),
+            CmdType::ClipboardSaveSet => unreachable!(),
+        }
     }
 }
 

--- a/parser/src/cfg/key_outputs.rs
+++ b/parser/src/cfg/key_outputs.rs
@@ -133,6 +133,7 @@ pub(crate) fn add_key_output_from_action_to_key_pos(
         | Action::RepeatableSequence { .. }
         | Action::CancelSequences
         | Action::OneShotIgnoreEventsTicks(_)
+        | Action::CmdBlocking(_)
         | Action::ReleaseState(_) => {}
     };
 }

--- a/parser/src/cfg/list_actions.rs
+++ b/parser/src/cfg/list_actions.rs
@@ -105,6 +105,7 @@ pub const CMD: &str = "cmd";
 pub const CMD_LOG: &str = "cmd-log";
 pub const PUSH_MESSAGE: &str = "push-msg";
 pub const CMD_OUTPUT_KEYS: &str = "cmd-output-keys";
+pub const CMD_BLOCKING: &str = "cmd-blocking";
 pub const FORK: &str = "fork";
 pub const CAPS_WORD: &str = "caps-word";
 pub const CAPS_WORD_A: &str = "word⇪";
@@ -238,6 +239,7 @@ pub fn is_list_action(ac: &str) -> bool {
         CMD,
         CMD_OUTPUT_KEYS,
         CMD_LOG,
+        CMD_BLOCKING,
         PUSH_MESSAGE,
         FORK,
         CAPS_WORD,

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1647,6 +1647,7 @@ fn parse_action_list(ac: &[SExpr], s: &ParserState) -> Result<&'static KanataAct
         CMD => parse_cmd(&ac[1..], s, CmdType::Standard),
         CMD_OUTPUT_KEYS => parse_cmd(&ac[1..], s, CmdType::OutputKeys),
         CMD_LOG => parse_cmd_log(&ac[1..], s),
+        CMD_BLOCKING => parse_cmd(&ac[1..], s, CmdType::KeyberonBlocking),
         PUSH_MESSAGE => parse_push_message(&ac[1..], s),
         FORK => parse_fork(&ac[1..], s),
         CAPS_WORD | CAPS_WORD_A => {

--- a/parser/src/cfg/switch.rs
+++ b/parser/src/cfg/switch.rs
@@ -88,6 +88,7 @@ pub fn parse_switch_case_bool(
             Layer,
             BaseLayer,
             DeviceHistory,
+            LastCmdStatus,
         }
         #[derive(Copy, Clone)]
         enum InputType {
@@ -115,6 +116,7 @@ pub fn parse_switch_case_bool(
                 "layer" => Some(AllowedListOps::Layer),
                 "base-layer" => Some(AllowedListOps::BaseLayer),
                 "device-history" => Some(AllowedListOps::DeviceHistory),
+                "last-cmd-status" => Some(AllowedListOps::LastCmdStatus),
                 _ => None,
             })
             .ok_or_else(|| {
@@ -122,7 +124,7 @@ pub fn parse_switch_case_bool(
                     op_expr,
                     "lists inside switch logic must begin with one of:\n\
                     or | and | not | key-history | key-timing\n\
-                    | input | input-history | layer | base-layer | device-history",
+                    | input | input-history | layer | base-layer | device-history | last-cmd-status",
                 )
             })?;
 
@@ -298,6 +300,18 @@ pub fn parse_switch_case_bool(
                 }
                 let device_recency = parse_u8_with_range(&l[2], s, "device-recency", 1, 8)? - 1;
                 let (op1, op2) = OpCode::new_device_history(id, device_recency);
+                ops.extend(&[op1, op2]);
+                Ok(())
+            }
+            AllowedListOps::LastCmdStatus => {
+                if l.len() != 2 {
+                    bail_expr!(
+                        op_expr,
+                        "last-cmd-status must have 1 parameter: status-code"
+                    );
+                }
+                let status_code = parse_u16(&l[1], s, "status-code")?;
+                let (op1, op2) = OpCode::new_last_cmd_status(status_code);
                 ops.extend(&[op1, op2]);
                 Ok(())
             }

--- a/src/kanata/cmd.rs
+++ b/src/kanata/cmd.rs
@@ -187,7 +187,7 @@ fn try_parse_chorded_list<'a>(
 }
 
 #[cfg(not(feature = "simulated_output"))]
-pub(super) fn keys_for_cmd_output(cmd_and_args: &[&str]) -> impl Iterator<Item = Item> {
+pub(super) fn keys_for_cmd_output(cmd_and_args: &[&str]) -> (impl Iterator<Item = Item>, i32) {
     let mut args = cmd_and_args.iter();
     let mut cmd = std::process::Command::new(
         args.next()
@@ -200,12 +200,12 @@ pub(super) fn keys_for_cmd_output(cmd_and_args: &[&str]) -> impl Iterator<Item =
         Ok(o) => o,
         Err(e) => {
             log::error!("Failed to execute cmd: {e}");
-            return empty();
+            return (empty(), -1);
         }
     };
     log::debug!("{LP} stderr: {}", String::from_utf8_lossy(&output.stderr));
     let stdout = String::from_utf8_lossy(&output.stdout);
-    match parse(&stdout, "cmd") {
+    let out_keys = match parse(&stdout, "cmd") {
         Ok(lists) => match lists.len() {
             0 => {
                 log::warn!("{LP} got zero top-level S-expression from cmd, expected 1:\n{stdout}");
@@ -226,13 +226,17 @@ pub(super) fn keys_for_cmd_output(cmd_and_args: &[&str]) -> impl Iterator<Item =
             );
             empty()
         }
-    }
+    };
+    (out_keys, output.status.code().unwrap_or(-1))
 }
 
 #[cfg(feature = "simulated_output")]
-pub(super) fn keys_for_cmd_output(cmd_and_args: &[&str]) -> impl Iterator<Item = Item> {
+pub(super) fn keys_for_cmd_output(cmd_and_args: &[&str]) -> (impl Iterator<Item = Item>, i32) {
     println!("cmd-keys:{cmd_and_args:?}");
-    [].iter().copied()
+    match cmd_and_args.first() {
+        Some(&"true") => ([].iter().copied(), 0),
+        _ => ([].iter().copied(), 1),
+    }
 }
 
 #[cfg(feature = "simulated_output")]

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1654,7 +1654,10 @@ impl Kanata {
                             // A delay here, as in KeyAction::Delay, will pause the entire
                             // state machine loop. That is _probably_ OK, but ideally this
                             // would be done in a separate thread or somehow
-                            for key_action in keys_for_cmd_output(_cmd) {
+                            let (key_actions, status_code) = keys_for_cmd_output(_cmd);
+                            log::debug!("status_code: {status_code}");
+                            layout.last_cmd_status = Some(status_code);
+                            for key_action in key_actions {
                                 match key_action {
                                     KeyAction::Press(osc) => press_key(&mut self.kbd_out, osc)?,
                                     KeyAction::Release(osc) => {

--- a/src/oskbd/linux.rs
+++ b/src/oskbd/linux.rs
@@ -690,9 +690,8 @@ pub fn discover_devices(
             )
         })
         .filter(|pd| {
-            let is_input = is_input_device(&pd.0, device_detect_mode);
             (match include_names {
-                None => is_input,
+                None => is_input_device(&pd.0, device_detect_mode),
                 Some(include_names) => {
                     let name = pd.0.name().unwrap_or("");
                     if include_names.iter().any(|include| name == include) {


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

An attempt at implementing the `cmd-fork` idea from https://github.com/jtroo/kanata/issues/2062, but as a `switch` check - `(switch (last-cmd-status 0) ...)`, similar to what was suggested in https://github.com/jtroo/kanata/pull/2068#issuecomment-4468640016).
Currently only for `cmd-output-keys` action (edit: also for `cmd-blocking` action), as it's synchronous, so was simpler to implement for.

~~This impl works only partially. Unfortunately not in a way that's usable with `tap-hold` (which was my original use case). It seems impossible to *in a single keypress* to trigger cmd and *afterwards* do the check, while working with `tap-hold`.
Here are all failed attempts:~~

[edit: I made it work with a new `cmd-blocking` action, see the comment below]


<details>
<summary>cmd-output-keys + switch in macro</summary>

```
;; Doesn't work because cmd is not allowed in macro.

(defalias a1
  (macro
    (cmd-output-keys bash -c "exit 0") fallthrough
    (switch
      ((last-cmd-status 0)) (tap-hold 0 500 a b) break
      () c break
    )
  )
)
```

</details>



<details>
<summary>inline cmd inside switch</summary>

```
;; This doesn't work because `evaluate_boolean` pre-determines the branches
;; taken in a given switch run. 
;; This happens before any action inside the switch is ran.
;; Because of this the order will be: last-cmd-status -> cmd run.  

(defalias a1
  (switch
    () (cmd-output-keys bash -c "exit 0") fallthrough
    ((last-cmd-status 0)) (tap-hold 0 500 a b) break
    () c break
  )
)
```

</details>



<details>
<summary>cmd-output-keys + switch in multi</summary>

```
;; Doesn't work because the cmd would run happen *after* the `switch`, 
due to the longstanding issue that all `CustomAction`s being ran at the end of `macro`.

(defalias a1
  (multi
    (cmd-output-keys bash -c "exit 0") fallthrough
    (switch
      ((last-cmd-status 0)) (tap-hold 0 500 a b) break
      () c break
    )
  )
)
```

</details>



<details>
<summary>cmd-output-keys + switch + vkeys + multi</summary>

```
;; This doesn't work because tap-hold within vkeys is broken,
;; always timing out and triggering hold action.

(deffakekeys vk_cmd1 (cmd-output-keys bash -c "exit 0"))
(deffakekeys
  vk_switch1 (switch
    ((last-cmd-status 0)) (tap-hold 0 500 a b) break
    () c break
  )
)
(defalias a1
  (multi
    (on-press tap-vkey vk_cmd1)
    (on-press press-vkey vk_switch1)
    (on-release release-vkey vk_switch1)
  )
)
```

</details>

I'm not exactly sure which direction to further take this to make it work, any suggestions appreciated.

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [ ] Yes
