### PR TITLE
feat(win): add opt to disable keystate sync

### DIFF
--- a/cfg_samples/kanata.kbd
+++ b/cfg_samples/kanata.kbd
@@ -170,6 +170,14 @@ If you need help, please feel welcome to ask in the GitHub discussions.
   ;; not work too well with other applications that use WH_KEYBOARD_LL.
   ;; Known applications with issues: GWSL/VcXsrv
 
+  ;; Windows without Interception has default behaviour to mitigate against
+  ;; unsynchronized Kanata and Windows keystates.
+  ;; The default value is: clear-kanata-states
+  ;;
+  ;; windows-sync-keystates  none
+  ;; windows-sync-keystates  clear-kanata-states
+  ;; windows-sync-keystates  clear-kanata-and-os-states
+
   ;; Enable kanata to execute commands.
   ;;
   ;; I consider this feature a hazard so it is conditionally compiled out of

--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -5114,6 +5114,34 @@ and any <<deflayermap,`deflayermap`>> `$input` position.
 )
 ----
 
+[[windows-only-windows-sync-keystates]]
+=== Windows only: windows-sync-keystates
+
+By default Kanata on Windows without Interception
+has behaviour to check against the Windows operating system
+and try to synchronize known keys where they differ
+between the OS and Kanata.
+This is because of limitations in the Windows keyboard APIs
+where Kanata is not guaranteed to see all events.
+However, likewise due to limitations in the APIs,
+even this sync mechanism is not perfect.
+If the sync behaviour is causing issues, set it to `none`.
+The default is `clear-kanata-states`.
+
+Options:
+
+* `none`
+* `clear-kanata-states`
+* `clear-kanata-and-os-states`
+
+.Example:
+[source]
+----
+(defcfg
+  windows-sync-keystates none
+)
+----
+
 For more context, see: https://github.com/jtroo/kanata/issues/55.
 
 NOTE: Even with these workarounds, putting `+lctl+` and `+ralt+` in your defsrc may not

--- a/parser/src/cfg/defcfg.rs
+++ b/parser/src/cfg/defcfg.rs
@@ -88,7 +88,7 @@ pub struct CfgWinterceptOptions {
 #[derive(Debug, Clone, Default)]
 pub struct CfgWindowsOptions {
     pub windows_altgr: AltGrBehaviour,
-    pub sync_keystates: bool,
+    pub windows_sync_keystates: WinSyncKeystateBehaviour,
 }
 
 #[cfg(all(any(target_os = "windows", target_os = "unknown"), feature = "gui"))]
@@ -485,9 +485,26 @@ pub fn parse_defcfg(expr: &[SExpr]) -> Result<CfgOptions> {
                         }
                     }
                     "windows-sync-keystates" => {
+                        let sync_mode = sexpr_to_str_or_err(val, label)?;
+                        match sync_mode {
+                            "none" | "clear-kanata-states" | "clear-kanata-and-os-states" => {}
+                            _ => bail_expr!(
+                                val,
+                                "Invalid value for {label}.\nExpected one of: none | clear-kanata-states | clear-kanata-and-os-states"
+                            ),
+                        };
                         #[cfg(any(target_os = "windows", target_os = "unknown"))]
                         {
-                            cfg.windows_opts.sync_keystates = parse_defcfg_val_bool(val, label)?;
+                            cfg.windows_opts.windows_sync_keystates = match sync_mode {
+                                "none" => WinSyncKeystateBehaviour::WinSyncDoNothing,
+                                "clear-kanata-states" => {
+                                    WinSyncKeystateBehaviour::WinSyncClearKanataStates
+                                }
+                                "clear-kanata-and-os-states" => {
+                                    WinSyncKeystateBehaviour::WinSyncClearKanataAndOsStates
+                                }
+                                _ => unreachable!("validated earlier"),
+                            };
                         }
                     }
                     "windows-interception-mouse-hwid" => {
@@ -1131,6 +1148,15 @@ pub enum AltGrBehaviour {
     DoNothing,
     CancelLctlPress,
     AddLctlRelease,
+}
+
+#[cfg(any(target_os = "windows", target_os = "unknown"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WinSyncKeystateBehaviour {
+    WinSyncDoNothing,
+    #[default]
+    WinSyncClearKanataStates,
+    WinSyncClearKanataAndOsStates,
 }
 
 #[cfg(any(target_os = "windows", target_os = "unknown"))]

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -237,7 +237,7 @@ pub struct Kanata {
     /// Tracks whether Kanata should try to synchronize keystates with the Windows OS.
     /// Has no effect on Interception. Fixes some use cases related to admin window permissions and
     /// potentially locking via Win+L.
-    pub windows_sync_keystates: bool,
+    pub windows_sync_keystates: WinSyncKeystateBehaviour,
     #[cfg(all(feature = "interception_driver", target_os = "windows"))]
     /// Used to know which input device to treat as a mouse for intercepting and processing inputs
     /// by kanata.
@@ -488,7 +488,7 @@ impl Kanata {
             #[cfg(any(target_os = "linux", target_os = "android"))]
             exclude_names: cfg.options.linux_opts.linux_dev_names_exclude,
             #[cfg(target_os = "windows")]
-            windows_sync_keystates: cfg.options.windows_opts.sync_keystates,
+            windows_sync_keystates: cfg.options.windows_opts.windows_sync_keystates,
             #[cfg(all(feature = "interception_driver", target_os = "windows"))]
             intercept_mouse_hwids: cfg.options.wintercept_opts.windows_interception_mouse_hwids,
             #[cfg(all(feature = "interception_driver", target_os = "windows"))]
@@ -642,7 +642,7 @@ impl Kanata {
             #[cfg(any(target_os = "linux", target_os = "android"))]
             exclude_names: cfg.options.linux_opts.linux_dev_names_exclude,
             #[cfg(target_os = "windows")]
-            windows_sync_keystates: cfg.options.windows_opts.sync_keystates,
+            windows_sync_keystates: cfg.options.windows_opts.windows_sync_keystates,
             #[cfg(all(feature = "interception_driver", target_os = "windows"))]
             intercept_mouse_hwids: cfg.options.wintercept_opts.windows_interception_mouse_hwids,
             #[cfg(all(feature = "interception_driver", target_os = "windows"))]
@@ -770,7 +770,7 @@ impl Kanata {
         self.virtual_keys = cfg.fake_keys;
         #[cfg(target_os = "windows")]
         {
-            self.windows_sync_keystates = cfg.options.windows_opts.sync_keystates;
+            self.windows_sync_keystates = cfg.options.windows_opts.windows_sync_keystates;
         }
         #[cfg(all(target_os = "windows", feature = "gui"))]
         {

--- a/src/kanata/windows/llhook.rs
+++ b/src/kanata/windows/llhook.rs
@@ -1,3 +1,4 @@
+use kanata_parser::cfg::WinSyncKeystateBehaviour;
 use parking_lot::Mutex;
 use std::convert::TryFrom;
 use std::sync::Arc;
@@ -193,6 +194,13 @@ impl Kanata {
         use kanata_keyberon::layout::*;
         use winapi::um::winuser::*;
 
+        if matches!(
+            self.windows_sync_keystates,
+            WinSyncKeystateBehaviour::WinSyncDoNothing
+        ) {
+            return;
+        }
+
         // Note: this procedure (1) used to be also gated behind the config flag.
         // Revisiting it later, it should be reasonably safe to always run this,
         // because releasing a Kanata state should not interfere with other programs
@@ -260,7 +268,10 @@ impl Kanata {
             drop(pressed_keys);
         }
 
-        if !self.windows_sync_keystates {
+        if matches!(
+            self.windows_sync_keystates,
+            WinSyncKeystateBehaviour::WinSyncClearKanataStates
+        ) {
             return;
         }
 


### PR DESCRIPTION
Release v1.12.0 enabled keystate sync on Windows LLHOOK. This triggered errors in user envs which had other userspace apps that use LLHOOK such as espanso.

Implement a way to turn the behaviour off.
Though the keystate sync is helpful in some cases
due to limitations of the Windows userspace keyboard APIs, it has limited knowledge and can behave incorrectly due again limitations of the Windows userspace keyboard APIs.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] Yes
- Update error messages
  - [x] Yes
- Added tests, or did manual testing
  - [x] Yes
