### PR TITLE
feat: add layer-lock-toggle action

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -922,7 +922,61 @@ defined in a `deflayer` entry.
 
 You may also use `layer-toggle` in place of `layer-while-held`; they behave
 exactly the same. The `layer-toggle` name is slightly shorter but is a bit
-inaccurate with regards to its meaning.
+inaccurate with regards to its meaning. If you want a layer that stays on
+after the key is released, see <<layer-lock-toggle,`layer-lock-toggle`>>.
+
+[[layer-lock-toggle]]
+=== layer-lock-toggle
+
+**Reference**
+
+A list action that locks a layer on, and unlocks it when pressed again.
+
+.Syntax:
+[source]
+----
+(layer-lock-toggle $layer-name)
+----
+
+[cols="1,5"]
+|===
+| `$layer-name`
+| Layer name to lock or unlock.
+|===
+
+**Description**
+
+Unlike `layer-while-held`, the layer stays active after the key is released.
+Pressing the key a second time releases it. This is the behaviour of QMK's
+`TG()`, and is useful for a numpad or mouse layer that you want to stay on
+while both hands are busy.
+
+The action tracks its own lock rather than the state of the layer, so it
+only releases a layer that it locked. If the layer is already active because
+of a `layer-while-held` key or a `layer-switch`, pressing the lock key adds a
+lock on top instead of turning the layer off.
+
+The lock is added to the same stack of temporary layers that
+`layer-while-held` uses, so it sits on top of the base layer. While it is
+held, `layer-switch` has no visible effect, because the locked layer stays
+above the base layer that `layer-switch` changes. Make sure the locked layer
+leaves the lock key reachable, either as the same alias or as `_`, otherwise
+there is no way to unlock it. `release-layer` also releases the lock.
+
+Each locked layer reserves one virtual key slot, so the number of locked
+layers plus the number of `defvirtualkeys` and `deffakekeys` entries cannot
+exceed the maximum number of virtual keys.
+
+.Example:
+[source]
+----
+(defalias
+  ;; lock or unlock the numpad layer
+  num (layer-lock-toggle numpad)
+  ;; tap to lock or unlock the numpad layer, hold for right ctrl
+  rctl (tap-hold-press 200 200 @num rctl)
+)
+----
 
 [[transparent-key]]
 === Transparent key

--- a/parser/src/cfg/deflayer.rs
+++ b/parser/src/cfg/deflayer.rs
@@ -256,6 +256,7 @@ pub(crate) fn parse_layers(
         // physically activated. This enable other code to rely on there always being a no-op key.
         layers_cfg[layer_level][0][0] = Action::NoOp;
     }
+    reserve_layer_locks(s, &mut layers_cfg)?;
     Ok(layers_cfg)
 }
 
@@ -275,4 +276,48 @@ pub(crate) fn parse_layer_toggle(
     let idx = layer_idx(ac_params, &s.layer_idxs, s)?;
     set_layer_change_lsp_hint(&ac_params[0], &mut s.lsp_hints.borrow_mut());
     Ok(s.a.sref(Action::Layer(idx)))
+}
+
+pub(crate) fn parse_layer_lock_toggle(
+    ac_params: &[SExpr],
+    s: &ParserState,
+) -> Result<&'static KanataAction> {
+    let idx = layer_idx(ac_params, &s.layer_idxs, s)?;
+    set_layer_change_lsp_hint(&ac_params[0], &mut s.lsp_hints.borrow_mut());
+    let mut slots = s.layer_lock_slots.borrow_mut();
+    // Uses of the same layer share a slot, so two keys toggle the same lock.
+    let next_slot = slots.len();
+    let (x, y) = get_layer_lock_coords(*slots.entry(idx).or_insert(next_slot));
+    custom(
+        CustomAction::FakeKey {
+            coord: Coord { x, y },
+            action: FakeKeyAction::Toggle,
+        },
+        &s.a,
+    )
+}
+
+/// Slots count down from the end of the row; virtual keys count up from the start.
+fn get_layer_lock_coords(slot: usize) -> (u8, u16) {
+    (FAKE_KEY_ROW, (KEYS_IN_ROW - 1 - slot) as u16)
+}
+
+/// Runs after all actions are parsed, when both counts sharing the row are final.
+fn reserve_layer_locks(s: &ParserState, layers_cfg: &mut IntermediateLayers) -> Result<()> {
+    let slots = s.layer_lock_slots.borrow();
+    if s.virtual_keys.len() + slots.len() > KEYS_IN_ROW {
+        bail!(
+            "Maximum number of virtual keys and layer-lock-toggle layers combined is \
+             {KEYS_IN_ROW}, found {} virtual keys and {} locked layers",
+            s.virtual_keys.len(),
+            slots.len()
+        );
+    }
+    for (layer_idx, slot) in slots.iter() {
+        let (x, y) = get_layer_lock_coords(*slot);
+        for layer in layers_cfg.iter_mut() {
+            layer[x as usize][y as usize] = Action::Layer(*layer_idx);
+        }
+    }
+    Ok(())
 }

--- a/parser/src/cfg/list_actions.rs
+++ b/parser/src/cfg/list_actions.rs
@@ -5,6 +5,7 @@
 pub const LAYER_SWITCH: &str = "layer-switch";
 pub const LAYER_TOGGLE: &str = "layer-toggle";
 pub const LAYER_WHILE_HELD: &str = "layer-while-held";
+pub const LAYER_LOCK_TOGGLE: &str = "layer-lock-toggle";
 pub const TAP_HOLD: &str = "tap-hold";
 pub const TAP_HOLD_PRESS: &str = "tap-hold-press";
 pub const TAP_HOLD_PRESS_A: &str = "tap⬓↓";
@@ -146,6 +147,7 @@ pub fn is_list_action(ac: &str) -> bool {
         LAYER_SWITCH,
         LAYER_TOGGLE,
         LAYER_WHILE_HELD,
+        LAYER_LOCK_TOGGLE,
         TAP_HOLD,
         TAP_HOLD_PRESS,
         TAP_HOLD_PRESS_A,

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -1157,6 +1157,8 @@ pub struct ParserState {
     layer_idxs: LayerIndexes,
     mapping_order: Vec<usize>,
     virtual_keys: HashMap<String, (usize, &'static KanataAction)>,
+    /// Layers used by `layer-lock-toggle`, mapped to their reserved virtual key slot.
+    layer_lock_slots: RefCell<HashMap<usize, usize>>,
     chord_groups: HashMap<String, ChordGroup>,
     defsrc_layer: [KanataAction; KEYS_IN_ROW],
     vars: HashMap<String, SExpr>,
@@ -1191,6 +1193,7 @@ impl Default for ParserState {
             mapping_order: Default::default(),
             defsrc_layer: [KanataAction::NoOp; KEYS_IN_ROW],
             virtual_keys: Default::default(),
+            layer_lock_slots: Default::default(),
             chord_groups: Default::default(),
             vars: Default::default(),
             is_cmd_enabled: default_cfg.enable_cmd,
@@ -1542,6 +1545,7 @@ fn parse_action_list(ac: &[SExpr], s: &ParserState) -> Result<&'static KanataAct
     match ac_type.as_str() {
         LAYER_SWITCH => parse_layer_base(&ac[1..], s),
         LAYER_TOGGLE | LAYER_WHILE_HELD => parse_layer_toggle(&ac[1..], s),
+        LAYER_LOCK_TOGGLE => parse_layer_lock_toggle(&ac[1..], s),
         TAP_HOLD => parse_tap_hold(&ac[1..], s, HoldTapConfig::Default),
         TAP_HOLD_PRESS | TAP_HOLD_PRESS_A => {
             parse_tap_hold(&ac[1..], s, HoldTapConfig::HoldOnOtherKeyPress)

--- a/src/tests/sim_tests/layer_sim_tests.rs
+++ b/src/tests/sim_tests/layer_sim_tests.rs
@@ -185,3 +185,78 @@ fn ls_sim_transparent_no_delegate() {
 // =============================================================================
 // End Layer Switch Simulator Input Tests
 // =============================================================================
+
+const LAYER_LOCK_TOGGLE_CFG: &str = r"
+    (defsrc a b c)
+    (defalias lk (layer-lock-toggle nums))
+    (deflayer base @lk y (release-layer nums))
+    (deflayer nums @lk 1 _)
+";
+
+#[test]
+fn layer_lock_toggle_outlives_the_key_press() {
+    let result = simulate(
+        LAYER_LOCK_TOGGLE_CFG,
+        "d:a t:10 u:a t:10 d:b t:10 u:b t:10 d:a t:10 u:a t:10 d:b t:10 u:b t:10",
+    )
+    .to_ascii();
+    assert_eq!(
+        "t:20ms dn:Kb1 t:10ms up:Kb1 t:30ms dn:Y t:10ms up:Y",
+        result
+    );
+}
+
+#[test]
+fn layer_lock_toggle_can_relock_after_release_layer() {
+    let result = simulate(
+        LAYER_LOCK_TOGGLE_CFG,
+        "d:c t:10 u:c t:10 d:a t:10 u:a t:10 d:b t:10 u:b t:10",
+    )
+    .to_ascii();
+    assert_eq!("t:40ms dn:Kb1 t:10ms up:Kb1", result);
+}
+
+#[test]
+fn layer_lock_toggle_does_not_collide_with_virtual_keys() {
+    const CFG: &str = r"
+        (defsrc a b)
+        (defvirtualkeys vk1 x vk2 x vk3 x)
+        (defalias lk (layer-lock-toggle nums))
+        (deflayer base @lk y)
+        (deflayer nums @lk 1)
+    ";
+    let result = simulate(CFG, "d:a t:10 u:a t:10 d:b t:10 u:b t:10").to_ascii();
+    assert_eq!("t:20ms dn:Kb1 t:10ms up:Kb1", result);
+}
+
+/// The virtual key map is still filling here, so the slot must survive the final count.
+#[test]
+fn layer_lock_toggle_inside_virtual_keys_still_activates_the_layer() {
+    const CFG: &str = r"
+        (defsrc a b)
+        (defvirtualkeys lk (layer-lock-toggle nums) vk1 x vk2 x)
+        (deflayer base (on-press-fakekey lk tap) y)
+        (deflayer nums _ 1)
+    ";
+    let result = simulate(CFG, "d:a t:10 u:a t:10 d:b t:10 u:b t:10").to_ascii();
+    assert_eq!("t:20ms dn:Kb1 t:10ms up:Kb1", result);
+}
+
+#[test]
+fn layer_lock_toggle_masks_layer_switch_until_released() {
+    const CFG: &str = r"
+        (defsrc a b c)
+        (defalias lk (layer-lock-toggle nums))
+        (deflayer base @lk y (layer-switch other))
+        (deflayer nums @lk 1 _)
+        (deflayer other @lk 9 _)
+    ";
+    let locked = simulate(CFG, "d:a t:10 u:a t:10 d:c t:10 u:c t:10 d:b t:10 u:b t:10").to_ascii();
+    assert_eq!("t:40ms dn:Kb1 t:10ms up:Kb1", locked);
+    let released = simulate(
+        CFG,
+        "d:a t:10 u:a t:10 d:c t:10 u:c t:10 d:a t:10 u:a t:10 d:b t:10 u:b t:10",
+    )
+    .to_ascii();
+    assert_eq!("t:60ms dn:Kb9 t:10ms up:Kb9", released);
+}


### PR DESCRIPTION
`layer-toggle` is an alias for `layer-while-held`, so there is currently no action that turns a layer on and leaves it on. The workaround from #360 is to define a virtual key holding `(layer-while-held ...)` and flip it with `(on-press-fakekey ... toggle)`.

This adds `(layer-lock-toggle <layer>)`, which does the same thing internally: each layer gets a reserved coordinate at the end of the virtual key row holding its `layer-while-held` action, and the action toggles that coordinate. `release-layer` turns it off as well.

Named after the suggestion in the issue. Happy to rename if you prefer `sticky-layer-toggle` or something else.

Closes #1877