### PR TITLE
feat(macos): route mouse buttons through the virtual HID pointing device

### DIFF
--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -291,6 +291,13 @@ pub struct Cfg {
     /// The potential outputs for a physical key position. The intention behind this is for sending
     /// key repeats.
     pub key_outputs: KeyOutputs,
+    /// Whether the config ever *outputs* a mouse button (`mlft`/`mrgt`/`mmid`/`mbck`/`mfwd` or
+    /// their `-tap` forms), anywhere — including inside nested actions, virtual keys, macros,
+    /// aliases and the on-load action. Tracked while parsing (see `mouse_button`) rather than by
+    /// walking the layout, so it does not depend on where the action ends up. macOS uses this to
+    /// gate installing the mouse event tap so configs that never emit mouse buttons do not request
+    /// extra permissions.
+    pub emits_mouse_buttons: bool,
     /// Layer info used for printing to the logs.
     pub layer_info: Vec<LayerInfo>,
     /// Configuration items in `defcfg`.
@@ -357,6 +364,10 @@ fn parse_cfg(p: &Path) -> MResult<Cfg> {
 fn populate_cfg_with_icfg(icfg: IntermediateCfg, s: ParserState) -> Cfg {
     let (layers, allocations) = icfg.klayers.get();
     let key_outputs = create_key_outputs(&layers, &icfg.overrides, &icfg.chords_v2);
+    // Tracked while parsing mouse-button actions (mlft/mrgt/… and their -tap
+    // forms), so it covers those actions wherever they end up — layers, virtual
+    // keys, macros, aliases, the on-load action — without walking the layout.
+    let emits_mouse_buttons = s.emits_mouse_buttons.get();
     let max_key_timing_check = std::cmp::max(
         s.max_key_timing_check.get(),
         icfg.options.tap_hold_require_prior_idle,
@@ -391,6 +402,7 @@ fn populate_cfg_with_icfg(icfg: IntermediateCfg, s: ParserState) -> Cfg {
         mapped_keys: icfg.mapped_keys,
         layer_info: icfg.layer_info,
         key_outputs,
+        emits_mouse_buttons,
         layout,
         sequences: icfg.sequences,
         overrides: icfg.overrides,
@@ -1167,6 +1179,11 @@ pub struct ParserState {
     block_unmapped_keys: bool,
     max_key_timing_check: Cell<u16>,
     multi_action_nest_count: Cell<u16>,
+    /// Set while parsing whenever a mouse-button output action (`mlft`/`mrgt`/
+    /// `mmid`/`mfwd`/`mbck`) is constructed, wherever it ends up — a layer, a
+    /// virtual key, a macro, an alias, or the on-load action. macOS reads this
+    /// (via `Cfg::emits_mouse_buttons`) to gate installing the mouse event tap.
+    emits_mouse_buttons: Cell<bool>,
     input_devices: Option<Vec<(std::num::NonZeroU8, InputDeviceMatcher)>>,
     pctx: ParserContext,
     pub lsp_hints: RefCell<LspHints>,
@@ -1200,6 +1217,7 @@ impl Default for ParserState {
             block_unmapped_keys: default_cfg.block_unmapped_keys,
             max_key_timing_check: Cell::new(0),
             multi_action_nest_count: Cell::new(0),
+            emits_mouse_buttons: Cell::new(false),
             input_devices: None,
             lsp_hints: Default::default(),
             hand_map: None,
@@ -1364,6 +1382,16 @@ fn custom(ca: CustomAction, a: &Allocations) -> Result<&'static KanataAction> {
     Ok(a.sref(Action::Custom(a.sref(ca))))
 }
 
+/// Like [`custom`], but also records that this config outputs a mouse button so
+/// macOS can gate the mouse event tap on actual usage. Used for both the direct
+/// button actions (`mlft`…) and the tap variants (`mltp`…); because every
+/// mouse-button action is constructed here, the flag is set regardless of where
+/// the action ends up (layer, virtual key, macro, alias, on-load action).
+fn mouse_button(ca: CustomAction, s: &ParserState) -> Result<&'static KanataAction> {
+    s.emits_mouse_buttons.set(true);
+    custom(ca, &s.a)
+}
+
 /// Parse a `kanata_keyberon::action::Action` from a string.
 fn parse_action_atom(ac_span: &Spanned<String>, s: &ParserState) -> Result<&'static KanataAction> {
     let ac = &*ac_span.t;
@@ -1397,16 +1425,18 @@ fn parse_action_atom(ac_span: &Spanned<String>, s: &ParserState) -> Result<&'sta
             );
         }
         "scnl" => return custom(CustomAction::SequenceCancel, &s.a),
-        "mlft" | "mouseleft" => return custom(CustomAction::Mouse(Btn::Left), &s.a),
-        "mrgt" | "mouseright" => return custom(CustomAction::Mouse(Btn::Right), &s.a),
-        "mmid" | "mousemid" => return custom(CustomAction::Mouse(Btn::Mid), &s.a),
-        "mfwd" | "mouseforward" => return custom(CustomAction::Mouse(Btn::Forward), &s.a),
-        "mbck" | "mousebackward" => return custom(CustomAction::Mouse(Btn::Backward), &s.a),
-        "mltp" | "mousetapleft" => return custom(CustomAction::MouseTap(Btn::Left), &s.a),
-        "mrtp" | "mousetapright" => return custom(CustomAction::MouseTap(Btn::Right), &s.a),
-        "mmtp" | "mousetapmid" => return custom(CustomAction::MouseTap(Btn::Mid), &s.a),
-        "mftp" | "mousetapforward" => return custom(CustomAction::MouseTap(Btn::Forward), &s.a),
-        "mbtp" | "mousetapbackward" => return custom(CustomAction::MouseTap(Btn::Backward), &s.a),
+        "mlft" | "mouseleft" => return mouse_button(CustomAction::Mouse(Btn::Left), s),
+        "mrgt" | "mouseright" => return mouse_button(CustomAction::Mouse(Btn::Right), s),
+        "mmid" | "mousemid" => return mouse_button(CustomAction::Mouse(Btn::Mid), s),
+        "mfwd" | "mouseforward" => return mouse_button(CustomAction::Mouse(Btn::Forward), s),
+        "mbck" | "mousebackward" => return mouse_button(CustomAction::Mouse(Btn::Backward), s),
+        "mltp" | "mousetapleft" => return mouse_button(CustomAction::MouseTap(Btn::Left), s),
+        "mrtp" | "mousetapright" => return mouse_button(CustomAction::MouseTap(Btn::Right), s),
+        "mmtp" | "mousetapmid" => return mouse_button(CustomAction::MouseTap(Btn::Mid), s),
+        "mftp" | "mousetapforward" => return mouse_button(CustomAction::MouseTap(Btn::Forward), s),
+        "mbtp" | "mousetapbackward" => {
+            return mouse_button(CustomAction::MouseTap(Btn::Backward), s);
+        }
         "mwu" | "mousewheelup" => {
             return custom(
                 CustomAction::MWheelNotch {

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -107,6 +107,68 @@ fn sizeof_action_is_two_usizes() {
 }
 
 #[test]
+fn emits_mouse_buttons_detects_in_layer_actions() {
+    let _lk = lock(&CFG_PARSE_LOCK);
+    // A mouse button output (`mlft`/`mrgt`/… and `-tap` forms) should flip the
+    // flag, plain or nested inside another action, including inside a macro
+    // (stored as a Sequence, which the flag catches at parse time).
+    for (name, action) in [
+        ("plain", "mlft"),
+        ("tap-variant", "mltp"),
+        ("multi", "(multi a mlft)"),
+        ("tap-hold", "(tap-hold 200 200 a mlft)"),
+        ("fork", "(fork a mmid (lctl))"),
+        ("macro", "(macro mlft)"),
+    ] {
+        let src = format!("(defsrc a)\n(deflayer base {action})");
+        let cfg = new_from_str(&src, HashMap::default())
+            .unwrap_or_else(|e| panic!("{name} config should parse: {e:?}"));
+        assert!(
+            cfg.emits_mouse_buttons,
+            "{name}: expected emits_mouse_buttons = true"
+        );
+    }
+}
+
+#[test]
+fn emits_mouse_buttons_detects_outside_layers() {
+    let _lk = lock(&CFG_PARSE_LOCK);
+    // The mouse button lives only in a virtual key, not on any layer key.
+    let vkey = "(defsrc a)\n(deflayer base (on-press-fakekey mymouse press))\n\
+                (defvirtualkeys mymouse mlft)";
+    // The mouse button lives only in an alias used solely as the on-load action.
+    let on_load = "(defcfg alias-to-trigger-on-load startmouse)\n(defsrc a)\n\
+                   (deflayer base a)\n(defalias startmouse mlft)";
+    for (name, src) in [("virtual-key", vkey), ("on-load-alias", on_load)] {
+        let cfg = new_from_str(src, HashMap::default())
+            .unwrap_or_else(|e| panic!("{name} config should parse: {e:?}"));
+        assert!(
+            cfg.emits_mouse_buttons,
+            "{name}: expected emits_mouse_buttons = true"
+        );
+    }
+}
+
+#[test]
+fn emits_mouse_buttons_false_without_mouse_button_output() {
+    let _lk = lock(&CFG_PARSE_LOCK);
+    // Plain keys, mouse *wheel* and mouse *movement* are not mouse buttons.
+    for (name, action) in [
+        ("plain-key", "b"),
+        ("mwheel", "(mwheel-up 50 120)"),
+        ("movemouse", "(movemouse-up 1 1)"),
+    ] {
+        let src = format!("(defsrc a)\n(deflayer base {action})");
+        let cfg = new_from_str(&src, HashMap::default())
+            .unwrap_or_else(|e| panic!("{name} config should parse: {e:?}"));
+        assert!(
+            !cfg.emits_mouse_buttons,
+            "{name}: expected emits_mouse_buttons = false"
+        );
+    }
+}
+
+#[test]
 fn test_span_absolute_ranges() {
     let s = "(hello world my oyster)\n(row two)";
     let tlevel = parse(s, "test").unwrap();

--- a/src/kanata/macos.rs
+++ b/src/kanata/macos.rs
@@ -112,9 +112,12 @@ impl Kanata {
         // the project-wide lock order `kanata -> MAPPED_KEYS`. Reversing it here
         // would create a new ordering edge with the rest of this file.
         {
-            let mmk = kanata.lock().mouse_movement_key.clone();
+            let (mmk, emb) = {
+                let k = kanata.lock();
+                (k.mouse_movement_key.clone(), k.emits_mouse_buttons.clone())
+            };
             let mapped = MAPPED_KEYS.lock();
-            let _ = crate::oskbd::start_mouse_listener(tx.clone(), &mapped, mmk);
+            let _ = crate::oskbd::start_mouse_listener(tx.clone(), &mapped, mmk, emb);
         }
 
         // Toggles `is_screen_grab_paused()` on lock / fast-user-switch.

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -326,6 +326,12 @@ pub struct Kanata {
         target_os = "unknown"
     ))]
     pub(crate) mouse_movement_key: Arc<Mutex<Option<OsCode>>>,
+    /// Whether the loaded config outputs mouse buttons. Gates installing the
+    /// macOS mouse event tap (for drag-assist) so configs that never emit mouse
+    /// buttons do not request the extra Accessibility / Input Monitoring
+    /// permission. Shared with the tap's install gate and updated on reload.
+    #[cfg(target_os = "macos")]
+    pub(crate) emits_mouse_buttons: Arc<Mutex<bool>>,
     /// Time when kanata started (for uptime tracking)
     #[cfg(feature = "tcp_server")]
     start_time: web_time::Instant,
@@ -554,6 +560,8 @@ impl Kanata {
                 target_os = "unknown"
             ))]
             mouse_movement_key: Arc::new(Mutex::new(cfg.options.mouse_movement_key)),
+            #[cfg(target_os = "macos")]
+            emits_mouse_buttons: Arc::new(Mutex::new(cfg.emits_mouse_buttons)),
             #[cfg(feature = "tcp_server")]
             start_time: web_time::Instant::now(),
             #[cfg(feature = "tcp_server")]
@@ -709,6 +717,8 @@ impl Kanata {
                 target_os = "unknown"
             ))]
             mouse_movement_key: Arc::new(Mutex::new(cfg.options.mouse_movement_key)),
+            #[cfg(target_os = "macos")]
+            emits_mouse_buttons: Arc::new(Mutex::new(cfg.emits_mouse_buttons)),
             #[cfg(feature = "tcp_server")]
             start_time: web_time::Instant::now(),
             #[cfg(feature = "tcp_server")]
@@ -840,6 +850,16 @@ impl Kanata {
             }
 
             *self.mouse_movement_key.lock() = cfg.options.mouse_movement_key;
+
+            // Refresh the mouse-button-output flag so the reload install gate
+            // (below) sees whether the new config emits mouse buttons. The tap
+            // reads this Arc live, so a reload that starts emitting mouse
+            // buttons installs the tap; the tap is process-lifetime and is not
+            // uninstalled if a later reload stops emitting them.
+            #[cfg(target_os = "macos")]
+            {
+                *self.emits_mouse_buttons.lock() = cfg.emits_mouse_buttons;
+            }
 
             #[cfg(target_os = "macos")]
             crate::oskbd::ensure_mouse_listener_installed_after_reload();

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -58,22 +58,18 @@ static DRAG_FORWARD_HELD: AtomicBool = AtomicBool::new(false);
 /// button so simultaneously-held buttons do not share state.
 static DRAG_CLICK_STATE: [AtomicI64; BUTTON_INDEX_COUNT] =
     [const { AtomicI64::new(1) }; BUTTON_INDEX_COUNT];
-/// Per-button cursor position captured at the start of a fallback drag gesture.
+/// Per-button cursor position captured at button press in `button_action`.
 /// The mouse-event-tap measures travel from here and drops the synthesized
 /// clickState to 0 once it exceeds `DRAG_CLICK_CANCEL_PX`, mirroring macOS's
 /// own click-cancellation on the HID path (measured to fire after ~8 px).
 /// Without this a fallback drag keeps clickState ≥ 1 forever, so apps that
 /// separate a click from a drag by clickCount see a click — the bug #2061
-/// opens with.
+/// opens with. Capturing at the press (rather than the first `MouseMoved`)
+/// counts the first delta, so a fast flick does not understate its own travel.
 static DRAG_ORIGIN_X: [AtomicI64; BUTTON_INDEX_COUNT] =
     [const { AtomicI64::new(0) }; BUTTON_INDEX_COUNT];
 static DRAG_ORIGIN_Y: [AtomicI64; BUTTON_INDEX_COUNT] =
     [const { AtomicI64::new(0) }; BUTTON_INDEX_COUNT];
-/// Per-button flag, false until `DRAG_ORIGIN_*` has been captured for the
-/// current gesture. Reset on every button press so each gesture measures from
-/// its own start.
-static DRAG_ORIGIN_CAPTURED: [AtomicBool; BUTTON_INDEX_COUNT] =
-    [const { AtomicBool::new(false) }; BUTTON_INDEX_COUNT];
 /// Per-button flag, set by the tap once a drag passes `DRAG_CLICK_CANCEL_PX`,
 /// so the fallback MouseUp in `button_action` also reports clickState 0 — the
 /// HID path cancels the click on both the drag *and* the release, and reading
@@ -1492,9 +1488,15 @@ impl KbdOut {
                 // press. Reuses the same-button / interval / slop rule as the
                 // CGEvent path.
                 if let Ok(event) = Self::make_event() {
-                    self.click_state[index] = self.next_click_state(index, event.location());
+                    let pos = event.location();
+                    self.click_state[index] = self.next_click_state(index, pos);
+                    // Measure drag travel from this press for click cancellation
+                    // in the tap (see DRAG_ORIGIN_*). Best-effort on this path:
+                    // if the position is unavailable the origin keeps its prior
+                    // value, same as the click-state update above.
+                    DRAG_ORIGIN_X[index].store(pos.x as i64, Ordering::Release);
+                    DRAG_ORIGIN_Y[index].store(pos.y as i64, Ordering::Release);
                 }
-                DRAG_ORIGIN_CAPTURED[index].store(false, Ordering::Release);
                 DRAG_CANCELLED[index].store(false, Ordering::Release);
             }
             log::debug!("pointing button: btn={btn:?} hid_button={hid_button} is_click={is_click}");
@@ -1605,9 +1607,10 @@ impl KbdOut {
             f.store(is_click, Ordering::Release);
             if is_click {
                 DRAG_CLICK_STATE[index].store(self.click_state[index], Ordering::Release);
-                // Start measuring drag travel from this press for click
+                // Measure drag travel from this press position for click
                 // cancellation in the tap (see DRAG_ORIGIN_*).
-                DRAG_ORIGIN_CAPTURED[index].store(false, Ordering::Release);
+                DRAG_ORIGIN_X[index].store(mouse_position.x as i64, Ordering::Release);
+                DRAG_ORIGIN_Y[index].store(mouse_position.y as i64, Ordering::Release);
                 DRAG_CANCELLED[index].store(false, Ordering::Release);
             }
         }
@@ -2000,15 +2003,23 @@ pub fn start_mouse_listener(
                                 // a click from a drag by clickCount sees a click.
                                 // Latch DRAG_CANCELLED so the matching MouseUp
                                 // (emitted from button_action) also reports 0.
+                                //
+                                // Travel is absolute displacement from the press
+                                // origin, which is not monotonic: a drag that
+                                // wanders back toward its start measures short
+                                // again. Read the latch first so cancellation is
+                                // one-way for the rest of the gesture — real
+                                // hardware never revives a click count mid-drag,
+                                // and an app that already classified the gesture
+                                // as a drag must not see it turn back into a
+                                // click.
                                 let bi = dnumber as usize;
                                 let loc = event.location();
-                                if !DRAG_ORIGIN_CAPTURED[bi].swap(true, Ordering::AcqRel) {
-                                    DRAG_ORIGIN_X[bi].store(loc.x as i64, Ordering::Release);
-                                    DRAG_ORIGIN_Y[bi].store(loc.y as i64, Ordering::Release);
-                                }
                                 let dx = loc.x - DRAG_ORIGIN_X[bi].load(Ordering::Acquire) as f64;
                                 let dy = loc.y - DRAG_ORIGIN_Y[bi].load(Ordering::Acquire) as f64;
-                                let click_state = if dx.abs() > DRAG_CLICK_CANCEL_PX
+                                let click_state = if DRAG_CANCELLED[bi].load(Ordering::Acquire) {
+                                    0
+                                } else if dx.abs() > DRAG_CLICK_CANCEL_PX
                                     || dy.abs() > DRAG_CLICK_CANCEL_PX
                                 {
                                     DRAG_CANCELLED[bi].store(true, Ordering::Release);

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -39,6 +39,23 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::SyncSender as Sender;
 use std::time::{Duration, Instant};
 
+/// Drag-assist state: set true while the synthesized mouse button is held by
+/// kanata output. The mouse-event-tap reads these on every physical
+/// MouseMoved and synthesizes a matching MouseDragged so that drag gestures
+/// (kanata-down + physical-trackpad-move) compose correctly. Side buttons
+/// (Backward = HID#4, Forward = HID#5) ride on OtherMouseDragged with the
+/// MOUSE_EVENT_BUTTON_NUMBER field overridden, mirroring the synthesis
+/// path in `button_action`.
+static DRAG_LEFT_HELD: AtomicBool = AtomicBool::new(false);
+static DRAG_RIGHT_HELD: AtomicBool = AtomicBool::new(false);
+static DRAG_MID_HELD: AtomicBool = AtomicBool::new(false);
+static DRAG_BACKWARD_HELD: AtomicBool = AtomicBool::new(false);
+static DRAG_FORWARD_HELD: AtomicBool = AtomicBool::new(false);
+/// Last clickState stamped on a kanata-synthesized button down, reused on
+/// every drag-assist Dragged event so WindowServer keeps the gesture in the
+/// same click sequence (single drag, double-click drag, …).
+static DRAG_CLICK_STATE: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(1);
+
 /// Mouse `OsCode`s that, when present in `MAPPED_KEYS`, justify installing the
 /// CGEventTap. Used both as the startup/reload install gate and as the set of
 /// codes the tap can produce.
@@ -1128,6 +1145,10 @@ fn set_hid_caps_lock_state(state: bool) -> io::Result<()> {
 pub struct KbdOut {
     output_pressed_since: HashMap<OsCode, Instant>,
     caps_lock_state: Option<bool>,
+    /// Last left-click down timestamp + running clickCount, used to populate
+    /// `kCGMouseEventClickState` so WindowServer recognizes double/triple clicks.
+    /// Tracked per-button.
+    last_click: HashMap<Btn, (Instant, i64)>,
 }
 
 /// Treat a sink-disconnect from the processing thread as a non-fatal drop.
@@ -1158,6 +1179,7 @@ impl KbdOut {
         Ok(KbdOut {
             output_pressed_since: HashMap::default(),
             caps_lock_state: get_hid_caps_lock_state(),
+            last_click: HashMap::default(),
         })
     }
 
@@ -1395,7 +1417,9 @@ impl KbdOut {
             ),
         };
 
-        let event_source = Self::make_event_source()?;
+        // Use the HID-system source so BTT (and similar) treat this
+        // synthesized button as a real hardware click / drag start.
+        let event_source = Self::make_event_source_hid()?;
         let event = Self::make_event()?;
         let mouse_position = event.location();
         let event = CGEvent::new_mouse_event(event_source, event_type, mouse_position, button)
@@ -1405,8 +1429,47 @@ impl KbdOut {
             event.set_integer_value_field(EventField::MOUSE_EVENT_BUTTON_NUMBER, num);
         }
 
+        // Compute and stamp clickCount so WindowServer recognizes
+        // double/triple clicks. Only updated on down; up reuses the count.
+        // Threshold matches NSEvent.doubleClickInterval default (~500ms).
+        let click_count = if is_click {
+            const DBL_CLICK_WINDOW: Duration = Duration::from_millis(500);
+            let now = Instant::now();
+            let entry = self.last_click.entry(btn).or_insert((now, 0));
+            let count = if now.duration_since(entry.0) <= DBL_CLICK_WINDOW {
+                entry.1 + 1
+            } else {
+                1
+            };
+            *entry = (now, count);
+            count
+        } else {
+            self.last_click.get(&btn).map(|(_, c)| *c).unwrap_or(1)
+        };
+        event.set_integer_value_field(EventField::MOUSE_EVENT_CLICK_STATE, click_count);
+
         // Mouse control only seems to work with CGEventTapLocation::HID.
         event.post(CGEventTapLocation::HID);
+
+        // Drag-assist (Plan G): keep a flag so the mouse-event-tap can
+        // synthesize Dragged events on physical trackpad movement while
+        // a kanata-driven button is held.
+        let flag = match btn {
+            Btn::Left => Some(&DRAG_LEFT_HELD),
+            Btn::Right => Some(&DRAG_RIGHT_HELD),
+            Btn::Mid => Some(&DRAG_MID_HELD),
+            Btn::Backward => Some(&DRAG_BACKWARD_HELD),
+            Btn::Forward => Some(&DRAG_FORWARD_HELD),
+        };
+        if let Some(f) = flag {
+            f.store(is_click, Ordering::Release);
+            if is_click {
+                DRAG_CLICK_STATE.store(click_count, Ordering::Release);
+            }
+        }
+        log::debug!(
+            "drag-assist: button_action btn={btn:?} is_click={is_click} click_count={click_count}"
+        );
         Ok(())
     }
 
@@ -1475,6 +1538,20 @@ impl KbdOut {
 
     fn make_event_source() -> Result<CGEventSource, Error> {
         CGEventSource::new(CGEventSourceStateID::CombinedSessionState)
+            .map_err(|_| Error::other("failed to create core graphics event source"))
+    }
+
+    /// Like `make_event_source` but reports `HIDSystemState` as the event's
+    /// source state — the same state real hardware events carry. Some apps
+    /// distinguish "real" from "synthetic" input by this field: notably
+    /// BetterTouchTool's window-snap detection only arms when a mouse-down
+    /// looks like a genuine hardware drag gesture. A `CombinedSessionState`
+    /// (ID 0) source marks the event as synthetic and BTT never treats it as
+    /// a drag start; `HIDSystemState` (ID 1) makes the synthesized button
+    /// indistinguishable from a physical click for those consumers. Used only
+    /// for mouse buttons — keyboard events keep the combined-session source.
+    fn make_event_source_hid() -> Result<CGEventSource, Error> {
+        CGEventSource::new(CGEventSourceStateID::HIDSystemState)
             .map_err(|_| Error::other("failed to create core graphics event source"))
     }
     /// Creates a core graphics event.
@@ -1680,6 +1757,67 @@ pub fn start_mouse_listener(
                             | CGEventType::RightMouseDragged
                             | CGEventType::OtherMouseDragged
                     ) {
+                        // Drag-assist: if a kanata-driven button is held,
+                        // rewrite this physical MouseMoved *in place* into the
+                        // matching Dragged event, then pass that single event
+                        // through.
+                        //
+                        // The earlier approach posted a *separate* synthesized
+                        // Dragged and still forwarded the bare MouseMoved. That
+                        // works in native AppKit (its drag loop only consumes
+                        // Dragged/Up and ignores the stray Moved) but breaks in
+                        // Chromium/Electron: blink translates each NSEvent
+                        // independently, so an interleaved no-button MouseMoved
+                        // between Dragged events reads as the button bouncing
+                        // up→down and shatters a fine drag into repeated clicks
+                        // (the "連続発火" symptom). Emitting exactly one event
+                        // per physical move, already typed as Dragged, gives
+                        // both stacks the clean Dragged-only stream a drag
+                        // expects.
+                        //
+                        // Rewriting in place (vs new_mouse_event) also preserves
+                        // the physical event's deltaX/deltaY, pressure, etc. — a
+                        // freshly synthesized event carries no deltas, which some
+                        // drag handlers rely on. WindowServer does not
+                        // auto-promote MouseMoved → Dragged across event sources,
+                        // so we do the promotion ourselves.
+                        if matches!(event_type, CGEventType::MouseMoved) {
+                            // (Dragged type, MOUSE_EVENT_BUTTON_NUMBER override).
+                            // CGEvent button numbers are 0-indexed: Left=0,
+                            // Right=1, Mid=2, Backward=3, Forward=4. Side buttons
+                            // ride on OtherMouseDragged with the number
+                            // overridden, mirroring the path in `button_action`.
+                            let drag_target = if DRAG_LEFT_HELD.load(Ordering::Acquire) {
+                                Some((CGEventType::LeftMouseDragged, 0i64))
+                            } else if DRAG_RIGHT_HELD.load(Ordering::Acquire) {
+                                Some((CGEventType::RightMouseDragged, 1i64))
+                            } else if DRAG_MID_HELD.load(Ordering::Acquire) {
+                                Some((CGEventType::OtherMouseDragged, 2i64))
+                            } else if DRAG_BACKWARD_HELD.load(Ordering::Acquire) {
+                                Some((CGEventType::OtherMouseDragged, 3i64))
+                            } else if DRAG_FORWARD_HELD.load(Ordering::Acquire) {
+                                Some((CGEventType::OtherMouseDragged, 4i64))
+                            } else {
+                                None
+                            };
+                            if let Some((dtype, dnumber)) = drag_target {
+                                event.set_type(dtype);
+                                event.set_integer_value_field(
+                                    EventField::MOUSE_EVENT_BUTTON_NUMBER,
+                                    dnumber,
+                                );
+                                event.set_integer_value_field(
+                                    EventField::MOUSE_EVENT_CLICK_STATE,
+                                    DRAG_CLICK_STATE.load(Ordering::Acquire),
+                                );
+                                log::trace!(
+                                    "drag-assist: rewrite MouseMoved -> Dragged button={dnumber} pos=({:.0},{:.0})",
+                                    event.location().x,
+                                    event.location().y
+                                );
+                            }
+                        }
+
                         // The Arc is stashed before this tap is created, so
                         // `get()` is `Some` in practice. Fall back to a plain
                         // pass-through if not, rather than panicking on the

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -122,6 +122,12 @@ static MOUSE_TAP_INSTALLED: AtomicBool = AtomicBool::new(false);
 /// path updates, so changes take effect with no extra plumbing.
 static MOUSE_MOVEMENT_KEY: OnceLock<std::sync::Arc<parking_lot::Mutex<Option<OsCode>>>> =
     OnceLock::new();
+/// Whether the loaded config outputs mouse buttons. Part of the tap install
+/// gate: drag-assist needs the tap whenever a config *emits* mouse buttons,
+/// even with no mouse input mapped. Stashed here (like `MOUSE_MOVEMENT_KEY`) so
+/// the reload hook can re-gate, and read live so a reload that starts emitting
+/// mouse buttons installs the tap.
+static MOUSE_EMITS_BUTTONS: OnceLock<std::sync::Arc<parking_lot::Mutex<bool>>> = OnceLock::new();
 
 // --- Karabiner startup-abort diagnostics ---
 //
@@ -1853,15 +1859,17 @@ pub fn start_mouse_listener(
     tx: Sender<KeyEvent>,
     mapped_keys: &MappedKeys,
     mouse_movement_key: std::sync::Arc<parking_lot::Mutex<Option<OsCode>>>,
+    emits_mouse_buttons: std::sync::Arc<parking_lot::Mutex<bool>>,
 ) -> Option<std::thread::JoinHandle<()>> {
-    // Stash both unconditionally so the reload helper always has them, even
+    // Stash all three unconditionally so the reload helper always has them, even
     // if this initial call bails on the install gate. `OnceLock::set` is a
     // no-op on subsequent calls — we rely on the single-process,
-    // single-Kanata assumption: the inner `parking_lot::Mutex` is shared with
+    // single-Kanata assumption: the inner `parking_lot::Mutex`es are shared with
     // `do_live_reload`, so reloads mutate the *value*, never replace the
     // Arc. The `debug_assert!` surfaces accidental violations in test builds.
     let tx_was_unset = MOUSE_TAP_TX.set(tx.clone()).is_ok();
     let _ = MOUSE_MOVEMENT_KEY.set(mouse_movement_key.clone());
+    let _ = MOUSE_EMITS_BUTTONS.set(emits_mouse_buttons.clone());
     debug_assert!(
         tx_was_unset
             || std::sync::Arc::ptr_eq(
@@ -1874,17 +1882,25 @@ pub fn start_mouse_listener(
          the previously stashed Arc would be silently kept"
     );
 
-    // Always install the tap. Upstream gates installation on whether
-    // defsrc maps mouse keys (or a mouse-movement-key is configured),
-    // but this fork also uses the tap to translate physical MouseMoved
-    // into MouseDragged while a kanata-synthesized button is held —
-    // that path needs the tap regardless of input-side mapping. We
-    // still compute the upstream conditions so the install reason is
-    // visible in logs.
+    // Install the tap when the config uses the mouse in any way the tap serves:
+    //   - mouse keys mapped in defsrc, or a mouse-movement-key   (upstream gate)
+    //   - the config *outputs* mouse buttons                     (drag-assist)
+    // The drag-assist path rewrites physical MouseMoved into MouseDragged while
+    // a kanata-synthesized button is held, so it needs the tap even when no
+    // mouse input is mapped. A config that uses none of these never creates the
+    // tap, so it never triggers the Accessibility / Input Monitoring prompt —
+    // requesting the permission only when the feature is actually used.
     let has_mouse_keys = MOUSE_OSCODES.iter().any(|c| mapped_keys.contains(c));
     let has_movement_key = mouse_movement_key.lock().is_some();
+    let emits_buttons = *emits_mouse_buttons.lock();
+    if !(has_mouse_keys || has_movement_key || emits_buttons) {
+        log::info!(
+            "not installing mouse event tap (mouse_keys=false, movement_key=false, emits_buttons=false)"
+        );
+        return None;
+    }
     log::info!(
-        "Installing mouse event tap (mouse_keys={has_mouse_keys}, movement_key={has_movement_key}, drag_assist=always)"
+        "Installing mouse event tap (mouse_keys={has_mouse_keys}, movement_key={has_movement_key}, emits_buttons={emits_buttons})"
     );
 
     // Claim the install slot atomically *before* spawning. Closes the race
@@ -2154,14 +2170,15 @@ pub fn start_mouse_listener(
 }
 
 /// Re-attempt installing the mouse event tap after a live reload. The running
-/// tap callback already reads `MAPPED_KEYS` and `MOUSE_MOVEMENT_KEY` live, so
-/// if the tap is already up there is nothing to do — but if a reload introduces
-/// the first mouse key in defsrc or the first `mouse-movement-key` value, the
-/// startup-time install gate may have skipped installation, and we need to
-/// install now.
+/// tap callback already reads `MAPPED_KEYS`, `MOUSE_MOVEMENT_KEY` and
+/// `MOUSE_EMITS_BUTTONS` live, so if the tap is already up there is nothing to
+/// do — but if a reload introduces the first mouse key in defsrc, the first
+/// `mouse-movement-key`, or the first mouse-button *output*, the startup-time
+/// install gate may have skipped installation, and we need to install now.
 pub fn ensure_mouse_listener_installed_after_reload() {
     if MOUSE_TAP_INSTALLED.load(Ordering::Acquire) {
-        // Existing tap reads both MAPPED_KEYS and MOUSE_MOVEMENT_KEY live.
+        // Existing tap reads MAPPED_KEYS, MOUSE_MOVEMENT_KEY and
+        // MOUSE_EMITS_BUTTONS live.
         return;
     }
     let Some(tx) = MOUSE_TAP_TX.get().cloned() else {
@@ -2172,6 +2189,10 @@ pub fn ensure_mouse_listener_installed_after_reload() {
         log::debug!("mouse tap reload hook: no mouse_movement_key stashed yet, skipping");
         return;
     };
+    let Some(emb) = MOUSE_EMITS_BUTTONS.get().cloned() else {
+        log::debug!("mouse tap reload hook: no emits_mouse_buttons stashed yet, skipping");
+        return;
+    };
     let mapped = crate::kanata::MAPPED_KEYS.lock();
-    let _ = start_mouse_listener(tx, &mapped, mmk);
+    let _ = start_mouse_listener(tx, &mapped, mmk, emb);
 }

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -1730,15 +1730,18 @@ pub fn start_mouse_listener(
          the previously stashed Arc would be silently kept"
     );
 
+    // Always install the tap. Upstream gates installation on whether
+    // defsrc maps mouse keys (or a mouse-movement-key is configured),
+    // but this fork also uses the tap to translate physical MouseMoved
+    // into MouseDragged while a kanata-synthesized button is held —
+    // that path needs the tap regardless of input-side mapping. We
+    // still compute the upstream conditions so the install reason is
+    // visible in logs.
     let has_mouse_keys = MOUSE_OSCODES.iter().any(|c| mapped_keys.contains(c));
     let has_movement_key = mouse_movement_key.lock().is_some();
-    if !has_mouse_keys && !has_movement_key {
-        log::info!(
-            "No mouse buttons/wheel in defsrc and no mouse-movement-key configured. \
-             Not installing mouse event tap."
-        );
-        return None;
-    }
+    log::info!(
+        "Installing mouse event tap (mouse_keys={has_mouse_keys}, movement_key={has_movement_key}, drag_assist=always)"
+    );
 
     // Claim the install slot atomically *before* spawning. Closes the race
     // where a live reload could observe `MOUSE_TAP_INSTALLED == false` between

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -35,7 +35,7 @@ use std::fmt;
 use std::io;
 use std::io::Error;
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::mpsc::SyncSender as Sender;
 use std::time::{Duration, Instant};
 
@@ -51,10 +51,39 @@ static DRAG_RIGHT_HELD: AtomicBool = AtomicBool::new(false);
 static DRAG_MID_HELD: AtomicBool = AtomicBool::new(false);
 static DRAG_BACKWARD_HELD: AtomicBool = AtomicBool::new(false);
 static DRAG_FORWARD_HELD: AtomicBool = AtomicBool::new(false);
-/// Last clickState stamped on a kanata-synthesized button down, reused on
-/// every drag-assist Dragged event so WindowServer keeps the gesture in the
-/// same click sequence (single drag, double-click drag, …).
-static DRAG_CLICK_STATE: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(1);
+/// Per-button click count stamped on a kanata-synthesized button down, reused
+/// on every drag-assist Dragged event so WindowServer keeps the gesture in the
+/// same click sequence (single drag, double-click drag, …) until the drag
+/// travels far enough to cancel the click (see `DRAG_ORIGIN_*`). Indexed by
+/// button so simultaneously-held buttons do not share state.
+static DRAG_CLICK_STATE: [AtomicI64; BUTTON_INDEX_COUNT] =
+    [const { AtomicI64::new(1) }; BUTTON_INDEX_COUNT];
+/// Per-button cursor position captured at the start of a fallback drag gesture.
+/// The mouse-event-tap measures travel from here and drops the synthesized
+/// clickState to 0 once it exceeds `DRAG_CLICK_CANCEL_PX`, mirroring macOS's
+/// own click-cancellation on the HID path (measured to fire after ~8 px).
+/// Without this a fallback drag keeps clickState ≥ 1 forever, so apps that
+/// separate a click from a drag by clickCount see a click — the bug #2061
+/// opens with.
+static DRAG_ORIGIN_X: [AtomicI64; BUTTON_INDEX_COUNT] =
+    [const { AtomicI64::new(0) }; BUTTON_INDEX_COUNT];
+static DRAG_ORIGIN_Y: [AtomicI64; BUTTON_INDEX_COUNT] =
+    [const { AtomicI64::new(0) }; BUTTON_INDEX_COUNT];
+/// Per-button flag, false until `DRAG_ORIGIN_*` has been captured for the
+/// current gesture. Reset on every button press so each gesture measures from
+/// its own start.
+static DRAG_ORIGIN_CAPTURED: [AtomicBool; BUTTON_INDEX_COUNT] =
+    [const { AtomicBool::new(false) }; BUTTON_INDEX_COUNT];
+/// Per-button flag, set by the tap once a drag passes `DRAG_CLICK_CANCEL_PX`,
+/// so the fallback MouseUp in `button_action` also reports clickState 0 — the
+/// HID path cancels the click on both the drag *and* the release, and reading
+/// clickCount on mouse-up is how some apps classify a click vs a drag. Reset on
+/// press.
+static DRAG_CANCELLED: [AtomicBool; BUTTON_INDEX_COUNT] =
+    [const { AtomicBool::new(false) }; BUTTON_INDEX_COUNT];
+/// Pointer travel (px, per axis) after which a fallback drag stops carrying
+/// the press's click count. Matches the ~8 px HID cancellation window.
+const DRAG_CLICK_CANCEL_PX: f64 = 8.0;
 
 /// Mouse `OsCode`s that, when present in `MAPPED_KEYS`, justify installing the
 /// CGEventTap. Used both as the startup/reload install gate and as the set of
@@ -1452,6 +1481,10 @@ impl KbdOut {
             };
             flag.store(is_click, Ordering::Release);
             self.button_path[index] = is_click.then_some(ButtonPath::Hid);
+            if is_click {
+                DRAG_ORIGIN_CAPTURED[index].store(false, Ordering::Release);
+                DRAG_CANCELLED[index].store(false, Ordering::Release);
+            }
             log::debug!("pointing button: btn={btn:?} hid_button={hid_button} is_click={is_click}");
             return Ok(());
         }
@@ -1530,7 +1563,16 @@ impl KbdOut {
         if is_click {
             self.click_state[index] = self.next_click_state(index, mouse_position);
         }
-        event.set_integer_value_field(EventField::MOUSE_EVENT_CLICK_STATE, self.click_state[index]);
+        // On release, if the drag traveled past the cancel threshold, report
+        // clickState 0 to match the HID path (whose MouseUp also cancels the
+        // click after ~8 px); a normal click / multi-click release keeps its
+        // press count so double/triple clicks still register on mouse-up.
+        let click_state = if !is_click && DRAG_CANCELLED[index].load(Ordering::Acquire) {
+            0
+        } else {
+            self.click_state[index]
+        };
+        event.set_integer_value_field(EventField::MOUSE_EVENT_CLICK_STATE, click_state);
 
         // Mouse control only seems to work with CGEventTapLocation::HID.
         event.post(CGEventTapLocation::HID);
@@ -1550,7 +1592,11 @@ impl KbdOut {
         if let Some(f) = flag {
             f.store(is_click, Ordering::Release);
             if is_click {
-                DRAG_CLICK_STATE.store(self.click_state[index], Ordering::Release);
+                DRAG_CLICK_STATE[index].store(self.click_state[index], Ordering::Release);
+                // Start measuring drag travel from this press for click
+                // cancellation in the tap (see DRAG_ORIGIN_*).
+                DRAG_ORIGIN_CAPTURED[index].store(false, Ordering::Release);
+                DRAG_CANCELLED[index].store(false, Ordering::Release);
             }
         }
         log::debug!(
@@ -1932,14 +1978,40 @@ pub fn start_mouse_listener(
                                     EventField::MOUSE_EVENT_BUTTON_NUMBER,
                                     dnumber,
                                 );
+                                // Cancel the click once the drag has traveled
+                                // far enough, mirroring the HID path where macOS
+                                // drops clickState to 0 after ~8 px. Until then
+                                // the press's count rides along so a barely-moved
+                                // (multi-)click still registers. Without the
+                                // zeroing, a fallback drag keeps clickState ≥ 1
+                                // for its whole length and an app that separates
+                                // a click from a drag by clickCount sees a click.
+                                // Latch DRAG_CANCELLED so the matching MouseUp
+                                // (emitted from button_action) also reports 0.
+                                let bi = dnumber as usize;
+                                let loc = event.location();
+                                if !DRAG_ORIGIN_CAPTURED[bi].swap(true, Ordering::AcqRel) {
+                                    DRAG_ORIGIN_X[bi].store(loc.x as i64, Ordering::Release);
+                                    DRAG_ORIGIN_Y[bi].store(loc.y as i64, Ordering::Release);
+                                }
+                                let dx = loc.x - DRAG_ORIGIN_X[bi].load(Ordering::Acquire) as f64;
+                                let dy = loc.y - DRAG_ORIGIN_Y[bi].load(Ordering::Acquire) as f64;
+                                let click_state = if dx.abs() > DRAG_CLICK_CANCEL_PX
+                                    || dy.abs() > DRAG_CLICK_CANCEL_PX
+                                {
+                                    DRAG_CANCELLED[bi].store(true, Ordering::Release);
+                                    0
+                                } else {
+                                    DRAG_CLICK_STATE[bi].load(Ordering::Acquire)
+                                };
                                 event.set_integer_value_field(
                                     EventField::MOUSE_EVENT_CLICK_STATE,
-                                    DRAG_CLICK_STATE.load(Ordering::Acquire),
+                                    click_state,
                                 );
                                 log::trace!(
-                                    "drag-assist: rewrite MouseMoved -> Dragged button={dnumber} pos=({:.0},{:.0})",
-                                    event.location().x,
-                                    event.location().y
+                                    "drag-assist: rewrite MouseMoved -> Dragged button={dnumber} click_state={click_state} pos=({:.0},{:.0})",
+                                    loc.x,
+                                    loc.y
                                 );
                             }
                         }

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -1366,6 +1366,46 @@ impl KbdOut {
     /// [1]: https://developer.apple.com/documentation/coregraphics/cgevent/init(mouseeventsource:mousetype:mousecursorposition:mousebutton:)
     /// [2]: https://developer.apple.com/documentation/coregraphics/cgevent/setintegervaluefield(_:value:)
     fn button_action(&mut self, btn: Btn, is_click: bool) -> Result<(), io::Error> {
+        // Preferred path: inject the button through the Karabiner
+        // VirtualHIDDevice pointing device so it is a *real* HID event.
+        // CGEvent-synthesized buttons — even with an HID-system source state —
+        // are invisible to consumers that read below the CGEvent layer, notably
+        // BetterTouchTool's window-snap detection, which only arms for genuine
+        // HID pointing input (confirmed: a physical mouse/trackpad triggers it,
+        // a CGEvent-synthesized click does not). A real HID button held during
+        // physical trackpad motion makes WindowServer emit a true drag, so this
+        // is what lets BTT snap areas react to kanata drags.
+        //
+        // We still keep the DRAG_*_HELD flags in sync (below) so the CGEvent
+        // drag-assist path remains a fallback if WindowServer ever delivers a
+        // bare MouseMoved instead of a Dragged while the button is held.
+        if is_pointing_ready() {
+            // HID button numbers are 1-indexed: 1=L, 2=R, 3=Mid, 4=Back, 5=Fwd.
+            let hid_button: u8 = match btn {
+                Btn::Left => 1,
+                Btn::Right => 2,
+                Btn::Mid => 3,
+                Btn::Backward => 4,
+                Btn::Forward => 5,
+            };
+            if is_click {
+                pointing_button_press(hid_button);
+            } else {
+                pointing_button_release(hid_button);
+            }
+            let flag = match btn {
+                Btn::Left => &DRAG_LEFT_HELD,
+                Btn::Right => &DRAG_RIGHT_HELD,
+                Btn::Mid => &DRAG_MID_HELD,
+                Btn::Backward => &DRAG_BACKWARD_HELD,
+                Btn::Forward => &DRAG_FORWARD_HELD,
+            };
+            flag.store(is_click, Ordering::Release);
+            log::debug!("pointing button: btn={btn:?} hid_button={hid_button} is_click={is_click}");
+            return Ok(());
+        }
+
+        // Fallback: pointing sink not ready — synthesize via CGEvent.
         // (event_type, placeholder_button, real_button_number_override)
         let (event_type, button, button_number) = match btn {
             Btn::Left => (

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -1894,8 +1894,10 @@ pub fn start_mouse_listener(
     let has_movement_key = mouse_movement_key.lock().is_some();
     let emits_buttons = *emits_mouse_buttons.lock();
     if !(has_mouse_keys || has_movement_key || emits_buttons) {
+        // Interpolate the same variables as the install branch below (all false
+        // here) so the line cannot go stale if the gate condition grows.
         log::info!(
-            "not installing mouse event tap (mouse_keys=false, movement_key=false, emits_buttons=false)"
+            "not installing mouse event tap (mouse_keys={has_mouse_keys}, movement_key={has_movement_key}, emits_buttons={emits_buttons})"
         );
         return None;
     }

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -1482,6 +1482,18 @@ impl KbdOut {
             flag.store(is_click, Ordering::Release);
             self.button_path[index] = is_click.then_some(ButtonPath::Hid);
             if is_click {
+                // Advance the fallback click bookkeeping here too, even though
+                // the HID event carries no CGEvent clickState (macOS counts the
+                // real HID clicks itself). Keeping this state path-independent
+                // means a later CGEvent-fallback click continues from the actual
+                // previous click instead of reviving a stale count left over
+                // from before the path switched. Best-effort: if the cursor
+                // position is unavailable, skip the update rather than fail the
+                // press. Reuses the same-button / interval / slop rule as the
+                // CGEvent path.
+                if let Ok(event) = Self::make_event() {
+                    self.click_state[index] = self.next_click_state(index, event.location());
+                }
                 DRAG_ORIGIN_CAPTURED[index].store(false, Ordering::Release);
                 DRAG_CANCELLED[index].store(false, Ordering::Release);
             }

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -1145,10 +1145,12 @@ fn set_hid_caps_lock_state(state: bool) -> io::Result<()> {
 pub struct KbdOut {
     output_pressed_since: HashMap<OsCode, Instant>,
     caps_lock_state: Option<bool>,
-    /// Last left-click down timestamp + running clickCount, used to populate
-    /// `kCGMouseEventClickState` so WindowServer recognizes double/triple clicks.
-    /// Tracked per-button.
-    last_click: HashMap<Btn, (Instant, i64)>,
+    /// Press that the next same-button press is compared against, to decide
+    /// whether it continues a multi-click sequence.
+    last_click: Option<(usize, Instant, CGPoint)>,
+    /// Click count in flight per button index, so a release stamps the same
+    /// count its press used.
+    click_state: [i64; BUTTON_INDEX_COUNT],
     /// Output path latched at press time per button index, so a release always
     /// goes out the mechanism its press used even if the pointing sink's
     /// readiness changed while the button was held.
@@ -1157,6 +1159,18 @@ pub struct KbdOut {
 
 /// Number of distinct mouse buttons kanata can synthesize.
 const BUTTON_INDEX_COUNT: usize = 5;
+
+/// Movement allowed between two presses that still count as a multi-click.
+///
+/// Deliberately looser than macOS itself: measured against a physical mouse,
+/// WindowServer stops counting a second click somewhere around 1.5 px. Clicks
+/// synthesized here are keyboard-driven, so a hand resting on the mouse can
+/// drift the cursor without the user meaning to end the sequence, and being
+/// stricter than needed loses double-clicks that were intended.
+const MULTI_CLICK_SLOP_PX: CGFloat = 5.0;
+
+/// Fallback for `NSEvent::doubleClickInterval`, matching the macOS default.
+const DEFAULT_DOUBLE_CLICK_INTERVAL: f64 = 0.5;
 
 /// Which output mechanism a mouse button press used. Latched per button at
 /// press time so the matching release is emitted the same way — mixing the two
@@ -1197,7 +1211,8 @@ impl KbdOut {
         Ok(KbdOut {
             output_pressed_since: HashMap::default(),
             caps_lock_state: get_hid_caps_lock_state(),
-            last_click: HashMap::default(),
+            last_click: None,
+            click_state: [1; BUTTON_INDEX_COUNT],
             button_path: [None; BUTTON_INDEX_COUNT],
         })
     }
@@ -1505,24 +1520,17 @@ impl KbdOut {
             event.set_integer_value_field(EventField::MOUSE_EVENT_BUTTON_NUMBER, num);
         }
 
-        // Compute and stamp clickCount so WindowServer recognizes
-        // double/triple clicks. Only updated on down; up reuses the count.
-        // Threshold matches NSEvent.doubleClickInterval default (~500ms).
-        let click_count = if is_click {
-            const DBL_CLICK_WINDOW: Duration = Duration::from_millis(500);
-            let now = Instant::now();
-            let entry = self.last_click.entry(btn).or_insert((now, 0));
-            let count = if now.duration_since(entry.0) <= DBL_CLICK_WINDOW {
-                entry.1 + 1
-            } else {
-                1
-            };
-            *entry = (now, count);
-            count
-        } else {
-            self.last_click.get(&btn).map(|(_, c)| *c).unwrap_or(1)
-        };
-        event.set_integer_value_field(EventField::MOUSE_EVENT_CLICK_STATE, click_count);
+        // Stamp clickCount so WindowServer recognizes double/triple clicks.
+        // Only recomputed on down; a release reuses the count its press set so
+        // the pair carries the same value. The count continues only when the
+        // press lands on the same button, soon enough *and* close enough — a
+        // time-only window runs away, stamping clickState 4, 5, 6… onto taps
+        // hundreds of pixels apart, which the drag-assist rewrite would then
+        // paint onto physical drags.
+        if is_click {
+            self.click_state[index] = self.next_click_state(index, mouse_position);
+        }
+        event.set_integer_value_field(EventField::MOUSE_EVENT_CLICK_STATE, self.click_state[index]);
 
         // Mouse control only seems to work with CGEventTapLocation::HID.
         event.post(CGEventTapLocation::HID);
@@ -1542,13 +1550,40 @@ impl KbdOut {
         if let Some(f) = flag {
             f.store(is_click, Ordering::Release);
             if is_click {
-                DRAG_CLICK_STATE.store(click_count, Ordering::Release);
+                DRAG_CLICK_STATE.store(self.click_state[index], Ordering::Release);
             }
         }
         log::debug!(
-            "drag-assist: button_action btn={btn:?} is_click={is_click} click_count={click_count}"
+            "drag-assist: button_action btn={btn:?} is_click={is_click} click_count={}",
+            self.click_state[index]
         );
         Ok(())
+    }
+
+    /// Click count for a press: continues the previous sequence when it lands
+    /// on the same button, soon enough and close enough, otherwise restarts.
+    fn next_click_state(&mut self, index: usize, position: CGPoint) -> i64 {
+        let now = Instant::now();
+        let continues = self
+            .last_click
+            .is_some_and(|(prev_index, prev_time, prev_position)| {
+                prev_index == index
+                    && now.duration_since(prev_time).as_secs_f64() <= Self::double_click_interval()
+                    && (prev_position.x - position.x).abs() <= MULTI_CLICK_SLOP_PX
+                    && (prev_position.y - position.y).abs() <= MULTI_CLICK_SLOP_PX
+            });
+        self.last_click = Some((index, now, position));
+        if continues {
+            self.click_state[index].saturating_add(1)
+        } else {
+            1
+        }
+    }
+
+    fn double_click_interval() -> f64 {
+        Class::get("NSEvent")
+            .map(|ns_event| unsafe { msg_send![ns_event, doubleClickInterval] })
+            .unwrap_or(DEFAULT_DOUBLE_CLICK_INTERVAL)
     }
 
     fn button_index(btn: Btn) -> usize {

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -1194,6 +1194,11 @@ pub struct KbdOut {
     /// in between (#2133), so while kanata is driving the cursor the position
     /// it last posted is kept as the origin of the next move instead.
     driven_mouse_position: Option<(CGPoint, SystemTime)>,
+    /// Buttons kanata is holding, in `NSEvent::pressedMouseButtons` bit order.
+    /// That API reports what the window server has settled on, which lags the
+    /// press kanata just posted, so it cannot be the only source for the
+    /// move-versus-drag decision.
+    held_buttons: usize,
 }
 
 /// Number of distinct mouse buttons kanata can synthesize.
@@ -1283,6 +1288,7 @@ impl KbdOut {
             click_state: [1; BUTTON_INDEX_COUNT],
             button_path: [None; BUTTON_INDEX_COUNT],
             driven_mouse_position: None,
+            held_buttons: 0,
         })
     }
 
@@ -1703,33 +1709,74 @@ impl KbdOut {
         }
     }
 
+    /// `NSEvent::pressedMouseButtons` bit for the buttons that have a CGEvent
+    /// drag type. The side buttons have none, so they cannot start a drag.
+    fn button_mask(btn: Btn) -> Option<usize> {
+        match btn {
+            Btn::Left => Some(1),
+            Btn::Right => Some(2),
+            Btn::Mid | Btn::Backward | Btn::Forward => None,
+        }
+    }
+
     pub fn click_btn(&mut self, btn: Btn) -> Result<(), io::Error> {
-        Self::button_action(self, btn, true)
+        Self::button_action(self, btn, true)?;
+        if let Some(mask) = Self::button_mask(btn) {
+            self.held_buttons |= mask;
+        }
+        Ok(())
     }
 
     pub fn release_btn(&mut self, btn: Btn) -> Result<(), io::Error> {
-        Self::button_action(self, btn, false)
+        Self::button_action(self, btn, false)?;
+        if let Some(mask) = Self::button_mask(btn) {
+            self.held_buttons &= !mask;
+        }
+        Ok(())
     }
 
     pub fn move_mouse(&mut self, mv: CalculatedMouseMove) -> Result<(), io::Error> {
-        let pressed = Self::pressed_buttons();
+        let pressed = Self::pressed_buttons() | self.held_buttons;
 
-        let event_type = if pressed & 1 > 0 {
-            CGEventType::LeftMouseDragged
+        let (event_type, dragged_index) = if pressed & 1 > 0 {
+            (
+                CGEventType::LeftMouseDragged,
+                Some(Self::button_index(Btn::Left)),
+            )
         } else if pressed & 2 > 0 {
-            CGEventType::RightMouseDragged
+            (
+                CGEventType::RightMouseDragged,
+                Some(Self::button_index(Btn::Right)),
+            )
         } else {
-            CGEventType::MouseMoved
+            (CGEventType::MouseMoved, None)
         };
 
+        // A drag carries the same source as the button that started it, so a
+        // consumer that only trusts HID input does not see the press and the
+        // motion come from two different devices.
+        let event_source = match dragged_index {
+            Some(_) => Self::make_event_source_hid()?,
+            None => Self::make_event_source()?,
+        };
         let origin = self.mouse_origin()?;
         let mouse_position = Self::moved_position(origin, &mv, &Self::display_bounds());
         if let Ok(event) = CGEvent::new_mouse_event(
-            Self::make_event_source()?,
+            event_source,
             event_type,
             mouse_position,
             CGMouseButton::Left,
         ) {
+            if let Some(index) = dragged_index {
+                // Without the count of the press that started it, a
+                // double-click-drag decays into a fresh single click on its
+                // first move, and selection falls back from words to
+                // characters.
+                event.set_integer_value_field(
+                    EventField::MOUSE_EVENT_CLICK_STATE,
+                    self.click_state[index],
+                );
+            }
             event.post(CGEventTapLocation::HID);
             self.record_mouse_position(mouse_position);
         }

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -1149,6 +1149,24 @@ pub struct KbdOut {
     /// `kCGMouseEventClickState` so WindowServer recognizes double/triple clicks.
     /// Tracked per-button.
     last_click: HashMap<Btn, (Instant, i64)>,
+    /// Output path latched at press time per button index, so a release always
+    /// goes out the mechanism its press used even if the pointing sink's
+    /// readiness changed while the button was held.
+    button_path: [Option<ButtonPath>; BUTTON_INDEX_COUNT],
+}
+
+/// Number of distinct mouse buttons kanata can synthesize.
+const BUTTON_INDEX_COUNT: usize = 5;
+
+/// Which output mechanism a mouse button press used. Latched per button at
+/// press time so the matching release is emitted the same way — mixing the two
+/// strands the button (a HID button never released, or a CGEvent up for a
+/// button the virtual device never pressed).
+#[cfg(all(not(feature = "simulated_output"), not(feature = "passthru_ahk")))]
+#[derive(Clone, Copy)]
+enum ButtonPath {
+    Hid,
+    CgEvent,
 }
 
 /// Treat a sink-disconnect from the processing thread as a non-fatal drop.
@@ -1180,6 +1198,7 @@ impl KbdOut {
             output_pressed_since: HashMap::default(),
             caps_lock_state: get_hid_caps_lock_state(),
             last_click: HashMap::default(),
+            button_path: [None; BUTTON_INDEX_COUNT],
         })
     }
 
@@ -1366,6 +1385,22 @@ impl KbdOut {
     /// [1]: https://developer.apple.com/documentation/coregraphics/cgevent/init(mouseeventsource:mousetype:mousecursorposition:mousebutton:)
     /// [2]: https://developer.apple.com/documentation/coregraphics/cgevent/setintegervaluefield(_:value:)
     fn button_action(&mut self, btn: Btn, is_click: bool) -> Result<(), io::Error> {
+        let index = Self::button_index(btn);
+
+        // Latch the output path at press time so a release always leaves the
+        // same way its press did. `is_pointing_ready()` is read per event, so
+        // without this a press taken on one path and a release taken on the
+        // other (the sink dropping — or coming back — mid-hold) strands the
+        // button: a HID button that never gets released, or a CGEvent up for a
+        // button the virtual device never pressed. A release with no recorded
+        // press falls back to current readiness rather than guessing.
+        let use_hid = if is_click {
+            is_pointing_ready()
+        } else {
+            self.button_path[index]
+                .map_or_else(is_pointing_ready, |path| matches!(path, ButtonPath::Hid))
+        };
+
         // Preferred path: inject the button through the Karabiner
         // VirtualHIDDevice pointing device so it is a *real* HID event.
         // CGEvent-synthesized buttons — even with an HID-system source state —
@@ -1379,7 +1414,7 @@ impl KbdOut {
         // We still keep the DRAG_*_HELD flags in sync (below) so the CGEvent
         // drag-assist path remains a fallback if WindowServer ever delivers a
         // bare MouseMoved instead of a Dragged while the button is held.
-        if is_pointing_ready() {
+        if use_hid {
             // HID button numbers are 1-indexed: 1=L, 2=R, 3=Mid, 4=Back, 5=Fwd.
             let hid_button: u8 = match btn {
                 Btn::Left => 1,
@@ -1401,6 +1436,7 @@ impl KbdOut {
                 Btn::Forward => &DRAG_FORWARD_HELD,
             };
             flag.store(is_click, Ordering::Release);
+            self.button_path[index] = is_click.then_some(ButtonPath::Hid);
             log::debug!("pointing button: btn={btn:?} hid_button={hid_button} is_click={is_click}");
             return Ok(());
         }
@@ -1491,6 +1527,8 @@ impl KbdOut {
         // Mouse control only seems to work with CGEventTapLocation::HID.
         event.post(CGEventTapLocation::HID);
 
+        self.button_path[index] = is_click.then_some(ButtonPath::CgEvent);
+
         // Drag-assist (Plan G): keep a flag so the mouse-event-tap can
         // synthesize Dragged events on physical trackpad movement while
         // a kanata-driven button is held.
@@ -1511,6 +1549,16 @@ impl KbdOut {
             "drag-assist: button_action btn={btn:?} is_click={is_click} click_count={click_count}"
         );
         Ok(())
+    }
+
+    fn button_index(btn: Btn) -> usize {
+        match btn {
+            Btn::Left => 0,
+            Btn::Right => 1,
+            Btn::Mid => 2,
+            Btn::Backward => 3,
+            Btn::Forward => 4,
+        }
     }
 
     pub fn click_btn(&mut self, btn: Btn) -> Result<(), io::Error> {


### PR DESCRIPTION
# feat(macos): route mouse buttons through the virtual HID pointing device

## Problem

On macOS, kanata synthesizes mouse buttons as `CGEvent`s. Two consequences:

1. **Consumers below the CGEvent layer ignore them.** Apps that distinguish
   real hardware from synthetic input — notably BetterTouchTool's window-snap
   detection — only arm for genuine HID pointing input. A CGEvent-synthesized
   click (even from an HID-system source) does not trigger them, so kanata
   drags cannot drive BTT snap areas.
2. **Click bookkeeping and drag composition were missing.** Mouse CGEvents
   never populated `kCGMouseEventClickState`, so repeated taps never
   registered as double/triple clicks. And a synthesized button held during
   physical trackpad motion arrived as `MouseMoved`, not `MouseDragged`, so no
   drag composed.

Relates to #2061.

## What changed

Scoped to macOS mouse **button** output (`src/oskbd/macos.rs`, plus a small
parser-side usage flag):

1. **Click-state + HID-source for the CGEvent path.** Track a per-button click
   count (500 ms window) and stamp `MOUSE_EVENT_CLICK_STATE`; source
   synthesized buttons from `HIDSystemState` so they look like real hardware
   clicks.
2. **Drag-assist.** While a synthesized button is held, the existing mouse
   event tap rewrites each physical `MouseMoved` *in place* into the matching
   `MouseDragged`. Rewriting in place (rather than posting a second
   synthesized event) preserves the event's deltas and avoids the
   click-bounce that interleaved bare `MouseMoved` events cause in
   Chromium/Electron.
3. **Virtual HID button path (headline).** When the Karabiner VirtualHIDDevice
   pointing device is ready, inject button press/release through it so the
   event is a real HID event. The CGEvent path remains as a fallback when the
   pointing sink is not ready.
4. **Install the mouse event tap based on usage.** The tap is installed when
   the config maps mouse keys in `defsrc`, sets a `mouse-movement-key`, **or
   outputs mouse buttons** — the last tracked by a new parse-time
   `Cfg::emits_mouse_buttons` flag. A config that does none of these installs no
   tap, so it does not request the Accessibility / Input Monitoring permission.
   (This replaces the earlier unconditional install; see **Install gate**.)

No dependency changes: `karabiner-driverkit` is already `0.4.0` on `main`
(#2123), which exposes the pointing-device API this uses.

## Why Virtual HID (rather than CGEvent-only)

- An HID-generated `MouseUp` carries the correct `clickState`, so macOS —
  not kanata — does the single/double/triple click bookkeeping.
- Virtual HID events share `stateID = 1` with physical hardware, so
  consumers that gate on "real" input accept them.
- With a real HID button held, physical pointer movement composes as a
  consistent `MouseDragged` stream from Down through Up.
- `CGEventPost`-based motion very likely does **not** enter macOS's click
  cancellation / drag bookkeeping, which is why the CGEvent-only approach
  fell short for HID-layer consumers.
- Concretely, in an A/B test the CGEvent-only path failed BetterTouchTool
  window snapping while the Virtual HID path succeeded (see Validation).

The virtual HID path is the preferred path; the CGEvent path is retained as a
fallback and is not claimed to be equivalent for HID-layer consumers.

## Review-driven fixes (@MadPigeon)

Since the initial review, several **CGEvent-fallback** issues @MadPigeon
reproduced on real hardware were fixed, each in its own commit:

- **Path latch per button** — `is_pointing_ready()` was read per event, so a
  press and its release could split across the HID and CGEvent paths and strand
  a held button. The output path is now latched at press and reused on release.
- **Position-checked fallback click count** — the fallback double-click window
  was time-only, so rapid taps hundreds of px apart kept incrementing
  `clickState`. It now also requires the same button within a small position
  slop.
- **Fallback click cancellation after drag travel, one-way.** A fallback drag
  used to keep `clickState ≥ 1` for its whole length (the #2061 symptom); it now
  drops to `0` once travel passes the ~8 px HID cancellation window and stays
  cancelled for the rest of the gesture. The travel test is against the press
  origin, which is not monotonic, so the `DRAG_CANCELLED` latch is read first —
  an out-and-back drag that wanders back toward its start no longer revives the
  click mid-gesture. The drag origin is captured at button press (not the first
  `MouseMoved`), so the first delta counts and a fast flick does not understate
  its travel.
- **Path-independent click bookkeeping** across HID/CGEvent switches, so a count
  cannot revive across a path change.

## Install gate

The mouse event tap installs only when the config uses the mouse in a way the
tap serves: mouse keys in `defsrc`, a `mouse-movement-key`, **or the config
outputs mouse buttons** (`mlft`/`mrgt`/`mmid`/`mbck`/`mfwd` and their `-tap`
forms). The third condition is a new `Cfg::emits_mouse_buttons` flag, **tracked
while parsing the mouse-button actions**, so it covers them wherever they end
up — nested actions, virtual keys, macros, aliases, and the on-load action —
without walking the compiled layout. It propagates to the tap install gate at
startup and across live reloads alongside `mouse_movement_key`. Configs that do
none of these install no tap and never request the extra permission, so the
permission is **not requested for configs that do not define mouse-button
output**.

A mouse-button action that is *defined but never bound* still sets the flag;
this over-installs the tap in that edge case but never under-installs it (a
config that does emit mouse buttons always gets drag-assist).

## Validation

**Implementation and on-device checks — @bambooRake**

| Scenario | CGEvent-only | Virtual HID (this PR) |
|---|---|---|
| single / double / triple click | OK | OK |
| Electron / VS Code fine drag | OK | OK |
| BetterTouchTool window snapping | **NG** | **OK** |

Manual on-device re-check on the latest build: single / double / triple click,
physical-motion drag with a kanata mouse button, BetterTouchTool window
snapping, and repeated out-and-back drags all behave correctly, with no
mid-gesture revival of the click/drag state. The install-gate log confirms the
tap installs for a config that outputs mouse buttons
(`emits_buttons=true`).

In this repo: `cargo build`, `cargo clippy` (no new warnings), and the library
tests (`kanata-parser` 125, `kanata` 35) all pass. Each commit builds
independently.

**Independent event-tap measurement and click-cancellation analysis —
@MadPigeon**

@MadPigeon independently exercised `e205617` on real hardware and confirmed
the Virtual HID button path lets macOS's `clickState` / drag bookkeeping treat
kanata output like physical input. @MadPigeon's event-tap measurements are
also the basis for the motion-path observation under Follow-ups below.

@MadPigeon also measured that, because `pointing_button_press` is synchronous,
a button press followed by a `move_mouse` on the same tick sees the updated
button state immediately, so the HID path emits no stray `MouseMoved` before
the drag — where the CGEvent fallback can leak one (its `event.post` is not yet
visible to the next tick's `pressedMouseButtons` read). This PR does not change
`move_mouse`; the motion path stays out of scope and is noted under Follow-ups.

## Known limitations / follow-ups

- **`move_mouse` (kanata-generated motion) is unchanged.** This PR composes
  drags from *physical* pointer motion + a Virtual HID button. Making
  kanata-generated movement carry drag deltas, and eventually routing
  `move_mouse` through the HID pointing device, are deliberately left to a
  follow-up.
- **Motion path is not solved here.** @MadPigeon's measurements suggest that
  `CGEventPost` motion may not participate in macOS click-cancellation and
  that `move_mouse` should probably also move to the HID pointing path. That
  is a larger change; this PR does not attempt or claim to resolve it.
- **CGEvent fallback: a click can be cancelled by ~8–15 px of cursor drift
  during a short tap.** On the fallback path, click cancellation is armed by
  displacement alone (`DRAG_CLICK_CANCEL_PX`, ~8 px) with no time allowance, so
  a hand that drifts past the threshold during a brief tap yields a `MouseUp`
  with `clickState=0`. Arming cancellation only after the button outlasts a tap
  was considered but not taken: real hardware cancels on movement regardless of
  elapsed time, so a time-gate would let a fast press-move-release drag be
  misread as a click. This affects only the CGEvent fallback; the HID path
  matches hardware.
- **CGEvent → virtual HID → CGEvent within one double-click interval can yield
  a `1,1,3`-style sequence.** kanata's internal click bookkeeping is now
  path-independent, but if the pointing sink flaps mid-sequence, macOS does not
  continue its own count across the CGEvent click, so an app may see a triple
  with no double in front of it. Re-syncing from the delivered `MouseDown` was
  judged not worth the machinery for a case that needs the sink to flap inside
  one double-click interval.
