### PR TITLE
doc: fix broken win-tray images in the guide

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -6310,11 +6310,11 @@ This can simplify launching the app on user login by placing a `.lnk`
 at `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup`, show custom icon indicator per config
 
 
-image:https://github.com/jtroo/kanata/blob/main/docs/win-tray/win-tray-screen.png[icon indicator per config,477,129]
+image:https://raw.githubusercontent.com/jtroo/kanata/main/docs/win-tray/win-tray-screen.png[icon indicator per config,477,129]
 
 as well as dynamic icon indicator per layer (might need to click on the gif below to play)
 
-image:https://github.com/jtroo/kanata/blob/main/docs/win-tray/win-tray-layer-change.gif[icon indicator per layer,33,35,opts=autoplay]
+image:https://raw.githubusercontent.com/jtroo/kanata/main/docs/win-tray/win-tray-layer-change.gif[icon indicator per layer,33,35,opts=autoplay]
 
 (see <<windows-only-win-tray>>). It also supports (re)loading configs.
 


### PR DESCRIPTION
The two win-tray images point at `github.com/jtroo/kanata/blob/main/...`, which serves an HTML page rather than the file, so the browser gets `text/html` where it expects an image and renders nothing. Switching both to `raw.githubusercontent.com` serves the actual `image/png` and `image/gif`.

Closes #2034