### PR TITLE
fix(parser): resolve variables in definputdevices

### DIFF
--- a/parser/src/cfg/definputdevices.rs
+++ b/parser/src/cfg/definputdevices.rs
@@ -10,7 +10,10 @@ pub struct InputDeviceMatcher {
     pub product_id: Option<u16>,
 }
 
-pub fn parse_definputdevices(expr: &[SExpr]) -> Result<Vec<(NonZeroU8, InputDeviceMatcher)>> {
+pub fn parse_definputdevices(
+    expr: &[SExpr],
+    vars: &HashMap<String, SExpr>,
+) -> Result<Vec<(NonZeroU8, InputDeviceMatcher)>> {
     let mut exprs = check_first_expr(expr.iter(), "definputdevices")?;
     let mut seen_ids = HashSet::default();
     let mut devices = vec![];
@@ -23,7 +26,7 @@ pub fn parse_definputdevices(expr: &[SExpr]) -> Result<Vec<(NonZeroU8, InputDevi
             );
         };
         let id_str = id_expr
-            .atom(None)
+            .atom(Some(vars))
             .ok_or_else(|| anyhow_expr!(id_expr, "device ID must be a number (1-255)"))?;
         let id_num: u8 = id_str
             .parse()
@@ -34,7 +37,7 @@ pub fn parse_definputdevices(expr: &[SExpr]) -> Result<Vec<(NonZeroU8, InputDevi
             bail_expr!(id_expr, "duplicate device ID: {id_num}");
         }
         let matcher_list = matchers_expr
-            .list(None)
+            .list(Some(vars))
             .ok_or_else(|| anyhow_expr!(matchers_expr, "device matchers must be a list"))?;
         if matcher_list.is_empty() {
             bail_expr!(
@@ -45,7 +48,7 @@ pub fn parse_definputdevices(expr: &[SExpr]) -> Result<Vec<(NonZeroU8, InputDevi
         }
         let mut matcher = InputDeviceMatcher::default();
         for m in matcher_list.iter() {
-            let props = m.list(None).ok_or_else(|| {
+            let props = m.list(Some(vars)).ok_or_else(|| {
                 anyhow_expr!(m, "each matcher must be a list, e.g. (name \"...\")")
             })?;
             if props.len() != 2 {
@@ -55,10 +58,10 @@ pub fn parse_definputdevices(expr: &[SExpr]) -> Result<Vec<(NonZeroU8, InputDevi
                 );
             }
             let prop_name = props[0]
-                .atom(None)
+                .atom(Some(vars))
                 .ok_or_else(|| anyhow_expr!(&props[0], "matcher property must be an atom"))?;
             let prop_val = props[1]
-                .atom(None)
+                .atom(Some(vars))
                 .ok_or_else(|| anyhow_expr!(&props[1], "matcher value must be an atom"))?;
             // Matcher values are commonly written as quoted strings in definputdevices.
             // Strip those syntax quotes before name matching or numeric/hash parsing.

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -640,11 +640,6 @@ pub fn parse_cfg_raw_string(
     }
     let (mut mapped_keys, mapping_order) = parse_defsrc(src_expr, &cfg)?;
 
-    let input_devices = root_exprs
-        .iter()
-        .find(gen_first_atom_filter("definputdevices"))
-        .map(|expr| parse_definputdevices(expr))
-        .transpose()?;
     if let Some(spanned) = spanned_root_exprs
         .iter()
         .filter(gen_first_atom_filter_spanned("definputdevices"))
@@ -661,6 +656,14 @@ pub fn parse_cfg_raw_string(
         .filter(gen_first_atom_filter("defvar"))
         .collect::<Vec<_>>();
     let vars = parse_vars(&var_exprs, &mut lsp_hints)?;
+
+    // Parsed after defvar so that device IDs can be written as variables, which is what the
+    // configuration guide recommends.
+    let input_devices = root_exprs
+        .iter()
+        .find(gen_first_atom_filter("definputdevices"))
+        .map(|expr| parse_definputdevices(expr, &vars))
+        .transpose()?;
 
     let deflayer_labels = [DEFLAYER, DEFLAYER_MAPPED];
     let deflayer_filter = |exprs: &&Vec<SExpr>| -> bool {

--- a/src/tests/sim_tests/switch_sim_tests.rs
+++ b/src/tests/sim_tests/switch_sim_tests.rs
@@ -97,3 +97,24 @@ fn sim_switch_not_logic() {
     .to_ascii();
     assert_eq!("dn:X t:10ms up:X", result);
 }
+
+/// The configuration guide recommends naming device IDs with `defvar`, so `definputdevices` has
+/// to resolve variables the same way `device-history` does.
+#[test]
+fn definputdevices_accepts_variables() {
+    let result = simulate(
+        r#"(defvar
+             id-internal 1
+             kbd-name "Apple Internal Keyboard"
+           )
+           (definputdevices
+             $id-internal ((name $kbd-name))
+           )
+           (defsrc a)
+           (deflayer base
+             (switch ((device-history $id-internal 1)) x break () a break))"#,
+        "d:a t:10 u:a t:10",
+    )
+    .to_ascii();
+    assert_eq!("dn:A t:10ms up:A", result);
+}


### PR DESCRIPTION
The `definputdevices` example in the configuration guide does not parse. It fails with `device ID must be a number (1-255)`, pointing at `$id-AppleInternal`:

```lisp
(defvar
  id-AppleInternal 1
  id-Go60          2
)

(definputdevices
  $id-AppleInternal ((name "Apple Internal Keyboard"))
  $id-Go60 ((name "Go60") (vendor_id 0x1D50) (product_id 0x615E))
)
```

Two things caused it. `definputdevices` was parsed before `defvar`, so no variable existed yet, and the block used `atom(None)`/`list(None)` throughout, so it would not have resolved one anyway. `(device-history $id 1)` in `switch` already uses `atom(s.vars())`, so the two halves of the feature disagreed.

This moves the block after `parse_vars` and passes the variables in, which also makes matcher values like `(name $kbd-name)` work. Literal IDs are unaffected.

Added a sim test covering a variable device ID and a variable matcher value; it fails on main with the error above.