### PR TITLE
docs(readme): remove xcape from Similar Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,6 @@ Other similar projects:
 - [keyberon](https://github.com/TeXitoi/keyberon): Rust `#[no_std]` library intended for keyboard firmware
 - [ktrl](https://github.com/ItayGarin/ktrl): Linux-only keyboard customizer with layers, a TCP server, and audio support
 - [kbremap](https://github.com/timokroeger/kbremap): Windows-only keyboard customizer with layers and unicode
-- [xcape](https://github.com/alols/xcape): Linux-only tap-hold modifiers
 - [karabiner-elements](https://karabiner-elements.pqrs.org/): Mac-only keyboard customizer
 - [capsicain](https://github.com/cajhin/capsicain): Windows-only key remapper with driver-level key interception
 - [keyd](https://github.com/rvaiya/keyd): Linux-only key remapper very similar to QMK, kmonad, and kanata


### PR DESCRIPTION
The github repo was deleted, so add the Internet Archive link.

## Describe your changes. Use imperative present tense.

Replaced https://github.com/alols/xcape with https://web.archive.org/web/20260310021606/https://github.com/alols/xcape.
The last release was in 2016 and the last commit was in 2018, so i don't think it was deleted for some serious reason that requires it to stay a ghost. So use the web archive link.
The other option is to remove the mention of it entirely from the README.

## Checklist

- Add documentation to docs/config.adoc
  - [ ] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [ ] Yes or N/A
- Update error messages
  - [ ] Yes or N/A
- Added tests, or did manual testing
  - [ ] Yes
