### PR TITLE
doc: add example of stale state

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -5614,6 +5614,9 @@ By default, Kanata adds a delay before reading keyboard inputs.
 This helps protect against stale states
 when started from a terminal.
 
+Without this delay, Kanata may interpret any keys you're still holding down when it starts
+as being stuck.
+
 However, this may be undesirable
 when running as a background service.
 


### PR DESCRIPTION
## Add example of a stale state

The current description of the [`--nodelay` command line argument](https://github.com/jtroo/kanata/blob/main/docs/config.adoc#remove-startup-delay--n---nodelay) reads:

> By default, Kanata adds a delay before reading keyboard inputs. This helps protect against stale states when started from a terminal.

However, it doesn't explain what a "stale state" actually is.

This PR clarifies what a stale state is by giving an example of a state the delay protects against.

## Checklist

- Add documentation to docs/config.adoc
  - [X] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [X] Yes or N/A
- Update error messages
  - [X] Yes or N/A
- Added tests, or did manual testing
  - [X] Yes
