### PR TITLE
doc(macos): clarify driver compatibility for MacOS

### DIFF
--- a/docs/setup-macos.md
+++ b/docs/setup-macos.md
@@ -19,12 +19,14 @@ xcode-select --install
 
 ### 2. Install Karabiner-DriverKit-VirtualHIDDevice
 
-The supported driver version is `v8.0.0`. Kanata's `karabiner-driverkit`
+Beginning with kanata version 1.13.0, the supported driver version is `v8.0.0`. Kanata's `karabiner-driverkit`
 v0.4.0 client uses protocol 7 and is not compatible with older protocol-5
 daemons such as VirtualHIDDevice v6.2.0. Upgrade the driver and kanata
 together. Download the `.pkg` from the
 [v8.0.0 release page](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/tag/v8.0.0)
 and run the installer.
+
+If you are still running a version of kanata prior to v1.13.0, please download version 6.2.0 of the Karabiner driver.
 
 Then activate the driver and approve its system extension:
 

--- a/docs/setup-macos.md
+++ b/docs/setup-macos.md
@@ -26,7 +26,7 @@ together. Download the `.pkg` from the
 [v8.0.0 release page](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/tag/v8.0.0)
 and run the installer.
 
-If you are still running a version of kanata prior to v1.13.0, please download version 6.2.0 of the Karabiner driver.
+If you are still running a version of kanata prior to v1.13.0, you should continue to use `v6.2.0` of the Karabiner driver which you can download from [its release page](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/tag/v6.2.0).
 
 Then activate the driver and approve its system extension:
 

--- a/docs/setup-macos.md
+++ b/docs/setup-macos.md
@@ -19,14 +19,14 @@ xcode-select --install
 
 ### 2. Install Karabiner-DriverKit-VirtualHIDDevice
 
-Beginning with kanata version 1.13.0, the supported driver version is `v8.0.0`. Kanata's `karabiner-driverkit`
+Beginning with kanata version `v1.13.0`, the supported driver version is `v8.0.0`. Kanata's `karabiner-driverkit`
 v0.4.0 client uses protocol 7 and is not compatible with older protocol-5
 daemons such as VirtualHIDDevice v6.2.0. Upgrade the driver and kanata
 together. Download the `.pkg` from the
 [v8.0.0 release page](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/tag/v8.0.0)
 and run the installer.
 
-If you are still running a version of kanata prior to v1.13.0, you should continue to use `v6.2.0` of the Karabiner driver which you can download from [its release page](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/tag/v6.2.0).
+If you are still running a version of kanata prior to `v1.13.0`, you should continue to use `v6.2.0` of the Karabiner driver which you can download from [its release page](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/tag/v6.2.0).
 
 Then activate the driver and approve its system extension:
 


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
Make a more explicit note that driver compatibility changed starting with (what I'm assuming will be) version 1.13.0 for those referencing this document before the stable release.

Closes #2125.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] N/A
