### PR TITLE
fix(parser): enforce movemouse and mwheel distance bounds

### DIFF
--- a/parser/src/cfg/mouse.rs
+++ b/parser/src/cfg/mouse.rs
@@ -7,6 +7,7 @@ pub(crate) fn parse_distance(expr: &SExpr, s: &ParserState, label: &str) -> Resu
     expr.atom(s.vars())
         .map(str::parse::<u16>)
         .and_then(|d| d.ok())
+        .filter(|&dist| (1..=30000).contains(&dist))
         .ok_or_else(|| anyhow_expr!(expr, "{label} must be 1-30000"))
 }
 

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -445,6 +445,57 @@ fn unknown_defcfg_item_fails() {
 }
 
 #[test]
+fn parse_distance_rejects_out_of_range() {
+    // Regression: the 1..=30000 range promised by the error message must be
+    // enforced for movemouse/mwheel distances. A clippy cleanup (f3488c4)
+    // previously dropped the range guard while keeping the message, so 0 and
+    // 30001..=65535 were silently accepted.
+    for distance in ["0", "30001", "65535"] {
+        let source = format!(
+            r#"(defsrc a)
+(deflayer base (movemouse-up 1 {distance}))
+"#
+        );
+        let err = parse_cfg(&source).expect_err("out-of-range distance should be rejected");
+        assert!(
+            err.msg.contains("distance must be 1-30000"),
+            "distance {distance}: real e: {}",
+            err.msg
+        );
+    }
+
+    // mwheel shares parse_distance.
+    let source = r#"(defsrc a)
+(deflayer base (mwheel-up 1 0))
+"#;
+    let err = parse_cfg(source).expect_err("zero mwheel distance should be rejected");
+    assert!(
+        err.msg.contains("distance must be 1-30000"),
+        "real e: {}",
+        err.msg
+    );
+
+    // movemouse-accel min/max distances flow through parse_distance too.
+    let source = r#"(defsrc a)
+(deflayer base (movemouse-accel-up 1 1 0 5))
+"#;
+    let err = parse_cfg(source).expect_err("zero min distance should be rejected");
+    assert!(err.msg.contains("min distance must be 1-30000"));
+
+    // Boundary values 1 and 30000 are valid.
+    for distance in ["1", "30000"] {
+        let source = format!(
+            r#"(defsrc a)
+(deflayer base (movemouse-up 1 {distance}))
+"#
+        );
+        parse_cfg(&source)
+            .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+            .expect("in-range distance should parse");
+    }
+}
+
+#[test]
 fn recursive_multi_is_flattened() {
     macro_rules! atom {
         ($e:expr) => {


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

`parse_distance` (used by `movemouse-*`, `movemouse-accel-*` `min`/`max`, and `mwheel-*`) states in its error message that the value `must be 1-30000`, but a clippy cleanup (`f3488c4`, "misc: clippy") collapsed the range-checking `match` arm

```rust
.and_then(|d| match d {
    Ok(dist @ 1..=30000) => Some(dist),
    _ => None,
})
```

into `.and_then(|d| d.ok())`, dropping the `1..=30000` guard while keeping the message. As a result `0` and any value in `30001..=65535` parsed silently instead of being rejected — a zero distance is a no-op motion, and the over-max values exceed the documented contract.

Root cause: a behavior-preserving clippy simplification that was not actually behavior-preserving, because the `1..=30000` guard was load-bearing.

This restores the guard using `RangeInclusive::contains`, so the documented range is enforced again and the error message is honest.

## Checklist
- Add documentation to docs/config.adoc — [ ] N/A (no new user-visible option; the 1-30000 range was already the documented contract)
- Add example and basic docs to cfg_samples/kanata.kbd — [ ] N/A
- Update error messages — [x] Yes (the existing `"{label} must be 1-30000"` message is now actually reachable for out-of-range input)
- Added tests, or did manual testing — [x] Yes

## Verification
- `cargo fmt --all --check` — clean
- `cargo test --all` — 491 passed, 0 failed
- `cargo clippy --all -- -D warnings` — clean
- `cargo test --all --features=cmd` — 493 passed, 0 failed
- `cargo clippy --all --features=cmd -- -D warnings` — clean
- Ran on macOS 15.6 (Apple Silicon). Parser-only change, no hardware runtime verification performed.