### PR TITLE
fix(macos): actually suppress mapped mouse events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "core-graphics"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation 0.10.1",
@@ -723,7 +723,7 @@ dependencies = [
  "arboard",
  "clap",
  "core-foundation 0.10.1",
- "core-graphics 0.24.0",
+ "core-graphics 0.25.0",
  "dirs",
  "embed-resource",
  "encode_unicode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ arboard = "3.4"
 [target.'cfg(target_os = "macos")'.dependencies]
 karabiner-driverkit = "0.4.0"
 objc = "0.2.7"
-core-graphics = "0.24.0"
+core-graphics = "0.25.0"
 open = { version = "5", optional = true }
 libc = "0.2"
 os_pipe = "1.2.1"

--- a/src/oskbd/macos.rs
+++ b/src/oskbd/macos.rs
@@ -20,7 +20,7 @@ use core_graphics::base::CGFloat;
 use core_graphics::display::{CGDisplay, CGPoint};
 use core_graphics::event::{
     CGEvent, CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventTapPlacement, CGEventType,
-    CGMouseButton, EventField,
+    CGMouseButton, CallbackResult, EventField,
 };
 use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 use kanata_parser::cfg::MappedKeys;
@@ -1668,8 +1668,6 @@ pub fn start_mouse_listener(
                 CGEventTapPlacement::HeadInsertEventTap,
                 CGEventTapOptions::Default,
                 events_of_interest,
-                // Callback receives &CGEvent; return Some(clone) to pass through,
-                // None to suppress the event.
                 move |_proxy, event_type, event| {
                     // Cursor movement (incl. drags while a button is held).
                     // Always pass through — never suppress, or the cursor freezes.
@@ -1686,7 +1684,7 @@ pub fn start_mouse_listener(
                         // hot path.
                         let mmk_slot = match MOUSE_MOVEMENT_KEY.get() {
                             Some(slot) => slot,
-                            None => return Some(event.clone()),
+                            None => return CallbackResult::Keep,
                         };
                         if let Some(code) = *mmk_slot.lock() {
                             let fake = KeyEvent::new(code, KeyValue::Tap);
@@ -1697,33 +1695,33 @@ pub fn start_mouse_listener(
                                 log::trace!("mouse tap (movement): drop synthetic tap: {e}");
                             }
                         }
-                        return Some(event.clone());
+                        return CallbackResult::Keep;
                     }
 
                     if matches!(event_type, CGEventType::ScrollWheel) {
                         let Some(key_event) = scroll_event_to_key_event(event) else {
-                            return Some(event.clone());
+                            return CallbackResult::Keep;
                         };
                         if !crate::kanata::MAPPED_KEYS.lock().contains(&key_event.code) {
-                            return Some(event.clone());
+                            return CallbackResult::Keep;
                         }
                         log::debug!("mouse tap (wheel): {key_event:?}");
                         if let Err(e) = tx.try_send(key_event) {
                             log::warn!("mouse tap: failed to send wheel event: {e}");
-                            return Some(event.clone());
+                            return CallbackResult::Keep;
                         }
-                        return None;
+                        return CallbackResult::Drop;
                     }
 
                     let button_number =
                         event.get_integer_value_field(EventField::MOUSE_EVENT_BUTTON_NUMBER);
                     let mut key_event = match KeyEvent::try_from((event_type, button_number)) {
                         Ok(ev) => ev,
-                        Err(()) => return Some(event.clone()),
+                        Err(()) => return CallbackResult::Keep,
                     };
 
                     if !crate::kanata::MAPPED_KEYS.lock().contains(&key_event.code) {
-                        return Some(event.clone());
+                        return CallbackResult::Keep;
                     }
 
                     // Track pressed state to convert duplicate presses into repeats,
@@ -1747,11 +1745,11 @@ pub fn start_mouse_listener(
 
                     if let Err(e) = tx.try_send(key_event) {
                         log::warn!("mouse tap: failed to send event: {e}");
-                        return Some(event.clone());
+                        return CallbackResult::Keep;
                     }
 
                     // Suppress the original event so it doesn't reach the system.
-                    None
+                    CallbackResult::Drop
                 },
             ) {
                 Ok(tap) => tap,
@@ -1768,7 +1766,7 @@ pub fn start_mouse_listener(
                 }
             };
 
-            let Ok(loop_source) = tap.mach_port.create_runloop_source(0) else {
+            let Ok(loop_source) = tap.mach_port().create_runloop_source(0) else {
                 log::error!("failed to create CFRunLoop source for mouse event tap");
                 MOUSE_TAP_INSTALLED.store(false, Ordering::Release);
                 return;


### PR DESCRIPTION
Today I got some new earbuds and wanted to use my mouse side buttons to control the
volume with Kanata. The mapping worked, but the original Back and Forward actions were
still reaching apps like Discord

I dug into it and found that `core-graphics` 0.24 treats a `None` event-tap callback
result as pass-through, so Kanata wasn’t actually suppressing mapped mouse button and
wheel events

Upgrade to `core-graphics` 0.25 and use its explicit `CallbackResult::Drop` and
`CallbackResult::Keep` API

## Describe your changes. Use imperative present tense

- Upgrade `core-graphics` from 0.24 to 0.25
- Drop mapped mouse button and wheel events after Kanata queues them successfully
- Keep movement, unmapped, unsupported, and unqueued events
- Keep the event tap at the Session location to avoid the Bluetooth cursor regressions
  described in #739 and #1636
- Keep mouse movement and drag events on the existing pass-through path

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes manually tested Back and Forward mouse buttons mapped to volume controls on
    macOS, and ran the full test suite and Clippy