### PR TITLE
fix(tap-hold): stop the queue scan at the waiting key's own release

### DIFF
--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -569,8 +569,16 @@ impl<'a, T: std::fmt::Debug> WaitingState<'a, T> {
         match cfg {
             HoldTapConfig::Default => (),
             HoldTapConfig::HoldOnOtherKeyPress => {
-                if queued.iter().any(|s| s.event.is_press()) {
-                    return Some(WaitingAction::Hold);
+                for s in queued.iter() {
+                    if s.event.coord() == self.coord {
+                        if s.event.is_release() {
+                            break;
+                        }
+                        continue;
+                    }
+                    if s.event.is_press() {
+                        return Some(WaitingAction::Hold);
+                    }
                 }
             }
             HoldTapConfig::Order { buffer, .. } => {
@@ -583,13 +591,19 @@ impl<'a, T: std::fmt::Debug> WaitingState<'a, T> {
                 // fast typing to resolve as Tap regardless of release order.
                 let mut queued = queued.iter();
                 while let Some(q) = queued.next() {
+                    let (i, j) = q.event.coord();
+                    if (i, j) == self.coord {
+                        if q.event.is_release() {
+                            break;
+                        }
+                        continue;
+                    }
                     if q.event.is_press() {
                         // Elapsed ticks since this key entered the queue, compared against buffer window.
                         let press_tick = self.ticks.saturating_sub(q.since);
                         if press_tick < buffer {
                             continue;
                         }
-                        let (i, j) = q.event.coord();
                         let target = Event::Release(i, j);
                         if queued.clone().any(|q| q.event == target) {
                             return Some(WaitingAction::Hold);
@@ -600,8 +614,14 @@ impl<'a, T: std::fmt::Debug> WaitingState<'a, T> {
             HoldTapConfig::PermissiveHold => {
                 let mut queued = queued.iter();
                 while let Some(q) = queued.next() {
+                    let (i, j) = q.event.coord();
+                    if (i, j) == self.coord {
+                        if q.event.is_release() {
+                            break;
+                        }
+                        continue;
+                    }
                     if q.event.is_press() {
-                        let (i, j) = q.event.coord();
                         let target = Event::Release(i, j);
                         if queued.clone().any(|q| q.event == target) {
                             return Some(WaitingAction::Hold);

--- a/src/tests/sim_tests/tap_hold_tests.rs
+++ b/src/tests/sim_tests/tap_hold_tests.rs
@@ -1366,3 +1366,21 @@ fn tap_hold_order_late_press_does_not_resolve_hold() {
         result
     );
 }
+
+#[test]
+fn tap_hold_press_second_press_of_same_key_does_not_end_the_scan() {
+    let result = simulate(
+        "
+        (defsrc a s d)
+        (deflayer base (tap-hold-press 0 200 a (layer-while-held nav))
+                       (tap-hold 0 500 s lctl) d)
+        (deflayer nav 1 2 3)
+        ",
+        "d:s t:50 d:a t:20 d:a t:20 d:d t:20 u:a t:20 u:d t:20 u:s t:300",
+    )
+    .to_ascii();
+    assert_eq!(
+        "t:150ms dn:S t:13ms dn:Kb1 t:1ms dn:Kb3 t:1ms up:Kb1 t:1ms up:Kb3 t:1ms up:S",
+        result
+    );
+}

--- a/src/tests/sim_tests/tap_hold_tests.rs
+++ b/src/tests/sim_tests/tap_hold_tests.rs
@@ -1279,3 +1279,90 @@ fn tap_hold_order_no_prior_idle_enters_normal_resolution() {
         result
     );
 }
+
+#[test]
+fn tap_hold_press_own_repress_does_not_resolve_hold() {
+    let result = simulate(
+        "
+        (defsrc a s)
+        (deflayer base (tap-hold-press 0 200 a (layer-while-held nav))
+                       (tap-hold 0 500 s lctl))
+        (deflayer nav 1 2)
+        ",
+        "d:s t:50 d:a t:20 u:a t:20 d:a t:20 u:a t:100 u:s t:300",
+    )
+    .to_ascii();
+    assert_eq!(
+        "t:210ms dn:S t:7ms dn:A t:6ms up:A t:2ms dn:A t:6ms up:A t:1ms up:S",
+        result
+    );
+}
+
+#[test]
+fn tap_hold_release_own_repress_does_not_resolve_hold() {
+    let result = simulate(
+        "
+        (defsrc a s)
+        (deflayer base (tap-hold-release 0 200 a lsft) (tap-hold 0 500 s lctl))
+        ",
+        "d:s t:50 d:a t:20 u:a t:20 d:a t:20 u:a t:100 u:s t:300",
+    )
+    .to_ascii();
+    assert_eq!(
+        "t:210ms dn:S t:7ms dn:A t:6ms up:A t:2ms dn:A t:6ms up:A t:1ms up:S",
+        result
+    );
+}
+
+#[test]
+fn tap_hold_press_late_press_does_not_resolve_hold() {
+    let result = simulate(
+        "
+        (defsrc a s d)
+        (deflayer base (tap-hold-press 0 200 a (layer-while-held nav))
+                       (tap-hold 0 500 s lctl) d)
+        (deflayer nav 1 2 3)
+        ",
+        "t:74 d:s t:92 d:a t:50 u:a t:55 d:d t:69 u:d t:18 u:s t:600",
+    )
+    .to_ascii();
+    assert_eq!(
+        "t:358ms dn:S t:7ms dn:A t:6ms up:A t:1ms dn:D t:1ms up:D t:1ms up:S",
+        result
+    );
+}
+
+#[test]
+fn tap_hold_release_late_press_does_not_resolve_hold() {
+    let result = simulate(
+        "
+        (defsrc a s d)
+        (deflayer base (tap-hold-release 0 200 a (layer-while-held nav))
+                       (tap-hold 0 500 s lctl) d)
+        (deflayer nav 1 2 3)
+        ",
+        "t:74 d:s t:92 d:a t:50 u:a t:55 d:d t:69 u:d t:18 u:s t:600",
+    )
+    .to_ascii();
+    assert_eq!(
+        "t:358ms dn:S t:7ms dn:A t:6ms up:A t:1ms dn:D t:1ms up:D t:1ms up:S",
+        result
+    );
+}
+
+#[test]
+fn tap_hold_order_late_press_does_not_resolve_hold() {
+    let result = simulate(
+        "
+        (defsrc a s d)
+        (deflayer base @a (tap-hold 0 500 s lctl) d)
+        (defalias a (tap-hold-order 0 0 a lsft))
+        ",
+        "t:74 d:s t:92 d:a t:50 u:a t:55 d:d t:69 u:d t:18 u:s t:600",
+    )
+    .to_ascii();
+    assert_eq!(
+        "t:358ms dn:S t:7ms dn:A t:6ms up:A t:1ms dn:D t:1ms up:D t:1ms up:S",
+        result
+    );
+}


### PR DESCRIPTION
**This is an update to the original pr.** The version of this PR that was up had
only the narrow shape below, where the later press is the key's own re-press,
and a fix that excluded the waiting key's coordinate. That fix does not reach
the general case, where the press belongs to a different key. `tap-hold-order`
is affected too, which the earlier version left open for want of a test.

---

A `tap-hold-press` key that has already been **released** inside its own window
can still be converted into a hold, by a press that arrives after that release.

With a layer as the hold action the conversion is silent, so a keystroke that
was typed never reaches the wire. With a modifier as the hold action you get a
modifier you never pressed, in place of the letter.

It needs a second tap-hold still deciding, because that is what defers the
stream and puts the later press into the same queue as this key's release.

**The (new) general variant.** `a` is down at 166 and up at 216, fifty
milliseconds inside its own 200 ms window with nothing pressed in between. `d`
is not pressed until 271, and that press is counted as evidence about a key that
is already up.

```
t:74 d:s t:92 d:a t:50 u:a t:55 d:d t:69 u:d t:18 u:s t:600
```

| config | what comes out |
|---|---|
| `tap-hold-press`, layer hold action | the `A` tap is gone, `D` on its own |
| `tap-hold-press`, modifier hold action | `LShift` where the `A` belongs |
| `tap-hold-release`, layer | the `A` tap is gone |
| `tap-hold-order`, modifier | `LShift` where the `A` belongs |

**The (original) special variant**, which is what this was first reported as.
Hold `s`, tap `a` twice underneath it, release `s`. Every tap lasts 20 ms and
`s` is held for 230 ms, so by time alone all three decisions are taps, and `a`'s
own re-press is the press that converts the first of them.

```
d:s t:50 d:a t:20 u:a t:20 d:a t:20 u:a t:100 u:s t:300
```

| config | what comes out |
|---|---|
| `tap-hold-press`, layer hold action | one `A` on the wire where two were typed |
| `tap-hold-press`, modifier hold action | an `LShift` nobody pressed, then one `A` |
| `tap-hold-release`, modifier | the same |

The modifier variants are what show a hold is being taken, and not a droppped
tap. The `LShift` lands where the tap belongs, so it is the earlier tap that was
converted. With a layer as the hold action there is nothing to see, which is why
the first table has two rows that emit nothing at all in place of the tap.

### Reproduce

The first commit adds seven failing tests to
`src/tests/sim_tests/tap_hold_tests.rs`, one per row above. Every expectation is
the output plain `tap-hold` already produces for the same input.

With nothing withholding, `a`'s release resolves it as a tap before the later
press exists. With `s` undecided, `a`'s events are deferred, so by the time they
are processed the later press is sitting in the queue that permissive hold
inspects.

### The fix

`WaitingState::handle_hold_tap` in `keyberon/src/layout.rs` scans the queued
events for a press and stops at nothing. The queue is in arrival order and holds
the waiting key's own release, so the scan reads past the moment the key came
up.

Excluding the waiting coordinate only reaches the shape where the later press is
the key's own. Stopping the scan at the key's own release covers both, and it
subsumes the coordinate check. In the re-press shape that release is the first
thing in the queue, so the scan ends before the re-press is reached.

```rust
HoldTapConfig::HoldOnOtherKeyPress => {
    for s in queued.iter() {
        if s.event.coord() == self.coord {
            if s.event.is_release() {
                break;
            }
            continue;
        }
        if s.event.is_press() {
            return Some(WaitingAction::Hold);
        }
    }
}
```

`HoldOnOtherKeyPress`, `PermissiveHold` and `Order` all carry the scan and all
take the guard. `Order` needs it as much as the other two and now has a test
that says so. its resolution is purely event-driven, with no timeout to fall
back on, so the scan is the whole of how it decides.

### Why `continue` rather than `break` on the keys own press

A press at the waiting coordinate that arrives *before* the release is skipped
rather than ending the scan, and the second commit adds a test showing why.

Ending the scan at that press loses a real permissive hold, and the output goes
incoherent with it. An `A` tap on the wire *and* the key's own hold layer still
active for the key pressed after it.

```
d:s t:50 d:a t:20 d:a t:20 d:d t:20 u:a t:20 u:d t:20 u:s t:300
```

That test passes before the fix and after it, and fails against the simpler
guard that breaks on any event at the waiting coordinate.
