### PR TITLE
fix(parser): set device detect mode for mouse keys in deflayermap

### DIFF
--- a/parser/src/cfg/defsrc.rs
+++ b/parser/src/cfg/defsrc.rs
@@ -9,11 +9,10 @@ use crate::bail_expr;
 pub(crate) fn parse_defsrc(
     expr: &[SExpr],
     defcfg: &CfgOptions,
-) -> Result<(MappedKeys, Vec<usize>, MouseInDefsrc)> {
+) -> Result<(MappedKeys, Vec<usize>)> {
     let exprs = check_first_expr(expr.iter(), "defsrc")?;
     let mut mkeys = MappedKeys::default();
     let mut ordered_codes = Vec::new();
-    let mut is_mouse_used = MouseInDefsrc::NoMouse;
     for expr in exprs {
         let s = match expr {
             SExpr::Atom(a) => &a.t,
@@ -21,21 +20,6 @@ pub(crate) fn parse_defsrc(
         };
         let oscode = str_to_oscode(s)
             .ok_or_else(|| anyhow_expr!(expr, "Unknown key in defsrc: \"{}\"", s))?;
-        is_mouse_used = match (is_mouse_used, oscode) {
-            (
-                MouseInDefsrc::NoMouse,
-                OsCode::BTN_LEFT
-                | OsCode::BTN_RIGHT
-                | OsCode::BTN_MIDDLE
-                | OsCode::BTN_SIDE
-                | OsCode::BTN_EXTRA
-                | OsCode::MouseWheelUp
-                | OsCode::MouseWheelDown
-                | OsCode::MouseWheelLeft
-                | OsCode::MouseWheelRight,
-            ) => MouseInDefsrc::MouseUsed,
-            _ => is_mouse_used,
-        };
 
         if mkeys.contains(&oscode) {
             bail_expr!(expr, "Repeat declaration of key in defsrc: \"{}\"", s)
@@ -89,7 +73,7 @@ pub(crate) fn parse_defsrc(
     }
 
     mkeys.shrink_to_fit();
-    Ok((mkeys, ordered_codes, is_mouse_used))
+    Ok((mkeys, ordered_codes))
 }
 
 pub(crate) fn create_defsrc_layer() -> [KanataAction; KEYS_IN_ROW] {

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -638,14 +638,7 @@ pub fn parse_cfg_raw_string(
             "Exactly one defsrc is allowed, found more. Delete the extras."
         )
     }
-    let (mut mapped_keys, mapping_order, _mouse_in_defsrc) = parse_defsrc(src_expr, &cfg)?;
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "unknown"))]
-    if cfg.linux_opts.linux_device_detect_mode.is_none() {
-        cfg.linux_opts.linux_device_detect_mode = Some(match _mouse_in_defsrc {
-            MouseInDefsrc::MouseUsed => DeviceDetectMode::Any,
-            MouseInDefsrc::NoMouse => DeviceDetectMode::KeyboardMice,
-        });
-    }
+    let (mut mapped_keys, mapping_order) = parse_defsrc(src_expr, &cfg)?;
 
     let input_devices = root_exprs
         .iter()
@@ -843,6 +836,20 @@ pub fn parse_cfg_raw_string(
     }
 
     let mut klayers = parse_layers(s, &mut mapped_keys, &cfg)?;
+
+    // Auto-derive the Linux device-detect mode AFTER parse_layers, because deflayermap pairs
+    // (not only defsrc) can introduce mouse OsCodes into mapped_keys (issue #2096). Deriving
+    // from the final mapped_keys set ensures mouse devices are grabbed whenever any mouse key
+    // is mapped, regardless of whether it was named in defsrc or deflayermap.
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "unknown"))]
+    if cfg.linux_opts.linux_device_detect_mode.is_none() {
+        cfg.linux_opts.linux_device_detect_mode =
+            Some(if mapped_keys.iter().any(|k| k.is_mouse_code()) {
+                DeviceDetectMode::Any
+            } else {
+                DeviceDetectMode::KeyboardMice
+            });
+    }
 
     resolve_chord_groups(&mut klayers, s)?;
     let layers = s.a.bref_slice(klayers);
@@ -1120,12 +1127,6 @@ fn check_first_expr<'a>(
         bail!("Passed non-{expected_first} expression to {expected_first}: {first_atom}");
     }
     Ok(exprs)
-}
-
-#[derive(Debug, Copy, Clone)]
-enum MouseInDefsrc {
-    MouseUsed,
-    NoMouse,
 }
 
 type Aliases = HashMap<String, &'static KanataAction>;

--- a/parser/src/cfg/tests/device_detect.rs
+++ b/parser/src/cfg/tests/device_detect.rs
@@ -63,4 +63,62 @@ mod linux {
             .map_err(|e| log::info!("{:?}", miette::Error::from(e)))
             .expect_err("error should happen");
     }
+
+    #[test]
+    fn deflayermap_mouse_sets_detect_mode_any() {
+        // Issue #2096: a mouse button listed ONLY in deflayermap (not defsrc) must still
+        // cause Linux to grab mouse devices (DeviceDetectMode::Any), because parse_layers
+        // inserts the mouse OsCode into mapped_keys.
+        let source = r#"
+(defsrc)
+(deflayermap (base)
+  mmid v
+)"#;
+        let icfg = parse_cfg(source)
+            .map_err(|e| log::info!("{:?}", miette::Error::from(e)))
+            .expect("parses");
+        assert!(icfg.mapped_keys.contains(&OsCode::BTN_MIDDLE));
+        assert_eq!(
+            icfg.options.linux_opts.linux_device_detect_mode,
+            Some(DeviceDetectMode::Any)
+        );
+    }
+
+    #[test]
+    fn deflayermap_without_mouse_stays_keyboard_mice() {
+        // Negative control: a keyboard-only deflayermap must NOT flip the mode to Any.
+        let source = r#"
+(defsrc a)
+(deflayermap (base)
+  b c
+)"#;
+        let icfg = parse_cfg(source)
+            .map_err(|e| log::info!("{:?}", miette::Error::from(e)))
+            .expect("parses");
+        assert_eq!(
+            icfg.options.linux_opts.linux_device_detect_mode,
+            Some(DeviceDetectMode::KeyboardMice)
+        );
+    }
+
+    #[test]
+    fn deflayermap_mouse_with_explicit_defcfg_mode_keeps_override() {
+        // An explicit `linux-device-detect-mode` in defcfg must win even when a mouse button is
+        // also named in deflayermap: the is_none() guard skips auto-derivation, so the user's
+        // choice is preserved (mmid still lands in mapped_keys, but it must not flip the mode).
+        let source = r#"
+(defcfg linux-device-detect-mode keyboard-only)
+(defsrc)
+(deflayermap (base)
+  mmid v
+)"#;
+        let icfg = parse_cfg(source)
+            .map_err(|e| log::info!("{:?}", miette::Error::from(e)))
+            .expect("parses");
+        assert!(icfg.mapped_keys.contains(&OsCode::BTN_MIDDLE));
+        assert_eq!(
+            icfg.options.linux_opts.linux_device_detect_mode,
+            Some(DeviceDetectMode::KeyboardOnly)
+        );
+    }
 }


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

On Linux, kanata auto-derives `linux-device-detect-mode` (which decides whether input devices
are grabbed as keyboard-only or keyboard+mouse) only when the user has not set it explicitly in
`defcfg`. That derivation was computed from a `defsrc`-only mouse flag (`MouseInDefsrc`) **before**
`parse_layers` ran. A mouse button name (`mmid`, `mlft`, `mrgt`, `mbck`, `mfwd`, `mwu`, …) listed
**only** in `deflayermap` is inserted into `mapped_keys` by `parse_layers` — which ran *after* the
decision — so it never influenced the result: the mode stayed `KeyboardMice`, the mouse device was
never grabbed, and the mapping was silently dead (#2096).

Move the derivation to **after** `parse_layers` and compute it from the final `mapped_keys` set
(`mapped_keys.iter().any(|k| k.is_mouse_code())` → `Any`, else `KeyboardMice`). This sees mouse
OsCodes named in **both** `defsrc` and `deflayermap`. Delete the now-dead `MouseInDefsrc` enum and
its tracking in `parse_defsrc` (which now returns `(MappedKeys, Vec<usize>)`). The `defcfg`
user-override path is preserved (the `is_none()` guard still skips auto-derivation when the user
sets `linux-device-detect-mode`), the `#[cfg(any(target_os = "linux", target_os = "android",
target_os = "unknown"))]` gate is unchanged, and the `process-unmapped-keys` mouse-exclusion
(bugfix #1879) in `parse_defsrc` is untouched. Parser-only; no runtime/HID or key-name changes.

Resolves #2096

## Checklist
- Add documentation to docs/config.adoc          — N/A
- Add example and basic docs to cfg_samples/kanata.kbd — N/A
- Update error messages                          — [x] N/A
- Added tests, or did manual testing             — [x] Yes
  (`deflayermap_mouse_sets_detect_mode_any`,
  `deflayermap_without_mouse_stays_keyboard_mice`,
  `deflayermap_mouse_with_explicit_defcfg_mode_keeps_override` in
  `parser/src/cfg/tests/device_detect.rs`; `#[cfg(linux/android)]`-gated, run by Linux CI)