### PR TITLE
feat(macos): support VirtualHIDDevice v8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "karabiner-driverkit"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e4fc764f78a4a5cbf705c9502a51a0ba4931dbee25f4fbc59654059f6ca9e9"
+checksum = "4f670d53bddbec6ca268f774aabbe22a14a5a8d7c76108337e4751e374dd5973"
 dependencies = [
  "cc",
  "os_info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ kanata-tcp-protocol = { path = "tcp_protocol", version = "0.1121.0" }
 arboard = "3.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-karabiner-driverkit = "0.3.0"
+karabiner-driverkit = "0.4.0"
 objc = "0.2.7"
 core-graphics = "0.24.0"
 open = { version = "5", optional = true }

--- a/docs/release-template.md
+++ b/docs/release-template.md
@@ -108,7 +108,9 @@ Explanation of items in the binary variant:
 <details>
 <summary>Instructions</summary>
 
-The supported Karabiner driver version in this release is `v6.2.0`.
+The supported Karabiner driver version in this release is `v8.0.0`. This
+release uses driver protocol 7 and is not compatible with protocol-5
+VirtualHIDDevice releases such as v6.2.0.
 
 **NOTE**: macOS mouse button input requires Accessibility or Input Monitoring permission in System Settings > Privacy & Security.
 
@@ -123,7 +125,10 @@ Explanation of items in the binary variant:
 
 ### Instructions for macOS 11 and newer
 
-You must use the Karabiner driver version `v6.2.0`.
+You must use the Karabiner driver version `v8.0.0`.
+
+Follow the current [macOS setup instructions](https://github.com/jtroo/kanata/blob/main/docs/setup-macos.md)
+to install and activate the driver.
 
 Please read through this issue comment:
 

--- a/docs/setup-macos.md
+++ b/docs/setup-macos.md
@@ -19,11 +19,11 @@ xcode-select --install
 
 ### 2. Install Karabiner-DriverKit-VirtualHIDDevice
 
-The supported driver version is `v6.2.0`. Kanata's bundled
-`karabiner-driverkit` crate is built against that release's IPC, and pqrs
-ships protocol changes between minor versions, so newer driver releases
-are not guaranteed to work. Download the `.pkg` from the
-[v6.2.0 release page](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/tag/v6.2.0)
+The supported driver version is `v8.0.0`. Kanata's `karabiner-driverkit`
+v0.4.0 client uses protocol 7 and is not compatible with older protocol-5
+daemons such as VirtualHIDDevice v6.2.0. Upgrade the driver and kanata
+together. Download the `.pkg` from the
+[v8.0.0 release page](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/tag/v8.0.0)
 and run the installer.
 
 Then activate the driver and approve its system extension:


### PR DESCRIPTION
## Summary

- update `karabiner-driverkit` from 0.3.x to 0.4.0
- update the lockfile to the published 0.4.0 crate
- document VirtualHIDDevice v8.0.0 as the supported macOS driver
- document the protocol-7 compatibility cut from protocol-5/v6.2.0

## Why

Karabiner-Elements 16.1 uses VirtualHIDDevice v8. Kanata currently depends on the protocol-5 driverkit client and documents VirtualHIDDevice v6.2.0, so it cannot communicate with the current v8 daemon.

`karabiner-driverkit` 0.4.0 adds the protocol-7/v8 client support. This intentionally updates Kanata to v8 rather than maintaining two IPC implementations. Users of the standalone v6.2.0 driver must upgrade the driver and Kanata together.

Closes #2105.

## Runtime validation

The driverkit migration was validated in a disposable macOS 15.7.7 ARM VM during psych3r/driverkit#20. The validated scenarios included:

- startup before and after daemon availability
- keyboard and pointing output readiness
- daemon loss and in-process recovery
- repeated reconnects
- clean shutdown
- two simultaneous output clients and recovery after daemon restart

The controlled v6/v8 comparison found the same same-device exclusive-input behavior in both versions; it was not introduced by the v8 migration.

## Local checks

- `cargo fmt --all --check`
- `RUSTFLAGS="-Dwarnings" cargo build --all-targets`
- `RUSTFLAGS="-Dwarnings" cargo test --all`
- `RUSTFLAGS="-Dwarnings" cargo clippy --all -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo test --all --features=cmd`
- `RUSTFLAGS="-Dwarnings" cargo clippy --all --features=cmd -- -D warnings`
- `RUSTFLAGS="-Dwarnings" cargo build --release`
- `RUSTFLAGS="-Dwarnings" cargo build --release --features=cmd`