### PR TITLE
fix(macos): restore catch-all device registration for Bluetooth keyboards

### DIFF
--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -643,21 +643,17 @@ impl KbdIn {
 
         // Based on the definition of include and exclude names, they should never be used together.
         // Kanata config parser should probably enforce this.
+        let has_device_filter = include_names.is_some() || exclude_names.is_some();
         let device_names = if let Some(ref included_names) = include_names {
             validate_and_register_devices(included_names)
-        } else {
-            // No include list: enumerate every device the driverkit iterator
-            // sees, drop any that are known-problematic (empty names, Sidecar
-            // virtual keyboards, etc., see `is_skipped_virtual_device`), then
-            // apply the user's exclude list on top. This replaces the former
-            // `register_device("")` catch-all, which silently seized Sidecar's
-            // virtual HID device and could abort the process during grab
-            // (issue #1342).
-            let excluded = exclude_names.unwrap_or_default();
+        } else if let Some(ref excluded_names) = exclude_names {
+            // Exclude list: enumerate devices, filter out excluded and
+            // known-problematic virtual devices (Sidecar, etc.), then
+            // register the remainder individually.
             let kb_list = fetch_devices();
             let devices_to_include = kb_list
                 .iter()
-                .filter(|k| !excluded.iter().any(|n| *k == n.as_str()))
+                .filter(|k| !excluded_names.iter().any(|n| *k == n.as_str()))
                 .filter(|k| !is_skipped_virtual_device(&k.product_key))
                 .map(|k| {
                     if k.product_key.trim().is_empty() {
@@ -669,9 +665,11 @@ impl KbdIn {
                 .collect::<Vec<String>>();
 
             validate_and_register_devices(&devices_to_include)
+        } else {
+            vec![]
         };
 
-        if !device_names.is_empty() {
+        if !device_names.is_empty() || (!has_device_filter && register_device("")) {
             if grab() {
                 let device_hash_to_id = build_device_hash_to_id_map(input_devices);
                 Ok(Self {


### PR DESCRIPTION
## Summary

- When no `macos-dev-names-include` or `macos-dev-names-exclude` filter is configured, skip the `fetch_devices()` enumeration and use `register_device("")` to grab all HID devices — restoring the v1.11 default behavior
- The enumerate-and-register-individually path introduced in #2031 filters out problematic virtual devices (Sidecar, etc.) but loses some Bluetooth keyboards somewhere in the pipeline between enumeration and registration
- This caused connected BT keyboards (e.g. Magic Keyboard) to silently stop being grabbed while the internal MacBook keyboard still worked
- The enumeration + virtual-device filtering path is preserved for users who configure `macos-dev-names-include` or `macos-dev-names-exclude`

## Context

Reported by @oschrenk in #1982 — on a MacBook, the internal keyboard works fine but an external Bluetooth Magic Keyboard is not grabbed on master (works on v1.11). The `register_device("")` catch-all was replaced with explicit `fetch_devices()` enumeration in #2031 (Apr 19). Both paths use the same IOKit iterator (`consume_devices` → `get_keyboards_iterator`), so the BT keyboard likely is enumerated but gets lost during kanata's filtering or individual name-based re-registration step.

The fix restores the three-branch structure from before #2031:
1. **Include list set** → enumerate and register only matching devices
2. **Exclude list set** → enumerate all, filter out excluded + virtual devices, register the rest
3. **No filters** → `register_device("")` catch-all grabs everything (v1.11 behavior)

## Tradeoff

Restoring `register_device("")` for the no-filter default means Sidecar's virtual keyboard can be grabbed again, which caused crashes for some users (#1342). However:

- v1.11 shipped with this behavior and Sidecar crashes were not widespread
- Silently dropping Bluetooth keyboards affects more users than the Sidecar edge case
- Users who do use Sidecar can opt into protection by adding `macos-dev-names-exclude ("Sidecar")` to their config

## Test plan

- [x] All existing tests pass
- [x] `cargo fmt` and `cargo clippy` clean
- [ ] Manual: verify Bluetooth keyboard is grabbed when no include/exclude filter is configured
- [ ] Manual: verify internal MacBook keyboard still works alongside BT keyboard
- [ ] Manual: verify `macos-dev-names-exclude` still filters out specified devices