### PR TITLE
stdout and stderr announcements only appear if not empty

### DIFF
--- a/src/kanata/cmd.rs
+++ b/src/kanata/cmd.rs
@@ -39,12 +39,43 @@ pub(super) fn run_cmd_in_thread(
         match cmd.output() {
             Ok(output) => {
                 if let Some(level) = log_level {
+                    let mut stdout = String::from_utf8_lossy(&output.stdout);
+                    let mut stderr = String::from_utf8_lossy(&output.stderr);
+                    let stdout_empty = stdout.is_empty();
+                    let stderr_empty = stderr.is_empty();
+                    let stdout_ends_in_newline = stdout.ends_with('\n');
+                    // log! provides us the final newline, so if we don't trim it from the last output,
+                    // we will see an extra blank line
+                    // that's why we're trying to figure out which output is the last one
+                    if !stderr_empty {
+                        if stderr.ends_with('\n') {
+                            // user might be intentionally printing blank lines, trimming more than one is overzealous
+                            stderr.to_mut().pop();
+                        }
+                    } else if !stdout_empty && stdout_ends_in_newline {
+                        stdout.to_mut().pop();
+                    }
+                    let stdout_announcer = if stdout_empty { "" } else { "stdout:\n" };
+                    let stderr_announcer = if stderr_empty {
+                        ""
+                    // we don't *re*-check whether stdout ends in a newline because the branch
+                    // that trims it out is unreachable if stderr is not empty
+                    } else if !stdout_empty && !stdout_ends_in_newline {
+                        "\nstderr:\n"
+                    } else {
+                        "stderr:\n"
+                    };
+                    let newline = if stdout_empty && stderr_empty {
+                        ""
+                    } else {
+                        "\n"
+                    };
                     log::log!(
                         level,
-                        "Successfully ran cmd: {}\nstdout:\n{}\nstderr:\n{}",
+                        "Successfully ran cmd: {}{newline}{stdout_announcer}{}{stderr_announcer}{}",
                         printable_cmd,
-                        String::from_utf8_lossy(&output.stdout),
-                        String::from_utf8_lossy(&output.stderr)
+                        stdout,
+                        stderr,
                     );
                 };
             }


### PR DESCRIPTION

Currently, after a `cmd` succeeds without any stdout or stderr, in the kanata daemon output, you'll see:
```
stdout:

stderr:

```

This bloats the output quite a bit.

With this pr: if the stdout is empty, its section is not printed. If the stderr is empty, its section is not printed. If both are empty, neither of their sections are printed.

Thanks to this, if a command succeeded with no output, you can more easily visually ignore it.
With the cleaner output, `systemctl status kanata.service` is cut off less often, with its default 10 last lines displayed.

# details

I set up a fish script on a hotkey to display how the kanata log output will look like.

```fish
#!/usr/bin/env fish

echo abandoned
echo somebody >&2
```
↓
```
18:02:50.7040 [INFO] Successfully ran cmd: Program: test.fish, Arguments:
stdout:
abandoned
stderr:
somebody
```

```fish
#!/usr/bin/env fish

# echo abandoned
echo somebody >&2
```
↓
```
18:03:35.2311 [INFO] Successfully ran cmd: Program: test.fish, Arguments:
stderr:
somebody
```

```fish
#!/usr/bin/env fish

echo abandoned
# echo somebody >&2
```
↓
```
18:05:09.0646 [INFO] Successfully ran cmd: Program: test.fish, Arguments:
stdout:
abandoned
```

```fish
#!/usr/bin/env fish

# echo abandoned
# echo somebody >&2
```
↓
```
18:05:46.4668 [INFO] Successfully ran cmd: Program: test.fish, Arguments:
```

---

The code is a bit hard to read right now, and it'd make sense to make a few unit tests for it; but want to present the idea first to see if it's liked, before I do that.