### PR TITLE
2. Analog Primitives (gamepad/analog-values)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,6 +73,8 @@ jobs:
         shared-key: "persist-cross-job"
         workspaces: ./
     - run: rustup component add clippy
+    - name: Install libudev
+      run: sudo apt-get update && sudo apt-get install -y libudev-dev
 
     - name: Run tests no features
       run: cargo test --all --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +545,41 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "gilrs"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902fb00d3f6398e635be22e5c837b303c501835cca7ac11a47bba138f7aafdd8"
+dependencies = [
+ "fnv",
+ "gilrs-core",
+ "log",
+ "uuid",
+ "vec_map",
+]
+
+[[package]]
+name = "gilrs-core"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7f0ce6237abcc0523f2a5502b1e3fe5802daaae47ac14e166fe49551301ea9"
+dependencies = [
+ "inotify 0.11.5",
+ "js-sys",
+ "libc",
+ "libudev-sys",
+ "log",
+ "nix 0.31.3",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "rusty-xinput",
+ "uuid",
+ "vec_map",
+ "wasm-bindgen",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -628,10 +669,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify-sys"
-version = "0.1.5"
+name = "inotify"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags 2.9.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -728,8 +780,9 @@ dependencies = [
  "embed-resource",
  "encode_unicode",
  "evdev",
+ "gilrs",
  "indoc",
- "inotify",
+ "inotify 0.10.2",
  "kanata-interception",
  "kanata-keyberon",
  "kanata-parser",
@@ -876,9 +929,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
@@ -888,6 +941,16 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1050,6 +1113,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "objc2-core-image"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1259,17 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1313,6 +1408,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "png"
@@ -1465,6 +1566,17 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-xinput"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3335c2b62e1e48dd927f6c8941705386e3697fa944aabcb10431bea7ee47ef3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -1852,6 +1964,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "vswhom"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +2081,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,18 @@ kanata-keyberon = { path = "keyberon", version = "0.1121.0" }
 kanata-parser =   { path = "parser", version = "0.1121.0" }
 kanata-tcp-protocol = { path = "tcp_protocol", version = "0.1121.0" }
 
+# Controller input. One crate covers evdev, IOKit and XInput, which is why
+# src/gamepad has no per-OS branches at all.
+#
+# `xinput` is selected over gilrs's default Windows.Gaming.Input backend on
+# purpose: WGI only delivers input to the focused window, which is unusable for
+# a background daemon, while XInput has no such restriction. The tradeoff is
+# that XInput sees only XUSB-compatible pads; DirectInput-only devices need the
+# Raw Input backend noted as follow-up work in docs/config.adoc. The feature is
+# inert on Linux and macOS, but gilrs-core fails to build with neither backend
+# feature selected on any platform, so it is set unconditionally.
+gilrs = { version = "0.11.2", default-features = false, features = ["xinput"] }
+
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 arboard = "3.4"
 
@@ -144,7 +156,6 @@ gui = ["win_manifest","kanata-parser/gui",
   "native-windows-gui/tray-notification","native-windows-gui/message-window","native-windows-gui/menu","native-windows-gui/cursor","native-windows-gui/high-dpi","native-windows-gui/embed-resource","native-windows-gui/image-decoder","native-windows-gui/notice","native-windows-gui/animation-timer",
 ]
 zippychord = ["kanata-parser/zippychord"]
-
 [profile.release]
 opt-level = "z"
 lto = "fat"

--- a/keyberon/src/key_code.rs
+++ b/keyberon/src/key_code.rs
@@ -5,7 +5,7 @@ pub const KEY_MAX: u16 = 850;
 
 #[test]
 fn keycode_max_test() {
-    assert!((KeyCode::KeyMax as u16) < KEY_MAX);
+    assert!((KeyCode::KeyCodeMax as u16) < KEY_MAX);
 }
 
 #[allow(missing_docs)]
@@ -782,6 +782,69 @@ pub enum KeyCode {
     K765 = 765,
     K766 = 766,
     KeyMax = 767,
+
+    // Codes above the OS scancode range. kanata reserves these for inputs no
+    // operating system reports as a scancode -- currently the game controller
+    // controls named in `kanata_parser::keys::OsCode`. `From<OsCode>` and
+    // `From<KeyCode>` transmute between the two enums, so this range has to
+    // cover every `OsCode` discriminant.
+    K768 = 768,
+    K769 = 769,
+    K770 = 770,
+    K771 = 771,
+    K772 = 772,
+    K773 = 773,
+    K774 = 774,
+    K775 = 775,
+    K776 = 776,
+    K777 = 777,
+    K778 = 778,
+    K779 = 779,
+    K780 = 780,
+    K781 = 781,
+    K782 = 782,
+    K783 = 783,
+    K784 = 784,
+    K785 = 785,
+    K786 = 786,
+    K787 = 787,
+    K788 = 788,
+    K789 = 789,
+    K790 = 790,
+    K791 = 791,
+    K792 = 792,
+    K793 = 793,
+    K794 = 794,
+    K795 = 795,
+    K796 = 796,
+    K797 = 797,
+    K798 = 798,
+    K799 = 799,
+    K800 = 800,
+    K801 = 801,
+    K802 = 802,
+    K803 = 803,
+    K804 = 804,
+    K805 = 805,
+    K806 = 806,
+    K807 = 807,
+    K808 = 808,
+    K809 = 809,
+    K810 = 810,
+    K811 = 811,
+    K812 = 812,
+    K813 = 813,
+    K814 = 814,
+    K815 = 815,
+    K816 = 816,
+    K817 = 817,
+    K818 = 818,
+    K819 = 819,
+    K820 = 820,
+    K821 = 821,
+    K822 = 822,
+    /// One past the highest variant.
+    KeyCodeMax = 823,
 }
 
 impl KeyCode {

--- a/parser/src/cfg/arbitrary_code.rs
+++ b/parser/src/cfg/arbitrary_code.rs
@@ -15,6 +15,11 @@ pub(crate) fn parse_arbitrary_code(
         .atom(s.vars())
         .map(str::parse::<u16>)
         .and_then(|c| c.ok())
+        // The range in the message was never enforced. It has to be now: this
+        // writes the code straight to the OS, and everything at or above
+        // `PAD_SOUTH` begins the synthetic controller range, which has no
+        // scancodes behind it.
+        .filter(|code| *code < OsCode::PAD_SOUTH as u16)
         .ok_or_else(|| anyhow!("{ERR_MSG}: got {:?}", ac_params[0]))?;
     custom(CustomAction::SendArbitraryCode(code), &s.a)
 }

--- a/parser/src/cfg/defsrc.rs
+++ b/parser/src/cfg/defsrc.rs
@@ -51,6 +51,9 @@ pub(crate) fn parse_defsrc(
     log::info!("process unmapped keys: {}", defcfg.process_unmapped_keys);
     if defcfg.process_unmapped_keys {
         for osc in 0..KEYS_IN_ROW as u16 {
+            // Controller controls need no exclusion here: they are synthetic,
+            // so `from_u16` never decodes one. `gamepad_controls_are_never_swept_in`
+            // pins that down.
             if let Some(osc) = OsCode::from_u16(osc) {
                 if osc.is_mouse_code() {
                     // Bugfix #1879:

--- a/parser/src/cfg/override.rs
+++ b/parser/src/cfg/override.rs
@@ -54,6 +54,12 @@ pub(crate) fn parse_override_inout_keys(
                     .ok_or_else(|| {
                         anyhow_expr!(key_expr, "Unknown output key name, must use known keys")
                     })?;
+                // The same rule every other output position enforces: a
+                // controller control names a physical input on a pad, and no
+                // OS can be asked to emit one.
+                if key.is_gamepad_code() {
+                    bail_expr!(key_expr, "{key} can only be used as an input");
+                }
                 keys.push(key);
                 Ok(keys)
             })?;

--- a/parser/src/cfg/unmod.rs
+++ b/parser/src/cfg/unmod.rs
@@ -65,18 +65,22 @@ pub(crate) fn parse_unmod(
     }
 
     let keys: Vec<KeyCode> = params.iter().try_fold(Vec::new(), |mut keys, param| {
-        keys.push(
-            param
-                .atom(s.vars())
-                .and_then(str_to_oscode)
-                .ok_or_else(|| {
-                    anyhow_expr!(
-                        &ac_params[0],
-                        "{unmod_type} {ERR_MSG}\nfound invalid key name"
-                    )
-                })?
-                .into(),
-        );
+        let osc = param
+            .atom(s.vars())
+            .and_then(str_to_oscode)
+            .ok_or_else(|| {
+                anyhow_expr!(
+                    &ac_params[0],
+                    "{unmod_type} {ERR_MSG}\nfound invalid key name"
+                )
+            })?;
+        // These keys are appended to the output list directly rather than
+        // going through an action, so the check `parse_action_atom` makes for
+        // every other output position has to be repeated here.
+        if osc.is_gamepad_code() || osc == OsCode::KEY_766 {
+            bail_expr!(param, "{osc} can only be used as an input");
+        }
+        keys.push(osc.into());
         Ok::<_, ParseError>(keys)
     })?;
     let keys = s.a.sref_vec(keys);

--- a/parser/src/gamepad/analog.rs
+++ b/parser/src/gamepad/analog.rs
@@ -346,3 +346,183 @@ impl Add for Demand {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(x: f32, y: f32) -> Vec2 {
+        Vec2 { x, y }
+    }
+
+    fn plain(speed: f32) -> Motion {
+        Motion {
+            deadzone: Unit::ZERO,
+            speed: speed * 1000.0,
+            curve: Curve::Linear,
+            invert: Vec2::KEEP,
+        }
+    }
+
+    #[test]
+    fn garbage_readings_are_clamped_or_read_as_at_rest() {
+        // Hardware overshoots its own range, and a disconnecting controller
+        // reports NaN. Treating NaN as full deflection would jam a direction
+        // on; letting it reach the deadzone rescale would poison the result.
+        assert_eq!(Unit::new(1.4), Unit::ONE);
+        assert_eq!(Unit::new(-0.2), Unit::ZERO);
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert_eq!(Unit::new(bad), Unit::ZERO);
+        }
+        assert_eq!(AxisValue::new(1.4).get(), 1.0);
+        assert_eq!(AxisValue::new(-1.4).get(), -1.0);
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert_eq!(AxisValue::new(bad), AxisValue::ZERO);
+        }
+        assert_eq!(StickPosition::new(2.0, f32::NAN).vector(), v(1.0, 0.0));
+        for bad in [v(f32::NAN, 0.0), v(0.0, f32::NAN), v(f32::NAN, f32::NAN)] {
+            assert_eq!(Motion::MOUSE.displace(bad), Vec2::ZERO, "{bad:?}");
+        }
+        for bad_speed in [f32::NAN, f32::INFINITY, -1.0] {
+            assert_eq!(
+                Motion {
+                    speed: bad_speed,
+                    ..Motion::MOUSE
+                }
+                .displace(v(1.0, 0.0)),
+                Vec2::ZERO
+            );
+        }
+    }
+
+    #[test]
+    fn the_deadzone_silences_the_center_without_a_jump_at_its_edge() {
+        let dz = Motion {
+            deadzone: Unit::new(0.15),
+            ..plain(1.0)
+        };
+        for inside in [v(0.0, 0.0), v(0.10, 0.0), v(0.10, 0.10), v(-0.14, 0.0)] {
+            assert_eq!(dz.displace(inside), Vec2::ZERO, "{inside:?}");
+        }
+        // Just past the edge is near zero, not near 0.15, and full deflection
+        // survives unattenuated.
+        assert!(dz.displace(v(0.16, 0.0)).x < 0.02);
+        assert!((dz.displace(v(1.0, 0.0)).x - 1.0).abs() < 1e-6);
+        // A deadzone of one silences the control instead of dividing by zero.
+        let all = Motion {
+            deadzone: Unit::ONE,
+            ..plain(1.0)
+        };
+        assert_eq!(all.displace(v(1.0, 1.0)), Vec2::ZERO);
+    }
+
+    #[test]
+    fn a_diagonal_keeps_its_direction_and_does_not_outrun_a_cardinal() {
+        // A hardware corner reads (1, 1), a radius of 1.41. Left alone that
+        // makes a diagonal 41% faster than a straight push.
+        let m = plain(10.0);
+        assert!((m.displace(v(1.0, 0.0)).x - 10.0).abs() < 1e-4);
+        for corner in [v(1.0, 1.0), v(-1.0, 1.0), v(1.0, -1.0)] {
+            let out = m.displace(corner);
+            assert!((out.radius() - 10.0).abs() < 1e-3, "{corner:?} -> {out:?}");
+            assert!((out.x.abs() - out.y.abs()).abs() < 1e-4, "off the diagonal");
+        }
+    }
+
+    #[test]
+    fn the_curve_applies_to_the_magnitude_not_to_each_axis() {
+        // Curving the axes independently would bend a diagonal toward an axis.
+        let cubic = Motion {
+            curve: Curve::Cubic,
+            ..plain(100.0)
+        };
+        let s = std::f32::consts::FRAC_1_SQRT_2 * 0.5;
+        let out = cubic.displace(v(s, s));
+        assert!((out.x - out.y).abs() < 1e-4, "{out:?}");
+        // magnitude 0.5, cubed to 0.125, times 100 units per tick.
+        assert!((out.radius() - 12.5).abs() < 1e-2, "{out:?}");
+        // Steeper curves give finer control near center, and every curve fixes
+        // the endpoints.
+        let half = Unit::new(0.5);
+        assert!(Curve::Cubic.apply(half) < Curve::Quadratic.apply(half));
+        assert!(Curve::Quadratic.apply(half) < Curve::Linear.apply(half));
+        for curve in [Curve::Linear, Curve::Quadratic, Curve::Cubic] {
+            assert_eq!(curve.apply(Unit::ZERO), Unit::ZERO, "{curve:?}");
+            assert_eq!(curve.apply(Unit::ONE), Unit::ONE, "{curve:?}");
+        }
+    }
+
+    #[test]
+    fn inversion_flips_only_the_requested_axis() {
+        assert!(
+            Motion::MOUSE.displace(v(0.0, 1.0)).y < 0.0,
+            "push away moves the pointer up the screen"
+        );
+        assert!(
+            Motion::SCROLL.displace(v(0.0, 1.0)).y > 0.0,
+            "push away scrolls up"
+        );
+        assert_eq!(Motion::MOUSE.invert.x, 1.0, "x is not flipped by default");
+    }
+
+    #[test]
+    fn a_scalar_control_gets_the_same_response_as_an_axis() {
+        // A trigger is one number, but the deadzone, curve and speed have to
+        // mean the same thing there as on a stick.
+        let m = Motion {
+            curve: Curve::Quadratic,
+            ..plain(8.0)
+        };
+        assert_eq!(m.rate(0.0), 0.0);
+        assert!((m.rate(0.5) - 2.0).abs() < 1e-4, "{}", m.rate(0.5));
+        assert!((m.displace(v(1.0, 0.0)).x - m.rate(1.0)).abs() < 1e-4);
+    }
+
+    #[test]
+    fn a_threshold_is_strict_at_its_boundary() {
+        let threshold = Unit::new(0.5);
+        assert!(!(Unit::new(0.49) > threshold));
+        assert!(!(Unit::new(0.50) > threshold));
+        assert!(Unit::new(0.51) > threshold);
+    }
+
+    #[test]
+    fn demands_sum_per_output_and_report_idleness() {
+        let mut a = Demand::default();
+        assert!(a.is_idle());
+        a[MotionKind::Mouse] = v(1.0, 2.0);
+        let mut b = Demand::default();
+        b[MotionKind::Mouse] = v(-1.0, 0.5);
+        b[MotionKind::Scroll] = v(0.0, 3.0);
+        assert!(!a.is_idle());
+        let sum = a + b;
+        assert_eq!(sum[MotionKind::Mouse], v(0.0, 2.5));
+        assert_eq!(sum[MotionKind::Scroll], v(0.0, 3.0));
+    }
+
+    #[test]
+    fn whole_units_accumulate_exactly_across_ticks() {
+        // Rounding each tick independently would make a 7.5 px/ms demand run
+        // permanently 7% slow or 25% fast, and a demand below one unit would
+        // round to nothing forever.
+        let mut carry = Vec2::ZERO;
+        let total: i32 = (0..1000)
+            .map(|_| {
+                carry += v(7.5, 0.0);
+                carry.take_whole().0
+            })
+            .sum();
+        assert_eq!(total, 7500);
+
+        // The two axes carry separately: a fast horizontal push must not drag
+        // the vertical axis along with it.
+        let mut slow = Vec2::ZERO;
+        let crawl: i32 = (0..10)
+            .map(|_| {
+                slow += v(0.25, -0.25);
+                slow.take_whole().0
+            })
+            .sum();
+        assert_eq!(crawl, 2, "0.25 a tick over 10 ticks is 2.5 pixels");
+        assert_eq!(slow.take_whole(), (0, 0));
+    }
+}

--- a/parser/src/gamepad/analog.rs
+++ b/parser/src/gamepad/analog.rs
@@ -1,0 +1,348 @@
+//! Analog values and the transformations that turn them into digital edges
+//! and continuous motion. Everything here is total and hardware-free.
+//!
+//! Two conventions are fixed once, so no call site has to remember them: **y
+//! is up-positive**, converted at the backend boundary, and **values are
+//! clamped, never rejected**, because hardware overshoots its own reported
+//! range and refusing such a reading would drop real input.
+
+use core::ops::{Add, AddAssign, Index, IndexMut, Mul};
+
+/// A magnitude in `[0.0, 1.0]`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
+pub struct Unit(f32);
+
+impl Unit {
+    pub const ZERO: Unit = Unit(0.0);
+    pub const ONE: Unit = Unit(1.0);
+
+    /// Clamp a raw reading into the unit interval. Non-finite values become
+    /// zero: a controller reporting garbage should read as at rest, not as
+    /// fully deflected.
+    pub fn new(value: f32) -> Unit {
+        match value.is_finite() {
+            true => Unit(value.clamp(0.0, 1.0)),
+            false => Unit::ZERO,
+        }
+    }
+
+    pub const fn get(self) -> f32 {
+        self.0
+    }
+}
+
+/// A normalized signed axis reading in `[-1.0, 1.0]`.
+///
+/// Hardware values enter through this constructor, so the projector cannot
+/// represent an infinite, NaN, or out-of-range stick position. Non-finite
+/// readings mean centered: unlike a large finite overshoot, they carry no
+/// recoverable direction.
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
+pub struct AxisValue(f32);
+
+impl AxisValue {
+    pub const ZERO: AxisValue = AxisValue(0.0);
+
+    pub fn new(value: f32) -> AxisValue {
+        match value.is_finite() {
+            true => AxisValue(value.clamp(-1.0, 1.0)),
+            false => AxisValue::ZERO,
+        }
+    }
+
+    pub const fn get(self) -> f32 {
+        self.0
+    }
+}
+
+/// One whole two-axis stick reading, normalized and y-up.
+///
+/// Keeping the pair together avoids exposing transient half-updated diagonals
+/// to projection. [`Vec2`] remains the intentionally unbounded vector used for
+/// rates and displacement; this type is only physical stick position.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct StickPosition {
+    x: AxisValue,
+    y: AxisValue,
+}
+
+impl StickPosition {
+    pub fn new(x: f32, y: f32) -> StickPosition {
+        StickPosition {
+            x: AxisValue::new(x),
+            y: AxisValue::new(y),
+        }
+    }
+
+    pub const fn x(self) -> AxisValue {
+        self.x
+    }
+
+    pub const fn y(self) -> AxisValue {
+        self.y
+    }
+
+    pub const fn vector(self) -> Vec2 {
+        Vec2 {
+            x: self.x.get(),
+            y: self.y.get(),
+        }
+    }
+}
+
+/// A two-axis reading, y-up.
+///
+/// Components are whatever the hardware reported, so the radius of a diagonal
+/// may exceed one until a deadzone normalizes it. Also serves as a
+/// displacement -- pixels or wheel notches -- and as a pair of axis signs.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Vec2 {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Vec2 {
+    pub const ZERO: Vec2 = Vec2 { x: 0.0, y: 0.0 };
+    /// The identity for [`Motion::invert`]: keep both axes as they are.
+    pub const KEEP: Vec2 = Vec2 { x: 1.0, y: 1.0 };
+
+    /// True distance from center, which a hardware corner puts past 1.0.
+    pub fn radius(self) -> f32 {
+        self.x.hypot(self.y)
+    }
+
+    pub fn is_zero(self) -> bool {
+        self.x == 0.0 && self.y == 0.0
+    }
+
+    /// Split into whole units, leaving the fraction in place.
+    ///
+    /// The pointer path carries the remainder between ticks: a stick asking
+    /// for 7.5 pixels a millisecond has to average exactly that, and rounding
+    /// a small demand to zero would make slow movement impossible rather than
+    /// merely slow.
+    pub fn take_whole(&mut self) -> (i32, i32) {
+        // This is the only place a bad reading could become lasting state:
+        // `NaN - NaN` is NaN, so a single poisoned component would leave the
+        // carry NaN and every later take at zero for the rest of the process.
+        // `Motion` already refuses to emit one; this is the backstop.
+        for axis in [&mut self.x, &mut self.y] {
+            if !axis.is_finite() {
+                *axis = 0.0;
+            }
+        }
+        let (x, y) = (self.x.trunc(), self.y.trunc());
+        self.x -= x;
+        self.y -= y;
+        (x as i32, y as i32)
+    }
+}
+
+impl Add for Vec2 {
+    type Output = Vec2;
+    fn add(self, other: Vec2) -> Vec2 {
+        Vec2 {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+}
+
+impl AddAssign for Vec2 {
+    fn add_assign(&mut self, other: Vec2) {
+        *self = *self + other;
+    }
+}
+
+impl Mul<f32> for Vec2 {
+    type Output = Vec2;
+    fn mul(self, scale: f32) -> Vec2 {
+        Vec2 {
+            x: self.x * scale,
+            y: self.y * scale,
+        }
+    }
+}
+
+/// Componentwise, which is what applies per-axis inversion.
+impl Mul<Vec2> for Vec2 {
+    type Output = Vec2;
+    fn mul(self, other: Vec2) -> Vec2 {
+        Vec2 {
+            x: self.x * other.x,
+            y: self.y * other.y,
+        }
+    }
+}
+
+/// The response curve applied to continuous projections.
+///
+/// Digital thresholds are compared *before* any curve, so changing the curve
+/// changes pointer feel without silently moving a press point.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Curve {
+    /// Output tracks deflection directly.
+    Linear,
+    /// Squared: finer control near center.
+    Quadratic,
+    /// Cubed: finest near center, full speed at the rim. The default for
+    /// pointer control, where small corrections matter most.
+    #[default]
+    Cubic,
+}
+
+impl Curve {
+    pub fn apply(self, t: Unit) -> Unit {
+        let t = t.get();
+        Unit::new(match self {
+            Curve::Linear => t,
+            Curve::Quadratic => t * t,
+            Curve::Cubic => t * t * t,
+        })
+    }
+}
+
+/// Which continuous output a projection drives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MotionKind {
+    Mouse,
+    Scroll,
+}
+
+impl MotionKind {
+    pub const ALL: [MotionKind; 2] = [MotionKind::Mouse, MotionKind::Scroll];
+}
+
+/// How a control's deflection becomes pointer or wheel movement.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Motion {
+    /// Radius below which the control reads as at rest. Applied radially
+    /// rather than per-axis: an axial deadzone lets a stick held diagonally at
+    /// low deflection register on one axis but not the other, which produces
+    /// phantom cardinal movement on the way to a diagonal.
+    pub deadzone: Unit,
+    /// Output at full deflection per second: pixels for the pointer, notches
+    /// for the wheel. Converted to the engine's 1 ms tick in [`Motion::rate`].
+    pub speed: f32,
+    pub curve: Curve,
+    /// Per-axis sign. See [`Vec2::KEEP`].
+    pub invert: Vec2,
+}
+
+impl Motion {
+    /// A generous upper bound that still catches an extra zero as a typo.
+    pub const MAX_SPEED: f32 = 100_000.0;
+
+    pub const MOUSE: Motion = Motion {
+        deadzone: Unit(0.15),
+        speed: 1000.0,
+        curve: Curve::Cubic,
+        // Screen coordinates grow downward while a stick's Y grows upward, so
+        // inverting by default makes "push away" mean "move up", which is what
+        // every user expects. `(invert-y no)` restores flight-sim behaviour.
+        invert: Vec2 { x: 1.0, y: -1.0 },
+    };
+
+    pub const SCROLL: Motion = Motion {
+        deadzone: Unit(0.15),
+        speed: 30.0,
+        curve: Curve::Linear,
+        // Stick Y and wheel-up are both up-positive, so no inversion.
+        invert: Vec2::KEEP,
+    };
+
+    pub const fn of(kind: MotionKind) -> Motion {
+        match kind {
+            MotionKind::Mouse => Motion::MOUSE,
+            MotionKind::Scroll => Motion::SCROLL,
+        }
+    }
+
+    /// The output per 1 ms tick a deflection of `magnitude` asks for.
+    ///
+    /// The dead region is removed and what survives is rescaled back to
+    /// `0..=1`, so the first movement past the edge produces the smallest
+    /// possible output instead of jumping straight to the deadzone radius.
+    /// Overshoot past the rim clamps, which is also what stops a stick at a
+    /// hardware corner from outrunning a straight push.
+    pub fn rate(self, magnitude: f32) -> f32 {
+        let dz = self.deadzone.get();
+        // Non-finite readings are spelled out rather than left to the
+        // comparisons below. A disconnecting controller reports NaN, and an
+        // infinite radius would clamp to full deflection and then hit the
+        // `rate / radius` division in `displace`, where `inf * 0.0` is NaN.
+        // They read as at rest rather than as full deflection because no
+        // direction can be recovered from them.
+        if !magnitude.is_finite() || magnitude <= dz || dz >= 1.0 {
+            return 0.0;
+        }
+        let speed = match self.speed.is_finite() {
+            true => self.speed.clamp(0.0, Motion::MAX_SPEED),
+            false => 0.0,
+        };
+        self.curve
+            .apply(Unit::new((magnitude - dz) / (1.0 - dz)))
+            .get()
+            * speed
+            / 1000.0
+    }
+
+    /// A two-axis reading as a per-tick displacement.
+    ///
+    /// The curve applies to the *magnitude* rather than to each axis, so the
+    /// direction the user is pushing survives; curving the axes independently
+    /// would bend a 45-degree push off the diagonal.
+    pub fn displace(self, raw: Vec2) -> Vec2 {
+        let radius = raw.radius();
+        let rate = self.rate(radius);
+        match rate == 0.0 {
+            true => Vec2::ZERO,
+            false => {
+                let displaced = raw * (rate / radius) * self.invert;
+                Vec2 {
+                    x: if displaced.x.is_finite() {
+                        displaced.x
+                    } else {
+                        0.0
+                    },
+                    y: if displaced.y.is_finite() {
+                        displaced.y
+                    } else {
+                        0.0
+                    },
+                }
+            }
+        }
+    }
+}
+
+/// What the continuous projections are asking for this tick.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Demand([Vec2; 2]);
+
+impl Demand {
+    pub fn is_idle(self) -> bool {
+        self.0.iter().all(|v| v.is_zero())
+    }
+}
+
+impl Index<MotionKind> for Demand {
+    type Output = Vec2;
+    fn index(&self, kind: MotionKind) -> &Vec2 {
+        &self.0[kind as usize]
+    }
+}
+
+impl IndexMut<MotionKind> for Demand {
+    fn index_mut(&mut self, kind: MotionKind) -> &mut Vec2 {
+        &mut self.0[kind as usize]
+    }
+}
+
+impl Add for Demand {
+    type Output = Demand;
+    fn add(self, other: Demand) -> Demand {
+        Demand([self.0[0] + other.0[0], self.0[1] + other.0[1]])
+    }
+}
+

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -404,6 +404,81 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         // position, in conjunction with `mouse-movement-key mvmt`
         "mvmt" | "mousemovement" | "🖰mv" => OsCode::KEY_766,
 
+        // Game controller controls. Input-only: they name a physical control
+        // on a pad, never an output scancode. See docs/config.adoc.
+        //
+        // Every name is positional rather than the glyph a vendor printed, so
+        // one config works on a DualSense, an Xbox pad and a Switch Pro pad.
+        // Face buttons, plus the pair some six-button pads add.
+        "pad-south" | "pad-a" | "pad-cross" => OsCode::PAD_SOUTH,
+        "pad-east" | "pad-b" | "pad-circle" => OsCode::PAD_EAST,
+        "pad-west" | "pad-x" | "pad-square" => OsCode::PAD_WEST,
+        "pad-north" | "pad-y" | "pad-triangle" => OsCode::PAD_NORTH,
+        "pad-c" => OsCode::PAD_C,
+        "pad-z" => OsCode::PAD_Z,
+
+        // Shoulder buttons, and the triggers' digital edge.
+        "pad-l1" | "pad-lb" => OsCode::PAD_L1,
+        "pad-r1" | "pad-rb" => OsCode::PAD_R1,
+        "pad-l2" | "pad-lt" => OsCode::PAD_L2,
+        "pad-r2" | "pad-rt" => OsCode::PAD_R2,
+
+        // Menu buttons and stick clicks.
+        "pad-select" | "pad-share" | "pad-view" | "pad-back" => OsCode::PAD_SELECT,
+        "pad-start" | "pad-options" | "pad-menu" => OsCode::PAD_START,
+        "pad-mode" | "pad-guide" | "pad-home" => OsCode::PAD_MODE,
+        "pad-l3" | "pad-lstick" => OsCode::PAD_L3,
+        "pad-r3" | "pad-rstick" => OsCode::PAD_R3,
+
+        // Left stick directions, from (stick left (digital ...)).
+        "pad-lstick-up" | "pad-ls-up" => OsCode::PAD_LSTICK_UP,
+        "pad-lstick-down" | "pad-ls-down" => OsCode::PAD_LSTICK_DOWN,
+        "pad-lstick-left" | "pad-ls-left" => OsCode::PAD_LSTICK_LEFT,
+        "pad-lstick-right" | "pad-ls-right" => OsCode::PAD_LSTICK_RIGHT,
+        "pad-lstick-upleft" | "pad-ls-upleft" => OsCode::PAD_LSTICK_UPLEFT,
+        "pad-lstick-upright" | "pad-ls-upright" => OsCode::PAD_LSTICK_UPRIGHT,
+        "pad-lstick-downleft" | "pad-ls-downleft" => OsCode::PAD_LSTICK_DOWNLEFT,
+        "pad-lstick-downright" | "pad-ls-downright" => OsCode::PAD_LSTICK_DOWNRIGHT,
+
+        // Right stick directions, from (stick right (digital ...)).
+        "pad-rstick-up" | "pad-rs-up" => OsCode::PAD_RSTICK_UP,
+        "pad-rstick-down" | "pad-rs-down" => OsCode::PAD_RSTICK_DOWN,
+        "pad-rstick-left" | "pad-rs-left" => OsCode::PAD_RSTICK_LEFT,
+        "pad-rstick-right" | "pad-rs-right" => OsCode::PAD_RSTICK_RIGHT,
+        "pad-rstick-upleft" | "pad-rs-upleft" => OsCode::PAD_RSTICK_UPLEFT,
+        "pad-rstick-upright" | "pad-rs-upright" => OsCode::PAD_RSTICK_UPRIGHT,
+        "pad-rstick-downleft" | "pad-rs-downleft" => OsCode::PAD_RSTICK_DOWNLEFT,
+        "pad-rstick-downright" | "pad-rs-downright" => OsCode::PAD_RSTICK_DOWNRIGHT,
+
+        // D-pad, unified across hat-axis and button reporting. The
+        // diagonals need (dpad (digital (mode 8way))).
+        "pad-dpad-up" | "pad-up" => OsCode::PAD_DPAD_UP,
+        "pad-dpad-down" | "pad-down" => OsCode::PAD_DPAD_DOWN,
+        "pad-dpad-left" | "pad-left" => OsCode::PAD_DPAD_LEFT,
+        "pad-dpad-right" | "pad-right" => OsCode::PAD_DPAD_RIGHT,
+        "pad-dpad-upleft" | "pad-upleft" => OsCode::PAD_DPAD_UPLEFT,
+        "pad-dpad-upright" | "pad-upright" => OsCode::PAD_DPAD_UPRIGHT,
+        "pad-dpad-downleft" | "pad-downleft" => OsCode::PAD_DPAD_DOWNLEFT,
+        "pad-dpad-downright" | "pad-downright" => OsCode::PAD_DPAD_DOWNRIGHT,
+
+        // Slots for controls no portable name covers; see (button-slot ...).
+        "pad-button-0" | "pb0" => OsCode::PAD_BUTTON_0,
+        "pad-button-1" | "pb1" => OsCode::PAD_BUTTON_1,
+        "pad-button-2" | "pb2" => OsCode::PAD_BUTTON_2,
+        "pad-button-3" | "pb3" => OsCode::PAD_BUTTON_3,
+        "pad-button-4" | "pb4" => OsCode::PAD_BUTTON_4,
+        "pad-button-5" | "pb5" => OsCode::PAD_BUTTON_5,
+        "pad-button-6" | "pb6" => OsCode::PAD_BUTTON_6,
+        "pad-button-7" | "pb7" => OsCode::PAD_BUTTON_7,
+        "pad-button-8" | "pb8" => OsCode::PAD_BUTTON_8,
+        "pad-button-9" | "pb9" => OsCode::PAD_BUTTON_9,
+        "pad-button-10" | "pb10" => OsCode::PAD_BUTTON_10,
+        "pad-button-11" | "pb11" => OsCode::PAD_BUTTON_11,
+        "pad-button-12" | "pb12" => OsCode::PAD_BUTTON_12,
+        "pad-button-13" | "pb13" => OsCode::PAD_BUTTON_13,
+        "pad-button-14" | "pb14" => OsCode::PAD_BUTTON_14,
+        "pad-button-15" | "pb15" => OsCode::PAD_BUTTON_15,
+
         _ => return None,
     })
 }
@@ -1190,6 +1265,83 @@ pub enum OsCode {
     KEY_766 = 766, // aliased to mvmt as a dummy input for use with mouse-movement-key
 
     KEY_MAX = 767,
+
+    // ---------------------------------------------------------------------
+    // Game controller controls.
+    //
+    // Synthetic: no operating system reports these as a scancode, so
+    // `from_u16` never decodes one and `process-unmapped-keys` can never
+    // sweep one into `defsrc`. They are built only through
+    // `crate::gamepad::PadCode`, which is what makes a name mean the same
+    // physical control on every platform.
+    //
+    // The range is contiguous and grouped: buttons, then eight directions
+    // for each directional control, then the assignable slots. `PadCode` is
+    // an index into it, so this order is load-bearing; `PadCode::control`
+    // inverts it and `pad_codes_tile_the_reserved_range` pins the two
+    // together.
+    //
+    // Analog values never live here: only threshold crossings and digital
+    // controls become codes, and the continuous value stays in the
+    // projector.
+    // ---------------------------------------------------------------------
+    PAD_SOUTH = 768,
+    PAD_EAST = 769,
+    PAD_WEST = 770,
+    PAD_NORTH = 771,
+    PAD_C = 772,
+    PAD_Z = 773,
+    PAD_L1 = 774,
+    PAD_R1 = 775,
+    PAD_L2 = 776,
+    PAD_R2 = 777,
+    PAD_SELECT = 778,
+    PAD_START = 779,
+    PAD_MODE = 780,
+    PAD_L3 = 781,
+    PAD_R3 = 782,
+    PAD_LSTICK_UP = 783,
+    PAD_LSTICK_DOWN = 784,
+    PAD_LSTICK_LEFT = 785,
+    PAD_LSTICK_RIGHT = 786,
+    PAD_LSTICK_UPLEFT = 787,
+    PAD_LSTICK_UPRIGHT = 788,
+    PAD_LSTICK_DOWNLEFT = 789,
+    PAD_LSTICK_DOWNRIGHT = 790,
+    PAD_RSTICK_UP = 791,
+    PAD_RSTICK_DOWN = 792,
+    PAD_RSTICK_LEFT = 793,
+    PAD_RSTICK_RIGHT = 794,
+    PAD_RSTICK_UPLEFT = 795,
+    PAD_RSTICK_UPRIGHT = 796,
+    PAD_RSTICK_DOWNLEFT = 797,
+    PAD_RSTICK_DOWNRIGHT = 798,
+    PAD_DPAD_UP = 799,
+    PAD_DPAD_DOWN = 800,
+    PAD_DPAD_LEFT = 801,
+    PAD_DPAD_RIGHT = 802,
+    PAD_DPAD_UPLEFT = 803,
+    PAD_DPAD_UPRIGHT = 804,
+    PAD_DPAD_DOWNLEFT = 805,
+    PAD_DPAD_DOWNRIGHT = 806,
+    PAD_BUTTON_0 = 807,
+    PAD_BUTTON_1 = 808,
+    PAD_BUTTON_2 = 809,
+    PAD_BUTTON_3 = 810,
+    PAD_BUTTON_4 = 811,
+    PAD_BUTTON_5 = 812,
+    PAD_BUTTON_6 = 813,
+    PAD_BUTTON_7 = 814,
+    PAD_BUTTON_8 = 815,
+    PAD_BUTTON_9 = 816,
+    PAD_BUTTON_10 = 817,
+    PAD_BUTTON_11 = 818,
+    PAD_BUTTON_12 = 819,
+    PAD_BUTTON_13 = 820,
+    PAD_BUTTON_14 = 821,
+    PAD_BUTTON_15 = 822,
+    /// One past the highest `OsCode`. This is the width of a layout row.
+    OSCODE_MAX = 823,
 }
 
 impl OsCode {
@@ -1208,6 +1360,63 @@ impl OsCode {
                 | MouseWheelRight
         )
     }
+
+    /// How many game controller controls the reserved range holds.
+    pub const GAMEPAD_COUNT: u8 = (OsCode::OSCODE_MAX as u16 - OsCode::PAD_SOUTH as u16) as u8;
+
+    /// True for the game controller controls, which occupy one contiguous
+    /// range above every real OS scancode.
+    ///
+    /// They are input-only. No OS can be asked to emit one, so the output path
+    /// ignores them the same way it ignores the reserved macro keys; see
+    /// `output_logic::write_key`.
+    pub const fn is_gamepad_code(self) -> bool {
+        self.gamepad_index().is_some()
+    }
+
+    /// This code's position within the reserved range, or `None` if it is an
+    /// ordinary key.
+    ///
+    /// The pair with [`OsCode::from_gamepad_index`] is what lets
+    /// `gamepad::PadCode` be a small index instead of a lookup table.
+    pub const fn gamepad_index(self) -> Option<u8> {
+        match (self as u16).checked_sub(OsCode::PAD_SOUTH as u16) {
+            Some(index) if index < OsCode::GAMEPAD_COUNT as u16 => Some(index as u8),
+            _ => None,
+        }
+    }
+
+    /// The `index`th control in the reserved range.
+    pub const fn from_gamepad_index(index: u8) -> Option<OsCode> {
+        if index >= OsCode::GAMEPAD_COUNT {
+            return None;
+        }
+        // SAFETY: the reserved range is a contiguous run of discriminants on a
+        // `#[repr(u16)]` enum, so every value in it names a variant. The
+        // `gamepad_indices_round_trip` test walks the whole range.
+        Some(unsafe {
+            core::mem::transmute::<u16, OsCode>(OsCode::PAD_SOUTH as u16 + index as u16)
+        })
+    }
+}
+
+#[test]
+fn gamepad_indices_round_trip() {
+    for index in 0..OsCode::GAMEPAD_COUNT {
+        let osc = OsCode::from_gamepad_index(index).expect("below the count");
+        assert_eq!(osc.gamepad_index(), Some(index));
+        assert_eq!(
+            u16::from(osc),
+            u16::from(OsCode::PAD_SOUTH) + u16::from(index)
+        );
+        // `Debug` on a transmuted value is the cheapest proof that the
+        // discriminant really names a variant.
+        assert!(format!("{osc:?}").starts_with("PAD_"), "{osc:?}");
+    }
+    assert_eq!(OsCode::from_gamepad_index(OsCode::GAMEPAD_COUNT), None);
+    assert_eq!(OsCode::KEY_A.gamepad_index(), None);
+    assert_eq!(OsCode::KEY_MAX.gamepad_index(), None);
+    assert_eq!(OsCode::OSCODE_MAX.gamepad_index(), None);
 }
 
 use core::fmt;
@@ -1224,7 +1433,7 @@ impl fmt::Display for OsCode {
 
 #[test]
 fn parser_key_max_lt_keyberon_key_max() {
-    assert!(u16::from(OsCode::KEY_MAX) < KEY_MAX);
+    assert!(u16::from(OsCode::OSCODE_MAX) < KEY_MAX);
 }
 
 #[cfg(test)]

--- a/parser/src/layers.rs
+++ b/parser/src/layers.rs
@@ -8,8 +8,9 @@ use crate::keys::OsCode;
 
 use std::sync::Arc;
 
-// OsCode::KEY_MAX is the biggest OsCode
-pub const KEYS_IN_ROW: usize = OsCode::KEY_MAX as usize;
+// OsCode::OSCODE_MAX is one past the biggest OsCode, including the synthetic
+// gamepad controls that live above the OS scancode range.
+pub const KEYS_IN_ROW: usize = OsCode::OSCODE_MAX as usize;
 pub const LAYER_ROWS: usize = 2;
 pub const DEFAULT_ACTION: KanataAction = KanataAction::KeyCode(KeyCode::ErrorUndefined);
 

--- a/parser/src/sequences.rs
+++ b/parser/src/sequences.rs
@@ -25,5 +25,12 @@ pub fn mod_mask_for_keycode(kc: KeyCode) -> u16 {
 #[test]
 fn keys_fit_within_mask() {
     use crate::keys::OsCode;
-    assert!(MASK_KEYCODES >= u16::from(OsCode::KEY_MAX));
+    // The mask has to cover the whole `OsCode` range, not just the codes a
+    // sequence can name. A sequence cannot hold a controller control -- the
+    // key list is parsed as actions, and those are rejected in an output
+    // position -- but the mask is applied to raw codes, so it still has to
+    // reach past the reserved range.
+    assert!(MASK_KEYCODES >= u16::from(OsCode::OSCODE_MAX));
+    // And the overlap marker has to stay clear of all of them.
+    const { assert!(KEY_OVERLAP_MARKER > MASK_KEYCODES) };
 }

--- a/src/kanata/sequences.rs
+++ b/src/kanata/sequences.rs
@@ -274,7 +274,9 @@ use kanata_keyberon::key_code::KeyCode::*;
 pub(super) fn do_successful_sequence_termination(
     kbd_out: &mut KbdOut,
     state: &mut SequenceState,
-    layout: &mut Layout<'_, 767, 2, &CustomAction>,
+    // The parser already names this shape; spelling the row width out here
+    // once let it silently desynchronize from the layout.
+    layout: &mut BorrowedKLayout<'_>,
     i: u8,
     j: u16,
     seq_type: EndSequenceType,


### PR DESCRIPTION
#### 2. Analog Primitives (`gamepad/analog-values`)

Here, part 2 now, I introduce the core types for continous input, which look like:

- normalized scalars
- vectors
- radial deadzones
- response curves (`linear`, `quadratic`, `cubic`).

- **Threshold Mechanics:** Felt right to add a strictly one-sided threshold evaluation (equality does not register as a press). The API intentionally omits press/release hysteresis in favor of a singular, stateless boundary.

added a ton of nice unit tests too

