### PR TITLE
fix(parser): take the empty-string fast-path in sref_str

### DIFF
--- a/parser/src/cfg/alloc.rs
+++ b/parser/src/cfg/alloc.rs
@@ -104,7 +104,7 @@ impl Allocations {
 
     /// Returns a `&'static str` by leaking a String.
     pub(crate) fn sref_str(&self, v: String) -> &'static str {
-        if !v.capacity() == 0 {
+        if v.capacity() == 0 {
             ""
         } else {
             let len = v.len();
@@ -115,5 +115,72 @@ impl Allocations {
             });
             s
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_zero_capacity_strings_take_the_fast_path() {
+        let a = unsafe { Allocations::new() };
+
+        // Zero-capacity empty strings (`String::new()`, `""`, `with_capacity(0)`)
+        // have no backing allocation, so they must take the `""` fast path: return a
+        // static empty str and record NO tracked allocation. The old guard
+        // `!v.capacity() == 0` (bitwise-NOT precedence) let these fall through to
+        // the leak branch, recording the String's dangling buffer pointer
+        // (`NonNull::dangling` == 0x1 for u8) as if it were a live allocation.
+        for input in [String::new(), "".to_string(), String::with_capacity(0)] {
+            assert_eq!(input.capacity(), 0);
+            let tracked_before = a.allocations.lock().len();
+            let out = a.sref_str(input);
+            assert_eq!(out, "");
+            assert_eq!(
+                a.allocations.lock().len(),
+                tracked_before,
+                "zero-capacity string must not be tracked as an allocation"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_string_with_reserved_capacity_is_still_tracked() {
+        // An empty string that nonetheless owns a heap allocation (capacity > 0)
+        // must take the tracking branch so its allocation is freed on drop. This is
+        // why the guard is `capacity() == 0` rather than `is_empty()`: `is_empty()`
+        // would route this case to the `""` fast path and leak the reserved buffer.
+        let a = unsafe { Allocations::new() };
+        let mut reserved = String::from("x");
+        reserved.clear();
+        assert!(reserved.is_empty());
+        assert!(reserved.capacity() >= 1);
+
+        let tracked_before = a.allocations.lock().len();
+        let out = a.sref_str(reserved);
+        assert_eq!(out, "");
+        assert_eq!(
+            a.allocations.lock().len(),
+            tracked_before + 1,
+            "empty-but-allocated string must be tracked so it is freed"
+        );
+    }
+
+    #[test]
+    fn nonempty_string_is_tracked_with_a_real_pointer() {
+        let a = unsafe { Allocations::new() };
+
+        let tracked_before = a.allocations.lock().len();
+        let out = a.sref_str("hello".to_string());
+        assert_eq!(out, "hello");
+
+        let allocs = a.allocations.lock();
+        assert_eq!(allocs.len(), tracked_before + 1);
+        // A tracked string must point at a real heap allocation, not the empty-slice
+        // dangling sentinel, so `Allocations::drop` frees a valid box.
+        let last = allocs.last().unwrap();
+        assert_eq!(last.len, 5);
+        assert_ne!(last.ptr, String::new().leak().as_ptr() as usize);
     }
 }


### PR DESCRIPTION
## Summary

`Allocations::sref_str` (`parser/src/cfg/alloc.rs`) leaked a `String` into a `&'static
str` and recorded the allocation for later freeing, with a fast path meant to return the
static `""` literal (and record nothing) when the `String` owns **no** backing allocation.
The guard selecting that fast path was broken, so empty/zero-capacity strings bypassed it,
were leaked, and their **dangling buffer pointer** was recorded as a live allocation.

This is reachable from user config via `(clipboard-set "")`, `(live-reload "")`,
`(cmd echo "")`, and empty `switch` case strings.

## Root cause

```rust
if !v.capacity() == 0 {   // parser/src/cfg/alloc.rs:107
    ""
} else { /* leak + track */ }
```

`!v.capacity() == 0` parses as `(!v.capacity()) == 0`. `v.capacity()` is a `usize` and `!`
on integers is **bitwise NOT**, so this is `(usize::MAX ^ capacity) == 0` — true only when
`capacity == usize::MAX`, i.e. effectively never. Zero-capacity empty strings
(`String::new()`, `""`) therefore fell into the leak branch: `String::new().leak()` yields
a `&str` backed by the dangling `u8` sentinel (`NonNull::dangling` == `0x1`), and the code
recorded `Allocation { ptr: 0x1, len: 0 }` — a dangling pointer with no backing allocation
that `Allocations::drop` later attempts to reconstruct and free.

## The fix

One-line guard change:

```diff
-        if !v.capacity() == 0 {
+        if v.capacity() == 0 {
```

Now zero-capacity strings take the `""` fast path and are not tracked; everything else is
unchanged.

### Why `capacity() == 0` and not `is_empty()`?

A `String` can be empty (`is_empty()` true) yet still own a heap allocation — e.g.
`String::with_capacity(16)` or `String::from("x")` then `.clear()` (len 0, capacity ≥ 1).
Such a string **must** stay on the leak+track branch so its allocation is freed on drop.
`is_empty()` would route it to the `""` fast path and **leak the buffer**. `capacity() == 0`
is the exact predicate for "owns no backing allocation" (invariant `len <= capacity`), and
matches the documented intent of the analogous `bref_slice` ("An empty slice has no backing
allocation").

## Tests

Added a `#[cfg(test)] mod tests` to `parser/src/cfg/alloc.rs`:

- `empty_zero_capacity_strings_take_the_fast_path` — `String::new()`, `""`,
  `String::with_capacity(0)` each return `""` and record **no** tracked allocation
  (RED `1` → GREEN `0` recorded allocations).
- `empty_string_with_reserved_capacity_is_still_tracked` — `String::from("x")` + `.clear()`
  (empty, capacity ≥ 1) must still be tracked; regression-guards against an `is_empty()`
  "fix" that would leak it.
- `nonempty_string_is_tracked_with_a_real_pointer` — `"hello"` is tracked and its recorded
  pointer is a real heap address (not the `0x1` sentinel), protecting the drop path.

## Validation

Full repo `just test` target, all green:

- `cargo fmt --all --check` — clean
- `cargo clippy --all` — clean
- `cargo test -p kanata -p kanata-parser -p kanata-keyberon -p kanata-wasm -p kanata-tcp-protocol` — 0 failed
- `cargo test --features=simulated_output sim_tests` — 211 passed; 0 failed
- `cargo test --features=simulated_output -- must_be_single_threaded --ignored --test-threads=1` — 4 passed; 0 failed

## Backward compatibility

Observable string content is unchanged (`""` was and remains `""`). Only allocation
*tracking* of zero-capacity strings is corrected, so no config or downstream consumer
behaves differently. No public API or signature changes.

---

DCO: signed off (`git commit -s`).
