### PR TITLE
doc: fix spelling

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -3794,7 +3794,7 @@ you wouldn't want this. Rather than retyping the code with `fork` and
 === if-equal
 
 Within a template you can use the list item `if-equal`
-to have condiditionally-used items within a template.
+to have conditionally-used items within a template.
 
 It accepts a minimum of 2 parameters.
 The first two parameters must be strings and are compared


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Fix spelling.

## Checklist

- Add documentation to docs/config.adoc
  - [X] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [X] Yes or N/A
- Update error messages
  - [X] Yes or N/A
- Added tests, or did manual testing
  - [X] Yes
