### PR TITLE
Fix tap-repress-timeout example sequence

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -2180,8 +2180,8 @@ The input event sequence is:
 
 With `(defvar $tap-repress-timeout 0)`, the output event sequence is:
 
-- 50 ms elapses
 - press `a`
+- 50 ms elapses
 - release `a`
 - 250 ms elapses
 - press `lctl`
@@ -2194,8 +2194,8 @@ between and including `0` and `99`.
 For a value of `100` or greater for `$tap-repress-timeout`,
 the output event sequence is instead:
 
-- 50 ms elapses
 - press `a`
+- 50 ms elapses
 - release `a`
 - 50 ms elapses
 - press `a`


### PR DESCRIPTION
## Describe your changes. Use imperative present tense.
The `Tap repress timeout in more detail` section sets the input event sequence before giving concrete examples.

Now the examples match the input event sequence.

## Checklist

- Add documentation to docs/config.adoc
  - [X] Yes or N/A
- Add example and basic docs to cfg_samples/kanata.kbd
  - N/A
- Update error messages
  - N/A
- Added tests, or did manual testing
  - Yes

Closes #2176