### PR TITLE
Fix quoting in keyboard matching

### DIFF
--- a/parser/src/cfg/definputdevices.rs
+++ b/parser/src/cfg/definputdevices.rs
@@ -60,6 +60,9 @@ pub fn parse_definputdevices(expr: &[SExpr]) -> Result<Vec<(NonZeroU8, InputDevi
             let prop_val = props[1]
                 .atom(None)
                 .ok_or_else(|| anyhow_expr!(&props[1], "matcher value must be an atom"))?;
+            // Matcher values are commonly written as quoted strings in definputdevices.
+            // Strip those syntax quotes before name matching or numeric/hash parsing.
+            let prop_val = prop_val.trim_atom_quotes();
             match prop_name {
                 "name" => {
                     if matcher.name.is_some() {

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -70,6 +70,35 @@ fn parse_cfg(cfg: &str) -> Result<IntermediateCfg> {
 }
 
 #[test]
+fn definputdevices_trims_quoted_matcher_values() {
+    let _lk = lock(&CFG_PARSE_LOCK);
+    // Quoted names must lose syntax quotes; the hash case also verifies quoted
+    // hex parsing.
+    let cfg = new_from_str(
+        r#"(defcfg)
+            (defsrc a)
+            (deflayer base a)
+            (definputdevices
+              1 ((name "Apple Internal Keyboard / Trackpad"))
+              2 ((name "silakka54") (vendor_id 0xFEED) (product_id 0x1212))
+              3 ((hash "E328037D977386DE")))"#,
+        HashMap::default(),
+    )
+    .expect("quoted device matchers should parse");
+    let devices = cfg
+        .input_devices
+        .expect("definputdevices should be retained");
+    assert_eq!(
+        devices[0].1.name.as_deref(),
+        Some("Apple Internal Keyboard / Trackpad")
+    );
+    assert_eq!(devices[1].1.name.as_deref(), Some("silakka54"));
+    assert_eq!(devices[1].1.vendor_id, Some(0xFEED));
+    assert_eq!(devices[1].1.product_id, Some(0x1212));
+    assert_eq!(devices[2].1.hash.as_deref(), Some("e328037d977386de"));
+}
+
+#[test]
 fn sizeof_action_is_two_usizes() {
     assert_eq!(
         std::mem::size_of::<KanataAction>(),


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Strip surrounding syntax quotes from `definputdevices` matcher values before matching or parsing them.

Without this fix, I could not match an external keyboard on my Mac using the documented quoted `name` syntax: the parser retained the literal quote characters. Quoted `hash` values also failed hexadecimal validation.

Reuse `trim_atom_quotes()` and add a regression test covering quoted names, vendor/product IDs, and an uppercase quoted hash.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A — existing documentation already specifies quoted matcher values
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A — this fixes existing syntax rather than adding a new configuration feature
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes
