### PR TITLE
fix(parser): reject invalid zippy output mappings

### DIFF
--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -336,6 +336,22 @@ fn parse_zippychord_file() {
 }
 
 #[test]
+#[cfg(feature = "zippychord")]
+fn reject_invalid_zippy_output_mapping_arity() {
+    let _lk = lock(&CFG_PARSE_LOCK);
+    let zippy_file: HashMap<String, String> = [("zippy.txt".to_owned(), "ab\tab".to_owned())]
+        .into_iter()
+        .collect();
+
+    for mapping in ["(no-erase)", "(no-erase a b)", "(single-output)"] {
+        let cfg = format!(
+            "(defsrc)\n(deflayer base)\n(defzippy zippy.txt output-character-mappings (a {mapping}))"
+        );
+        assert!(new_from_str(&cfg, zippy_file.clone()).is_err());
+    }
+}
+
+#[test]
 fn disallow_nested_tap_hold() {
     let _lk = lock(&CFG_PARSE_LOCK);
     match new_from_file(&std::path::PathBuf::from("./test_cfgs/nested_tap_hold.kbd"))

--- a/parser/src/cfg/zippychord.rs
+++ b/parser/src/cfg/zippychord.rs
@@ -457,7 +457,7 @@ mod inner {
                                     ZchIoMappingType::NoErase => {
                                         const ERR: &str = "expects a single key or output chord.";
                                         if output_list.len() != 2 {
-                                            anyhow_expr!(&output_list[1], "{NO_ERASE} {ERR}");
+                                            bail_expr!(&mapping_pair[1], "{NO_ERASE} {ERR}");
                                         }
                                         let output =
                                             output_list[1].atom(s.vars()).ok_or_else(|| {
@@ -471,8 +471,8 @@ mod inner {
                                     }
                                     ZchIoMappingType::SingleOutput => {
                                         if output_list.len() < 2 {
-                                            anyhow_expr!(
-                                                &output_list[1],
+                                            bail_expr!(
+                                                &mapping_pair[1],
                                                 "{SINGLE_OUTPUT_MULTI_KEY} expects one or more keys or output chords."
                                             );
                                         }


### PR DESCRIPTION
## Summary

Reject malformed `no-erase` and `single-output` zippychord mappings with parser errors.

Previously, mappings without required output values indexed an empty list and panicked during configuration validation. A `no-erase` mapping with extra values was also accepted instead of rejected.

## Validation

- `cargo test --all --no-default-features`
- `cargo test --all`
- `cargo clippy --all --no-default-features -- -D warnings`
- `cargo clippy --all -- -D warnings`
- `cargo fmt --all --check`
