### PR TITLE
fix(parser): consume value in non-applicable deflocalkeys variant

### DIFF
--- a/parser/src/cfg/deflocalkeys.rs
+++ b/parser/src/cfg/deflocalkeys.rs
@@ -66,6 +66,14 @@ pub(crate) fn parse_deflocalkeys(
         // use a dummy OsCode to keep the "same name" validation
         // while avoiding the u16->OsCode conversion attempt.
         if !deflocalkeys_variant_applies_to_current_os(def_local_keys_variant) {
+            // The value still has to be consumed so the next loop iteration
+            // reads the real key, not this key's value; otherwise a value that
+            // collides with a later key name trips a spurious "Duplicate" error
+            // and a config that is valid on its target OS fails to parse
+            // everywhere else.
+            if exprs.next().is_none() {
+                bail_expr!(key_expr, "Key without a number in {def_local_keys_variant}");
+            }
             localkeys.insert(key.to_owned(), OsCode::KEY_RESERVED);
             continue;
         }

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -1291,6 +1291,37 @@ new 316
 }
 
 #[test]
+fn deflocalkeys_non_applicable_variant_consumes_value() {
+    // Regression: a non-applicable deflocalkeys-* variant must still consume
+    // each key's paired value. Previously the non-applicable branch did
+    // `insert` + `continue` without advancing the iterator, so a value that
+    // collided with a later key name was read back as a key and tripped a
+    // spurious "Duplicate" error — a config valid on its target OS failed to
+    // parse on every other OS.
+    let non_applicable = DEFLOCALKEYS_VARIANTS
+        .iter()
+        .copied()
+        .find(|v| !deflocalkeys_variant_applies_to_current_os(v))
+        .expect("there are multiple variants, so at least one is non-applicable");
+
+    // The value `2` for key `1` collides with the next declared key `2`.
+    // On the variant's target OS this maps 1->2, 2->3 and parses fine; on
+    // every other OS it must parse fine too, not error with "Duplicate 2".
+    let source = format!(
+        r#"({non_applicable}
+  1 2
+  2 3
+)
+(defsrc 1 2)
+(deflayer base a b)
+"#
+    );
+    parse_cfg(&source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("non-applicable deflocalkeys variant must not spuriously reject");
+}
+
+#[test]
 fn use_default_overridable_mappings() {
     let source = r#"
 (defsrc + [  ]  a  b  /  ;  `  =  -  '  ,  .  9  yen ¥  )


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

`parse_deflocalkeys` runs for every `deflocalkeys-*` variant regardless of the host OS (it is looped over in `mod.rs`, and errors propagate before the non-applicable mapping is discarded). For a variant that does not apply to the current OS, the non-applicable branch inserted a placeholder `OsCode::KEY_RESERVED` for the key and `continue`d **without advancing the iterator past the paired value**. That value was then read back as the next key name; when it collided with a later declared key, parsing aborted with a spurious `Duplicate ... found in deflocalkeys-<variant>` error.

The user-visible consequence is that a config which is valid on its target OS fails to parse on every other OS — defeating the point of having per-OS variants. Example: a `deflocalkeys-win` block containing `1 2` then `2 3` parses fine on Windows but errors with `Duplicate 2 found in deflocalkeys-win` on macOS/Linux, because the orphaned value `2` of key `1` is mistaken for the next key.

Root cause: the `continue` skipped the only `exprs.next()` that consumes the value.

The fix consumes the value before continuing, reusing the same "Key without a number" arity check as the applicable branch so structural errors stay consistent across OSes.

## Checklist
- Add documentation to docs/config.adoc — [ ] N/A (no new user-visible option; per-OS variants are already documented)
- Add example and basic docs to cfg_samples/kanata.kbd — [ ] N/A
- Update error messages — [ ] N/A (no message change; a previously spurious error is simply no longer raised)
- Added tests, or did manual testing — [x] Yes

## Verification
- `cargo fmt --all --check` — clean
- `cargo test --all` — 491 passed, 0 failed
- `cargo clippy --all -- -D warnings` — clean
- `cargo test --all --features=cmd` — 493 passed, 0 failed
- `cargo clippy --all --features=cmd -- -D warnings` — clean
- Ran on macOS 15.6 (Apple Silicon). Parser-only change, no hardware runtime verification performed. The regression test picks a non-applicable variant at runtime via `DEFLOCALKEYS_VARIANTS`, so it exercises the bug on every OS.