### PR TITLE
fix(one-shot): end one-shot-release when activator key is re-pressed on another layer (#2049)

### DIFF
--- a/keyberon/src/layout.rs
+++ b/keyberon/src/layout.rs
@@ -1123,14 +1123,24 @@ impl OneShotState {
         if self.keys.is_empty() {
             return (true, None);
         }
+        // A coordinate can legitimately appear in both `keys` (as the original
+        // activator) and `other_pressed_keys` (fix #2049): if the activator's
+        // physical key is re-pressed as a normal, non-oneshot key after the
+        // activating layer is gone, that press is registered in
+        // `other_pressed_keys`, but the activator coordinate still lingers in
+        // `keys` until the oneshot terminates. In that case the release must
+        // terminate the oneshot rather than be swallowed as an "activator
+        // release", so the `other_pressed_keys` check has to win over the
+        // `keys` membership check below.
+        if matches!(
+            self.end_config,
+            OneShotEndConfig::EndOnFirstRelease | OneShotEndConfig::EndOnFirstReleaseOrRepress
+        ) && self.other_pressed_keys.contains(&(i, j))
+        {
+            self.release_on_next_tick = true;
+            return (true, None);
+        }
         if !self.keys.contains(&(i, j)) {
-            if matches!(
-                self.end_config,
-                OneShotEndConfig::EndOnFirstRelease | OneShotEndConfig::EndOnFirstReleaseOrRepress
-            ) && self.other_pressed_keys.contains(&(i, j))
-            {
-                self.release_on_next_tick = true;
-            }
             (true, None)
         } else {
             // delay release for one shot keys
@@ -4002,6 +4012,66 @@ mod test {
         layout.event(Release(0, 2));
         assert_eq!(CustomEvent::NoEvent, layout.tick());
         assert_keys(&[LShift], layout.keycodes());
+        assert_eq!(CustomEvent::NoEvent, layout.tick());
+        assert_keys(&[], layout.keycodes());
+    }
+
+    #[test]
+    fn one_shot_end_on_release_activator_repressed_on_other_layer() {
+        // Regression test for #2049.
+        //
+        // The one-shot activator's physical key is re-pressed as a normal key
+        // on a different layer (the activating layer is momentary and gone by
+        // then). The re-press's release must terminate the one-shot; before the
+        // fix it was swallowed as an "activator release" because the activator
+        // coordinate still lingered in `OneShotState::keys`, so the modifier
+        // leaked onto every subsequent keypress until the timeout.
+        //
+        // Layout:
+        //   (0,0): base -> momentary Layer(1) ("tab"),      nav -> Trans
+        //   (0,1): base -> k(A) ("d"),                      nav -> one-shot LShift
+        //   (0,2): base -> k(B) ("p"),                      nav -> Trans
+        static LAYERS: Layers<3, 1> = &[
+            [[Layer(1), k(A), k(B)]],
+            [[
+                Trans,
+                OneShot(&crate::action::OneShot {
+                    timeout: 100,
+                    action: &k(LShift),
+                    end_config: OneShotEndConfig::EndOnFirstRelease,
+                }),
+                Trans,
+            ]],
+        ];
+        let mut layout = Layout::new(LAYERS);
+
+        // Activate the one-shot from the nav layer, then leave that layer.
+        layout.event(Press(0, 0)); // hold "tab" -> nav layer
+        assert_eq!(CustomEvent::NoEvent, layout.tick());
+        layout.event(Press(0, 1)); // "d" on nav -> one-shot LShift
+        assert_eq!(CustomEvent::NoEvent, layout.tick());
+        assert_keys(&[LShift], layout.keycodes());
+        layout.event(Release(0, 1)); // activator release, swallowed while waiting
+        assert_eq!(CustomEvent::NoEvent, layout.tick());
+        assert_keys(&[LShift], layout.keycodes());
+        layout.event(Release(0, 0)); // release "tab" -> back to base layer
+        assert_eq!(CustomEvent::NoEvent, layout.tick());
+        assert_keys(&[LShift], layout.keycodes());
+
+        // Re-press the activator's physical key; on base it is a normal `A`.
+        layout.event(Press(0, 1));
+        assert_eq!(CustomEvent::NoEvent, layout.tick());
+        assert_keys(&[A, LShift], layout.keycodes());
+        // Releasing it must release both `A` and end the one-shot.
+        layout.event(Release(0, 1));
+        assert_eq!(CustomEvent::NoEvent, layout.tick());
+        assert_keys(&[], layout.keycodes());
+
+        // A subsequent, unrelated keypress must not carry the modifier.
+        layout.event(Press(0, 2)); // "p" -> B, no LShift
+        assert_eq!(CustomEvent::NoEvent, layout.tick());
+        assert_keys(&[B], layout.keycodes());
+        layout.event(Release(0, 2));
         assert_eq!(CustomEvent::NoEvent, layout.tick());
         assert_keys(&[], layout.keycodes());
     }

--- a/src/tests/sim_tests/oneshot_tests.rs
+++ b/src/tests/sim_tests/oneshot_tests.rs
@@ -75,3 +75,25 @@ fn oneshot_multi_with_layer() {
     //                                         v
     assert_eq!("dn:A t:10ms up:A t:10ms dn:B t:5ms up:B", result);
 }
+
+#[test]
+fn oneshot_release_activator_repressed_on_other_layer() {
+    // Regression test for #2049.
+    // `tab` momentarily activates the `nav` layer where `d` is a
+    // `one-shot-release lalt`. After leaving `nav`, re-pressing the same
+    // physical `d` key (now a normal key on `base`) and releasing it must
+    // terminate the one-shot. Previously LAlt leaked onto every subsequent
+    // key (here `p`) until the 2000ms timeout.
+    let result = simulate(
+        "(defsrc tab d p)
+         (deflayer base (layer-while-held nav) d p)
+         (deflayer nav _ (one-shot-release 2000 lalt) _)",
+        "d:Tab t:10 d:KeyD t:10 u:KeyD t:10 u:Tab t:10 \
+         d:KeyD t:10 u:KeyD t:10 d:KeyP t:10 u:KeyP t:10",
+    )
+    .to_ascii();
+    assert_eq!(
+        "t:10ms dn:LAlt t:30ms dn:D t:10ms up:LAlt up:D t:10ms dn:P t:10ms up:P",
+        result
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2049.

`one-shot-release` (and `one-shot-release-pcancel`) did not terminate when the activator's physical key was re-pressed as a normal key on a **different** layer (the activating layer being momentary and already gone). The modifier then leaked onto every subsequent keypress until the timeout fired.

### Root cause

`OneShotState::handle_release` in `keyberon/src/layout.rs` checked `keys` (activator) membership **before** the `other_pressed_keys` termination check. When the activator's coordinate is re-pressed as a normal key, that coordinate ends up in **both** `keys` (lingering activator, only cleared on termination) and `other_pressed_keys`. The `keys.contains(..)` branch matched first, so the release was swallowed as an "activator release" and the one-shot never ended.

`EndOnFirstPress` is unaffected because it terminates in `handle_press` without consulting `keys`.

### Fix

Reorder `handle_release` so the release-path termination check on `other_pressed_keys` wins over the `keys` membership check for the `EndOnFirstRelease` / `EndOnFirstReleaseOrRepress` configs.

## Testing

- Added a `keyberon` unit test (`one_shot_end_on_release_activator_repressed_on_other_layer`) and an end-to-end simulated-input test (`oneshot_release_activator_repressed_on_other_layer`) reproducing the issue's exact `layer-while-held` + `one-shot-release` config. Both fail before the fix and pass after.
- `cargo test -p kanata-keyberon --lib`: 89 passed.
- Full simulated-output suite: 219 passed.
- `cargo fmt --check` and `cargo clippy` clean.