### PR TITLE
feat: use ColorChoice::Auto instead of AlwaysAnsi

### DIFF
--- a/example_tcp_client/src/main.rs
+++ b/example_tcp_client/src/main.rs
@@ -127,7 +127,7 @@ fn init_logger(args: &Args) {
         log_lvl,
         log_cfg.build(),
         TerminalMode::Mixed,
-        ColorChoice::AlwaysAnsi,
+        ColorChoice::Auto,
     )])
     .expect("init logger");
     log::info!(

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -30,7 +30,7 @@ fn init_log() {
             LevelFilter::Error,
             log_cfg.build(),
             TerminalMode::Stderr,
-            ColorChoice::AlwaysAnsi,
+            ColorChoice::Auto,
         )])
         .expect("logger can init");
     });

--- a/simulated_input/src/sim.rs
+++ b/simulated_input/src/sim.rs
@@ -95,7 +95,7 @@ fn log_init() {
         LevelFilter::Info,
         log_cfg.build(),
         TerminalMode::Stderr,
-        ColorChoice::AlwaysAnsi,
+        ColorChoice::Auto,
     )])
     .expect("logger can init");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ mod cli {
             log_lvl,
             log_cfg.build(),
             TerminalMode::Mixed,
-            ColorChoice::AlwaysAnsi,
+            ColorChoice::Auto,
         )])
         .expect("logger can init");
 

--- a/src/main_lib/win_gui.rs
+++ b/src/main_lib/win_gui.rs
@@ -25,7 +25,7 @@ fn cli_init() -> Result<ValidatedArgs> {
                         LevelFilter::Debug,
                         log_cfg.build(),
                         TerminalMode::Mixed,
-                        ColorChoice::AlwaysAnsi,
+                        ColorChoice::Auto,
                     ),
                     log_win::windbg_simple_combo(LevelFilter::Debug, noti_lvl),
                 ])
@@ -99,7 +99,7 @@ fn cli_init() -> Result<ValidatedArgs> {
                 log_lvl,
                 log_cfg.build(),
                 TerminalMode::Mixed,
-                ColorChoice::AlwaysAnsi,
+                ColorChoice::Auto,
             ),
             log_win::windbg_simple_combo(log_lvl, noti_lvl),
         ])

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -33,7 +33,7 @@ fn init_log() {
             LevelFilter::Off,
             log_cfg.build(),
             TerminalMode::Stderr,
-            ColorChoice::AlwaysAnsi,
+            ColorChoice::Auto,
         )])
         .expect("logger can init");
     });

--- a/windows_key_tester/src/windows.rs
+++ b/windows_key_tester/src/windows.rs
@@ -43,7 +43,7 @@ fn cli_init() {
         log_lvl,
         log_cfg.build(),
         TerminalMode::Mixed,
-        ColorChoice::AlwaysAnsi,
+        ColorChoice::Auto,
     )])
     .expect("logger can init");
     log::info!("windows_key_tester v{} starting", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.

Make kanata respect NO_COLOR env var, which I want to set in [kanata-tray](https://github.com/rszyma/kanata-tray) to not show ascii characters when viewing kanata logs with a text editor, opened by clicking a button from UI.

Invocation from CI and directly from terminal should still work the same, but redirecting to file or setting NO_COLOR=1 should now not output ANSII color chars.

Looking at git history, specifically commit 31a04d893f9d69788bcfdef0b4d767637812bf8b, I don't see other values being considered, `ColorChoice::AlwaysAnsi` was picked from the beginning for no apparent reason, when simple_log bump 0.8.0 -> 0.12.0 added this parameter.

Only the change in `src/main.rs` would do for me, but I'm changing other usages as well for consistency.

## Checklist

- Add documentation to docs/config.adoc
  - [x] N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes, manual testing
