### PR TITLE
5. Runtime Engine (gamepad/runtime-engine)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,6 +73,8 @@ jobs:
         shared-key: "persist-cross-job"
         workspaces: ./
     - run: rustup component add clippy
+    - name: Install libudev
+      run: sudo apt-get update && sudo apt-get install -y libudev-dev
 
     - name: Run tests no features
       run: cargo test --all --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +545,41 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "gilrs"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902fb00d3f6398e635be22e5c837b303c501835cca7ac11a47bba138f7aafdd8"
+dependencies = [
+ "fnv",
+ "gilrs-core",
+ "log",
+ "uuid",
+ "vec_map",
+]
+
+[[package]]
+name = "gilrs-core"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7f0ce6237abcc0523f2a5502b1e3fe5802daaae47ac14e166fe49551301ea9"
+dependencies = [
+ "inotify 0.11.5",
+ "js-sys",
+ "libc",
+ "libudev-sys",
+ "log",
+ "nix 0.31.3",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "rusty-xinput",
+ "uuid",
+ "vec_map",
+ "wasm-bindgen",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -628,10 +669,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify-sys"
-version = "0.1.5"
+name = "inotify"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags 2.9.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -728,8 +780,9 @@ dependencies = [
  "embed-resource",
  "encode_unicode",
  "evdev",
+ "gilrs",
  "indoc",
- "inotify",
+ "inotify 0.10.2",
  "kanata-interception",
  "kanata-keyberon",
  "kanata-parser",
@@ -876,9 +929,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
@@ -888,6 +941,16 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1050,6 +1113,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "objc2-core-image"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1259,17 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1313,6 +1408,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "png"
@@ -1465,6 +1566,17 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-xinput"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3335c2b62e1e48dd927f6c8941705386e3697fa944aabcb10431bea7ee47ef3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -1852,6 +1964,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "vswhom"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +2081,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,18 @@ kanata-keyberon = { path = "keyberon", version = "0.1121.0" }
 kanata-parser =   { path = "parser", version = "0.1121.0" }
 kanata-tcp-protocol = { path = "tcp_protocol", version = "0.1121.0" }
 
+# Controller input. One crate covers evdev, IOKit and XInput, which is why
+# src/gamepad has no per-OS branches at all.
+#
+# `xinput` is selected over gilrs's default Windows.Gaming.Input backend on
+# purpose: WGI only delivers input to the focused window, which is unusable for
+# a background daemon, while XInput has no such restriction. The tradeoff is
+# that XInput sees only XUSB-compatible pads; DirectInput-only devices need the
+# Raw Input backend noted as follow-up work in docs/config.adoc. The feature is
+# inert on Linux and macOS, but gilrs-core fails to build with neither backend
+# feature selected on any platform, so it is set unconditionally.
+gilrs = { version = "0.11.2", default-features = false, features = ["xinput"] }
+
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 arboard = "3.4"
 
@@ -144,7 +156,6 @@ gui = ["win_manifest","kanata-parser/gui",
   "native-windows-gui/tray-notification","native-windows-gui/message-window","native-windows-gui/menu","native-windows-gui/cursor","native-windows-gui/high-dpi","native-windows-gui/embed-resource","native-windows-gui/image-decoder","native-windows-gui/notice","native-windows-gui/animation-timer",
 ]
 zippychord = ["kanata-parser/zippychord"]
-
 [profile.release]
 opt-level = "z"
 lto = "fat"

--- a/keyberon/src/key_code.rs
+++ b/keyberon/src/key_code.rs
@@ -5,7 +5,7 @@ pub const KEY_MAX: u16 = 850;
 
 #[test]
 fn keycode_max_test() {
-    assert!((KeyCode::KeyMax as u16) < KEY_MAX);
+    assert!((KeyCode::KeyCodeMax as u16) < KEY_MAX);
 }
 
 #[allow(missing_docs)]
@@ -782,6 +782,69 @@ pub enum KeyCode {
     K765 = 765,
     K766 = 766,
     KeyMax = 767,
+
+    // Codes above the OS scancode range. kanata reserves these for inputs no
+    // operating system reports as a scancode -- currently the game controller
+    // controls named in `kanata_parser::keys::OsCode`. `From<OsCode>` and
+    // `From<KeyCode>` transmute between the two enums, so this range has to
+    // cover every `OsCode` discriminant.
+    K768 = 768,
+    K769 = 769,
+    K770 = 770,
+    K771 = 771,
+    K772 = 772,
+    K773 = 773,
+    K774 = 774,
+    K775 = 775,
+    K776 = 776,
+    K777 = 777,
+    K778 = 778,
+    K779 = 779,
+    K780 = 780,
+    K781 = 781,
+    K782 = 782,
+    K783 = 783,
+    K784 = 784,
+    K785 = 785,
+    K786 = 786,
+    K787 = 787,
+    K788 = 788,
+    K789 = 789,
+    K790 = 790,
+    K791 = 791,
+    K792 = 792,
+    K793 = 793,
+    K794 = 794,
+    K795 = 795,
+    K796 = 796,
+    K797 = 797,
+    K798 = 798,
+    K799 = 799,
+    K800 = 800,
+    K801 = 801,
+    K802 = 802,
+    K803 = 803,
+    K804 = 804,
+    K805 = 805,
+    K806 = 806,
+    K807 = 807,
+    K808 = 808,
+    K809 = 809,
+    K810 = 810,
+    K811 = 811,
+    K812 = 812,
+    K813 = 813,
+    K814 = 814,
+    K815 = 815,
+    K816 = 816,
+    K817 = 817,
+    K818 = 818,
+    K819 = 819,
+    K820 = 820,
+    K821 = 821,
+    K822 = 822,
+    /// One past the highest variant.
+    KeyCodeMax = 823,
 }
 
 impl KeyCode {

--- a/parser/src/cfg/arbitrary_code.rs
+++ b/parser/src/cfg/arbitrary_code.rs
@@ -15,6 +15,11 @@ pub(crate) fn parse_arbitrary_code(
         .atom(s.vars())
         .map(str::parse::<u16>)
         .and_then(|c| c.ok())
+        // The range in the message was never enforced. It has to be now: this
+        // writes the code straight to the OS, and everything at or above
+        // `PAD_SOUTH` begins the synthetic controller range, which has no
+        // scancodes behind it.
+        .filter(|code| *code < OsCode::PAD_SOUTH as u16)
         .ok_or_else(|| anyhow!("{ERR_MSG}: got {:?}", ac_params[0]))?;
     custom(CustomAction::SendArbitraryCode(code), &s.a)
 }

--- a/parser/src/cfg/defsrc.rs
+++ b/parser/src/cfg/defsrc.rs
@@ -51,6 +51,9 @@ pub(crate) fn parse_defsrc(
     log::info!("process unmapped keys: {}", defcfg.process_unmapped_keys);
     if defcfg.process_unmapped_keys {
         for osc in 0..KEYS_IN_ROW as u16 {
+            // Controller controls need no exclusion here: they are synthetic,
+            // so `from_u16` never decodes one. `gamepad_controls_are_never_swept_in`
+            // pins that down.
             if let Some(osc) = OsCode::from_u16(osc) {
                 if osc.is_mouse_code() {
                     // Bugfix #1879:

--- a/parser/src/cfg/override.rs
+++ b/parser/src/cfg/override.rs
@@ -54,6 +54,12 @@ pub(crate) fn parse_override_inout_keys(
                     .ok_or_else(|| {
                         anyhow_expr!(key_expr, "Unknown output key name, must use known keys")
                     })?;
+                // The same rule every other output position enforces: a
+                // controller control names a physical input on a pad, and no
+                // OS can be asked to emit one.
+                if key.is_gamepad_code() {
+                    bail_expr!(key_expr, "{key} can only be used as an input");
+                }
                 keys.push(key);
                 Ok(keys)
             })?;

--- a/parser/src/cfg/unmod.rs
+++ b/parser/src/cfg/unmod.rs
@@ -65,18 +65,22 @@ pub(crate) fn parse_unmod(
     }
 
     let keys: Vec<KeyCode> = params.iter().try_fold(Vec::new(), |mut keys, param| {
-        keys.push(
-            param
-                .atom(s.vars())
-                .and_then(str_to_oscode)
-                .ok_or_else(|| {
-                    anyhow_expr!(
-                        &ac_params[0],
-                        "{unmod_type} {ERR_MSG}\nfound invalid key name"
-                    )
-                })?
-                .into(),
-        );
+        let osc = param
+            .atom(s.vars())
+            .and_then(str_to_oscode)
+            .ok_or_else(|| {
+                anyhow_expr!(
+                    &ac_params[0],
+                    "{unmod_type} {ERR_MSG}\nfound invalid key name"
+                )
+            })?;
+        // These keys are appended to the output list directly rather than
+        // going through an action, so the check `parse_action_atom` makes for
+        // every other output position has to be repeated here.
+        if osc.is_gamepad_code() || osc == OsCode::KEY_766 {
+            bail_expr!(param, "{osc} can only be used as an input");
+        }
+        keys.push(osc.into());
         Ok::<_, ParseError>(keys)
     })?;
     let keys = s.a.sref_vec(keys);

--- a/parser/src/gamepad/analog.rs
+++ b/parser/src/gamepad/analog.rs
@@ -346,3 +346,183 @@ impl Add for Demand {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(x: f32, y: f32) -> Vec2 {
+        Vec2 { x, y }
+    }
+
+    fn plain(speed: f32) -> Motion {
+        Motion {
+            deadzone: Unit::ZERO,
+            speed: speed * 1000.0,
+            curve: Curve::Linear,
+            invert: Vec2::KEEP,
+        }
+    }
+
+    #[test]
+    fn garbage_readings_are_clamped_or_read_as_at_rest() {
+        // Hardware overshoots its own range, and a disconnecting controller
+        // reports NaN. Treating NaN as full deflection would jam a direction
+        // on; letting it reach the deadzone rescale would poison the result.
+        assert_eq!(Unit::new(1.4), Unit::ONE);
+        assert_eq!(Unit::new(-0.2), Unit::ZERO);
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert_eq!(Unit::new(bad), Unit::ZERO);
+        }
+        assert_eq!(AxisValue::new(1.4).get(), 1.0);
+        assert_eq!(AxisValue::new(-1.4).get(), -1.0);
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert_eq!(AxisValue::new(bad), AxisValue::ZERO);
+        }
+        assert_eq!(StickPosition::new(2.0, f32::NAN).vector(), v(1.0, 0.0));
+        for bad in [v(f32::NAN, 0.0), v(0.0, f32::NAN), v(f32::NAN, f32::NAN)] {
+            assert_eq!(Motion::MOUSE.displace(bad), Vec2::ZERO, "{bad:?}");
+        }
+        for bad_speed in [f32::NAN, f32::INFINITY, -1.0] {
+            assert_eq!(
+                Motion {
+                    speed: bad_speed,
+                    ..Motion::MOUSE
+                }
+                .displace(v(1.0, 0.0)),
+                Vec2::ZERO
+            );
+        }
+    }
+
+    #[test]
+    fn the_deadzone_silences_the_center_without_a_jump_at_its_edge() {
+        let dz = Motion {
+            deadzone: Unit::new(0.15),
+            ..plain(1.0)
+        };
+        for inside in [v(0.0, 0.0), v(0.10, 0.0), v(0.10, 0.10), v(-0.14, 0.0)] {
+            assert_eq!(dz.displace(inside), Vec2::ZERO, "{inside:?}");
+        }
+        // Just past the edge is near zero, not near 0.15, and full deflection
+        // survives unattenuated.
+        assert!(dz.displace(v(0.16, 0.0)).x < 0.02);
+        assert!((dz.displace(v(1.0, 0.0)).x - 1.0).abs() < 1e-6);
+        // A deadzone of one silences the control instead of dividing by zero.
+        let all = Motion {
+            deadzone: Unit::ONE,
+            ..plain(1.0)
+        };
+        assert_eq!(all.displace(v(1.0, 1.0)), Vec2::ZERO);
+    }
+
+    #[test]
+    fn a_diagonal_keeps_its_direction_and_does_not_outrun_a_cardinal() {
+        // A hardware corner reads (1, 1), a radius of 1.41. Left alone that
+        // makes a diagonal 41% faster than a straight push.
+        let m = plain(10.0);
+        assert!((m.displace(v(1.0, 0.0)).x - 10.0).abs() < 1e-4);
+        for corner in [v(1.0, 1.0), v(-1.0, 1.0), v(1.0, -1.0)] {
+            let out = m.displace(corner);
+            assert!((out.radius() - 10.0).abs() < 1e-3, "{corner:?} -> {out:?}");
+            assert!((out.x.abs() - out.y.abs()).abs() < 1e-4, "off the diagonal");
+        }
+    }
+
+    #[test]
+    fn the_curve_applies_to_the_magnitude_not_to_each_axis() {
+        // Curving the axes independently would bend a diagonal toward an axis.
+        let cubic = Motion {
+            curve: Curve::Cubic,
+            ..plain(100.0)
+        };
+        let s = std::f32::consts::FRAC_1_SQRT_2 * 0.5;
+        let out = cubic.displace(v(s, s));
+        assert!((out.x - out.y).abs() < 1e-4, "{out:?}");
+        // magnitude 0.5, cubed to 0.125, times 100 units per tick.
+        assert!((out.radius() - 12.5).abs() < 1e-2, "{out:?}");
+        // Steeper curves give finer control near center, and every curve fixes
+        // the endpoints.
+        let half = Unit::new(0.5);
+        assert!(Curve::Cubic.apply(half) < Curve::Quadratic.apply(half));
+        assert!(Curve::Quadratic.apply(half) < Curve::Linear.apply(half));
+        for curve in [Curve::Linear, Curve::Quadratic, Curve::Cubic] {
+            assert_eq!(curve.apply(Unit::ZERO), Unit::ZERO, "{curve:?}");
+            assert_eq!(curve.apply(Unit::ONE), Unit::ONE, "{curve:?}");
+        }
+    }
+
+    #[test]
+    fn inversion_flips_only_the_requested_axis() {
+        assert!(
+            Motion::MOUSE.displace(v(0.0, 1.0)).y < 0.0,
+            "push away moves the pointer up the screen"
+        );
+        assert!(
+            Motion::SCROLL.displace(v(0.0, 1.0)).y > 0.0,
+            "push away scrolls up"
+        );
+        assert_eq!(Motion::MOUSE.invert.x, 1.0, "x is not flipped by default");
+    }
+
+    #[test]
+    fn a_scalar_control_gets_the_same_response_as_an_axis() {
+        // A trigger is one number, but the deadzone, curve and speed have to
+        // mean the same thing there as on a stick.
+        let m = Motion {
+            curve: Curve::Quadratic,
+            ..plain(8.0)
+        };
+        assert_eq!(m.rate(0.0), 0.0);
+        assert!((m.rate(0.5) - 2.0).abs() < 1e-4, "{}", m.rate(0.5));
+        assert!((m.displace(v(1.0, 0.0)).x - m.rate(1.0)).abs() < 1e-4);
+    }
+
+    #[test]
+    fn a_threshold_is_strict_at_its_boundary() {
+        let threshold = Unit::new(0.5);
+        assert!(!(Unit::new(0.49) > threshold));
+        assert!(!(Unit::new(0.50) > threshold));
+        assert!(Unit::new(0.51) > threshold);
+    }
+
+    #[test]
+    fn demands_sum_per_output_and_report_idleness() {
+        let mut a = Demand::default();
+        assert!(a.is_idle());
+        a[MotionKind::Mouse] = v(1.0, 2.0);
+        let mut b = Demand::default();
+        b[MotionKind::Mouse] = v(-1.0, 0.5);
+        b[MotionKind::Scroll] = v(0.0, 3.0);
+        assert!(!a.is_idle());
+        let sum = a + b;
+        assert_eq!(sum[MotionKind::Mouse], v(0.0, 2.5));
+        assert_eq!(sum[MotionKind::Scroll], v(0.0, 3.0));
+    }
+
+    #[test]
+    fn whole_units_accumulate_exactly_across_ticks() {
+        // Rounding each tick independently would make a 7.5 px/ms demand run
+        // permanently 7% slow or 25% fast, and a demand below one unit would
+        // round to nothing forever.
+        let mut carry = Vec2::ZERO;
+        let total: i32 = (0..1000)
+            .map(|_| {
+                carry += v(7.5, 0.0);
+                carry.take_whole().0
+            })
+            .sum();
+        assert_eq!(total, 7500);
+
+        // The two axes carry separately: a fast horizontal push must not drag
+        // the vertical axis along with it.
+        let mut slow = Vec2::ZERO;
+        let crawl: i32 = (0..10)
+            .map(|_| {
+                slow += v(0.25, -0.25);
+                slow.take_whole().0
+            })
+            .sum();
+        assert_eq!(crawl, 2, "0.25 a tick over 10 ticks is 2.5 pixels");
+        assert_eq!(slow.take_whole(), (0, 0));
+    }
+}

--- a/parser/src/gamepad/analog.rs
+++ b/parser/src/gamepad/analog.rs
@@ -1,0 +1,348 @@
+//! Analog values and the transformations that turn them into digital edges
+//! and continuous motion. Everything here is total and hardware-free.
+//!
+//! Two conventions are fixed once, so no call site has to remember them: **y
+//! is up-positive**, converted at the backend boundary, and **values are
+//! clamped, never rejected**, because hardware overshoots its own reported
+//! range and refusing such a reading would drop real input.
+
+use core::ops::{Add, AddAssign, Index, IndexMut, Mul};
+
+/// A magnitude in `[0.0, 1.0]`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
+pub struct Unit(f32);
+
+impl Unit {
+    pub const ZERO: Unit = Unit(0.0);
+    pub const ONE: Unit = Unit(1.0);
+
+    /// Clamp a raw reading into the unit interval. Non-finite values become
+    /// zero: a controller reporting garbage should read as at rest, not as
+    /// fully deflected.
+    pub fn new(value: f32) -> Unit {
+        match value.is_finite() {
+            true => Unit(value.clamp(0.0, 1.0)),
+            false => Unit::ZERO,
+        }
+    }
+
+    pub const fn get(self) -> f32 {
+        self.0
+    }
+}
+
+/// A normalized signed axis reading in `[-1.0, 1.0]`.
+///
+/// Hardware values enter through this constructor, so the projector cannot
+/// represent an infinite, NaN, or out-of-range stick position. Non-finite
+/// readings mean centered: unlike a large finite overshoot, they carry no
+/// recoverable direction.
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
+pub struct AxisValue(f32);
+
+impl AxisValue {
+    pub const ZERO: AxisValue = AxisValue(0.0);
+
+    pub fn new(value: f32) -> AxisValue {
+        match value.is_finite() {
+            true => AxisValue(value.clamp(-1.0, 1.0)),
+            false => AxisValue::ZERO,
+        }
+    }
+
+    pub const fn get(self) -> f32 {
+        self.0
+    }
+}
+
+/// One whole two-axis stick reading, normalized and y-up.
+///
+/// Keeping the pair together avoids exposing transient half-updated diagonals
+/// to projection. [`Vec2`] remains the intentionally unbounded vector used for
+/// rates and displacement; this type is only physical stick position.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct StickPosition {
+    x: AxisValue,
+    y: AxisValue,
+}
+
+impl StickPosition {
+    pub fn new(x: f32, y: f32) -> StickPosition {
+        StickPosition {
+            x: AxisValue::new(x),
+            y: AxisValue::new(y),
+        }
+    }
+
+    pub const fn x(self) -> AxisValue {
+        self.x
+    }
+
+    pub const fn y(self) -> AxisValue {
+        self.y
+    }
+
+    pub const fn vector(self) -> Vec2 {
+        Vec2 {
+            x: self.x.get(),
+            y: self.y.get(),
+        }
+    }
+}
+
+/// A two-axis reading, y-up.
+///
+/// Components are whatever the hardware reported, so the radius of a diagonal
+/// may exceed one until a deadzone normalizes it. Also serves as a
+/// displacement -- pixels or wheel notches -- and as a pair of axis signs.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Vec2 {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Vec2 {
+    pub const ZERO: Vec2 = Vec2 { x: 0.0, y: 0.0 };
+    /// The identity for [`Motion::invert`]: keep both axes as they are.
+    pub const KEEP: Vec2 = Vec2 { x: 1.0, y: 1.0 };
+
+    /// True distance from center, which a hardware corner puts past 1.0.
+    pub fn radius(self) -> f32 {
+        self.x.hypot(self.y)
+    }
+
+    pub fn is_zero(self) -> bool {
+        self.x == 0.0 && self.y == 0.0
+    }
+
+    /// Split into whole units, leaving the fraction in place.
+    ///
+    /// The pointer path carries the remainder between ticks: a stick asking
+    /// for 7.5 pixels a millisecond has to average exactly that, and rounding
+    /// a small demand to zero would make slow movement impossible rather than
+    /// merely slow.
+    pub fn take_whole(&mut self) -> (i32, i32) {
+        // This is the only place a bad reading could become lasting state:
+        // `NaN - NaN` is NaN, so a single poisoned component would leave the
+        // carry NaN and every later take at zero for the rest of the process.
+        // `Motion` already refuses to emit one; this is the backstop.
+        for axis in [&mut self.x, &mut self.y] {
+            if !axis.is_finite() {
+                *axis = 0.0;
+            }
+        }
+        let (x, y) = (self.x.trunc(), self.y.trunc());
+        self.x -= x;
+        self.y -= y;
+        (x as i32, y as i32)
+    }
+}
+
+impl Add for Vec2 {
+    type Output = Vec2;
+    fn add(self, other: Vec2) -> Vec2 {
+        Vec2 {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+}
+
+impl AddAssign for Vec2 {
+    fn add_assign(&mut self, other: Vec2) {
+        *self = *self + other;
+    }
+}
+
+impl Mul<f32> for Vec2 {
+    type Output = Vec2;
+    fn mul(self, scale: f32) -> Vec2 {
+        Vec2 {
+            x: self.x * scale,
+            y: self.y * scale,
+        }
+    }
+}
+
+/// Componentwise, which is what applies per-axis inversion.
+impl Mul<Vec2> for Vec2 {
+    type Output = Vec2;
+    fn mul(self, other: Vec2) -> Vec2 {
+        Vec2 {
+            x: self.x * other.x,
+            y: self.y * other.y,
+        }
+    }
+}
+
+/// The response curve applied to continuous projections.
+///
+/// Digital thresholds are compared *before* any curve, so changing the curve
+/// changes pointer feel without silently moving a press point.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Curve {
+    /// Output tracks deflection directly.
+    Linear,
+    /// Squared: finer control near center.
+    Quadratic,
+    /// Cubed: finest near center, full speed at the rim. The default for
+    /// pointer control, where small corrections matter most.
+    #[default]
+    Cubic,
+}
+
+impl Curve {
+    pub fn apply(self, t: Unit) -> Unit {
+        let t = t.get();
+        Unit::new(match self {
+            Curve::Linear => t,
+            Curve::Quadratic => t * t,
+            Curve::Cubic => t * t * t,
+        })
+    }
+}
+
+/// Which continuous output a projection drives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MotionKind {
+    Mouse,
+    Scroll,
+}
+
+impl MotionKind {
+    pub const ALL: [MotionKind; 2] = [MotionKind::Mouse, MotionKind::Scroll];
+}
+
+/// How a control's deflection becomes pointer or wheel movement.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Motion {
+    /// Radius below which the control reads as at rest. Applied radially
+    /// rather than per-axis: an axial deadzone lets a stick held diagonally at
+    /// low deflection register on one axis but not the other, which produces
+    /// phantom cardinal movement on the way to a diagonal.
+    pub deadzone: Unit,
+    /// Output at full deflection per second: pixels for the pointer, notches
+    /// for the wheel. Converted to the engine's 1 ms tick in [`Motion::rate`].
+    pub speed: f32,
+    pub curve: Curve,
+    /// Per-axis sign. See [`Vec2::KEEP`].
+    pub invert: Vec2,
+}
+
+impl Motion {
+    /// A generous upper bound that still catches an extra zero as a typo.
+    pub const MAX_SPEED: f32 = 100_000.0;
+
+    pub const MOUSE: Motion = Motion {
+        deadzone: Unit(0.15),
+        speed: 1000.0,
+        curve: Curve::Cubic,
+        // Screen coordinates grow downward while a stick's Y grows upward, so
+        // inverting by default makes "push away" mean "move up", which is what
+        // every user expects. `(invert-y no)` restores flight-sim behaviour.
+        invert: Vec2 { x: 1.0, y: -1.0 },
+    };
+
+    pub const SCROLL: Motion = Motion {
+        deadzone: Unit(0.15),
+        speed: 30.0,
+        curve: Curve::Linear,
+        // Stick Y and wheel-up are both up-positive, so no inversion.
+        invert: Vec2::KEEP,
+    };
+
+    pub const fn of(kind: MotionKind) -> Motion {
+        match kind {
+            MotionKind::Mouse => Motion::MOUSE,
+            MotionKind::Scroll => Motion::SCROLL,
+        }
+    }
+
+    /// The output per 1 ms tick a deflection of `magnitude` asks for.
+    ///
+    /// The dead region is removed and what survives is rescaled back to
+    /// `0..=1`, so the first movement past the edge produces the smallest
+    /// possible output instead of jumping straight to the deadzone radius.
+    /// Overshoot past the rim clamps, which is also what stops a stick at a
+    /// hardware corner from outrunning a straight push.
+    pub fn rate(self, magnitude: f32) -> f32 {
+        let dz = self.deadzone.get();
+        // Non-finite readings are spelled out rather than left to the
+        // comparisons below. A disconnecting controller reports NaN, and an
+        // infinite radius would clamp to full deflection and then hit the
+        // `rate / radius` division in `displace`, where `inf * 0.0` is NaN.
+        // They read as at rest rather than as full deflection because no
+        // direction can be recovered from them.
+        if !magnitude.is_finite() || magnitude <= dz || dz >= 1.0 {
+            return 0.0;
+        }
+        let speed = match self.speed.is_finite() {
+            true => self.speed.clamp(0.0, Motion::MAX_SPEED),
+            false => 0.0,
+        };
+        self.curve
+            .apply(Unit::new((magnitude - dz) / (1.0 - dz)))
+            .get()
+            * speed
+            / 1000.0
+    }
+
+    /// A two-axis reading as a per-tick displacement.
+    ///
+    /// The curve applies to the *magnitude* rather than to each axis, so the
+    /// direction the user is pushing survives; curving the axes independently
+    /// would bend a 45-degree push off the diagonal.
+    pub fn displace(self, raw: Vec2) -> Vec2 {
+        let radius = raw.radius();
+        let rate = self.rate(radius);
+        match rate == 0.0 {
+            true => Vec2::ZERO,
+            false => {
+                let displaced = raw * (rate / radius) * self.invert;
+                Vec2 {
+                    x: if displaced.x.is_finite() {
+                        displaced.x
+                    } else {
+                        0.0
+                    },
+                    y: if displaced.y.is_finite() {
+                        displaced.y
+                    } else {
+                        0.0
+                    },
+                }
+            }
+        }
+    }
+}
+
+/// What the continuous projections are asking for this tick.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Demand([Vec2; 2]);
+
+impl Demand {
+    pub fn is_idle(self) -> bool {
+        self.0.iter().all(|v| v.is_zero())
+    }
+}
+
+impl Index<MotionKind> for Demand {
+    type Output = Vec2;
+    fn index(&self, kind: MotionKind) -> &Vec2 {
+        &self.0[kind as usize]
+    }
+}
+
+impl IndexMut<MotionKind> for Demand {
+    fn index_mut(&mut self, kind: MotionKind) -> &mut Vec2 {
+        &mut self.0[kind as usize]
+    }
+}
+
+impl Add for Demand {
+    type Output = Demand;
+    fn add(self, other: Demand) -> Demand {
+        Demand([self.0[0] + other.0[0], self.0[1] + other.0[1]])
+    }
+}
+

--- a/parser/src/gamepad/mod.rs
+++ b/parser/src/gamepad/mod.rs
@@ -388,3 +388,197 @@ impl PadButton {
     ];
 }
 
+// -------------------------------------------------------------------- codes
+
+/// A control on a game controller, as an index into the `OsCode` range
+/// reserved for them.
+///
+/// The only supported way to obtain a controller `OsCode`: keeping the
+/// synthetic range behind a constructor stops it leaking into code that
+/// reasons about real scancodes. The range is laid out as buttons, then eight
+/// directions per [`Directional`], then the slots, so construction and
+/// [`PadCode::control`] are index arithmetic rather than a lookup table.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PadCode(u8);
+
+impl PadCode {
+    /// How many `pad-button-N` slots exist.
+    pub const SLOTS: u8 = 16;
+
+    const DIRECTIONS: u8 = PadButton::ALL.len() as u8;
+    const SLOT_BASE: u8 = PadCode::DIRECTIONS + (Directional::ALL.len() * Dir::ALL.len()) as u8;
+
+    pub const fn button(button: PadButton) -> PadCode {
+        PadCode(button as u8)
+    }
+
+    pub const fn direction(control: Directional, dir: Dir) -> PadCode {
+        PadCode(PadCode::DIRECTIONS + control as u8 * Dir::ALL.len() as u8 + dir as u8)
+    }
+
+    pub const fn slot(index: u8) -> Option<PadCode> {
+        match index < PadCode::SLOTS {
+            true => Some(PadCode(PadCode::SLOT_BASE + index)),
+            false => None,
+        }
+    }
+
+    /// Recover a `PadCode`, rejecting anything outside the reserved range.
+    pub const fn from_os_code(code: OsCode) -> Option<PadCode> {
+        match code.gamepad_index() {
+            Some(index) => Some(PadCode(index)),
+            None => None,
+        }
+    }
+
+    pub const fn os_code(self) -> OsCode {
+        match OsCode::from_gamepad_index(self.0) {
+            Some(code) => code,
+            None => unreachable!(),
+        }
+    }
+
+    /// What this code names: the inverse of the constructors, so callers can
+    /// reason about a code without re-deriving the layout of the range.
+    pub const fn control(self) -> PadControl {
+        let index = self.0;
+        if index < PadCode::DIRECTIONS {
+            return PadControl::Button(PadButton::ALL[index as usize]);
+        }
+        if index < PadCode::SLOT_BASE {
+            let rest = (index - PadCode::DIRECTIONS) as usize;
+            return PadControl::Direction(
+                Directional::ALL[rest / Dir::ALL.len()],
+                Dir::ALL[rest % Dir::ALL.len()],
+            );
+        }
+        PadControl::Slot(index - PadCode::SLOT_BASE)
+    }
+}
+
+/// The vocabulary above and the reserved `OsCode` range are two spellings of
+/// one thing, and every constructor here assumes they agree.
+const _: () = {
+    assert!(
+        PadCode::SLOT_BASE + PadCode::SLOTS == OsCode::GAMEPAD_COUNT,
+        "the reserved OsCode range and the control vocabulary disagree"
+    );
+    assert!(
+        OsCode::GAMEPAD_COUNT as u32 <= u64::BITS,
+        "a PadSet has one bit per control; widen it or shrink the vocabulary"
+    );
+};
+
+/// The three kinds of control the reserved range holds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PadControl {
+    Button(PadButton),
+    Direction(Directional, Dir),
+    /// A user-assignable `pad-button-N`.
+    Slot(u8),
+}
+
+impl From<PadCode> for OsCode {
+    fn from(code: PadCode) -> OsCode {
+        code.os_code()
+    }
+}
+
+impl fmt::Debug for PadCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.os_code())
+    }
+}
+
+impl fmt::Display for PadCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.os_code())
+    }
+}
+
+/// A digital control changing state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PadEdge {
+    pub code: PadCode,
+    pub pressed: bool,
+}
+
+/// The set of controls a controller is holding.
+///
+/// One `u64`, because the reserved range is deliberately smaller than that.
+/// Holding state, merging several controllers and diffing for edges are then
+/// each a single instruction, and nothing on the event path allocates.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+pub struct PadSet(u64);
+
+impl PadSet {
+    pub const EMPTY: PadSet = PadSet(0);
+
+    pub const fn contains(self, code: PadCode) -> bool {
+        self.0 & (1 << code.0) != 0
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    pub fn insert(&mut self, code: PadCode) {
+        self.0 |= 1 << code.0;
+    }
+
+    pub fn set(&mut self, code: PadCode, present: bool) {
+        let bit = 1u64 << code.0;
+        self.0 = if present { self.0 | bit } else { self.0 & !bit };
+    }
+
+    pub fn iter(self) -> impl Iterator<Item = PadCode> {
+        codes(self.0)
+    }
+
+    /// The transitions from `self` to `next`.
+    ///
+    /// Releases come before presses: a four-way stick moving from Up to Left
+    /// must not momentarily hold both, which a game reads as a diagonal. Every
+    /// control group diffs through here, so that rule is written once.
+    pub fn edges(self, next: PadSet) -> impl Iterator<Item = PadEdge> {
+        let released = codes(self.0 & !next.0).map(|code| PadEdge {
+            code,
+            pressed: false,
+        });
+        let pressed = codes(next.0 & !self.0).map(|code| PadEdge {
+            code,
+            pressed: true,
+        });
+        released.chain(pressed)
+    }
+}
+
+fn codes(mut bits: u64) -> impl Iterator<Item = PadCode> {
+    core::iter::from_fn(move || {
+        (bits != 0).then(|| {
+            let index = bits.trailing_zeros() as u8;
+            bits &= bits - 1;
+            PadCode(index)
+        })
+    })
+}
+
+impl BitOr for PadSet {
+    type Output = PadSet;
+    fn bitor(self, other: PadSet) -> PadSet {
+        PadSet(self.0 | other.0)
+    }
+}
+
+impl BitOrAssign for PadSet {
+    fn bitor_assign(&mut self, other: PadSet) {
+        self.0 |= other.0;
+    }
+}
+
+impl fmt::Debug for PadSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+

--- a/parser/src/gamepad/mod.rs
+++ b/parser/src/gamepad/mod.rs
@@ -402,6 +402,8 @@ impl PadButton {
 pub struct PadCode(u8);
 
 impl PadCode {
+    /// The number of controls in the reserved controller range.
+    pub const COUNT: usize = OsCode::GAMEPAD_COUNT as usize;
     /// How many `pad-button-N` slots exist.
     pub const SLOTS: u8 = 16;
 
@@ -429,6 +431,10 @@ impl PadCode {
             Some(index) => Some(PadCode(index)),
             None => None,
         }
+    }
+
+    pub(crate) const fn from_index(index: usize) -> PadCode {
+        PadCode(index as u8)
     }
 
     pub const fn os_code(self) -> OsCode {
@@ -638,6 +644,9 @@ pub struct Digital {
     /// -- deadzone or curve -- can silently move it. Ignored by a d-pad, which
     /// is digital before it arrives.
     pub threshold: Unit,
+    /// How long a raw crossing must remain on its new side before it becomes
+    /// a key edge. Zero preserves immediate threshold behavior.
+    pub debounce: u16,
 }
 
 /// At most one projection for each continuous output domain.
@@ -679,6 +688,7 @@ impl Default for Digital {
             mode: DirMode::default(),
             socd: Socd::default(),
             threshold: Unit::new(0.50),
+            debounce: 0,
         }
     }
 }
@@ -713,6 +723,8 @@ impl Projection {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Trigger {
     pub threshold: Unit,
+    /// See [`Digital::debounce`].
+    pub debounce: u16,
     pub motions: Motions<TriggerMotion>,
 }
 
@@ -728,6 +740,7 @@ impl Default for Trigger {
         // A trigger actuates much earlier than a stick.
         Trigger {
             threshold: Unit::new(0.30),
+            debounce: 0,
             motions: Motions::default(),
         }
     }

--- a/parser/src/gamepad/mod.rs
+++ b/parser/src/gamepad/mod.rs
@@ -113,3 +113,278 @@ impl Directional {
         }
     }
 }
+
+/// One of eight directions a projected control can expose to the layout.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Dir {
+    Up,
+    Down,
+    Left,
+    Right,
+    UpLeft,
+    UpRight,
+    DownLeft,
+    DownRight,
+}
+
+impl Dir {
+    pub const ALL: [Dir; 8] = [
+        Dir::Up,
+        Dir::Down,
+        Dir::Left,
+        Dir::Right,
+        Dir::UpLeft,
+        Dir::UpRight,
+        Dir::DownLeft,
+        Dir::DownRight,
+    ];
+
+    pub const fn is_diagonal(self) -> bool {
+        (self as u8) >= Dir::UpLeft as u8
+    }
+
+    /// The direction that cancels this one, which is what SOCD arbitrates.
+    pub const fn opposite(self) -> Dir {
+        match self {
+            Dir::Up => Dir::Down,
+            Dir::Down => Dir::Up,
+            Dir::Left => Dir::Right,
+            Dir::Right => Dir::Left,
+            Dir::UpLeft => Dir::DownRight,
+            Dir::UpRight => Dir::DownLeft,
+            Dir::DownLeft => Dir::UpRight,
+            Dir::DownRight => Dir::UpLeft,
+        }
+    }
+
+    /// The unit vector this direction points along, y-up.
+    pub const fn vector(self) -> Vec2 {
+        let (x, y) = match self {
+            Dir::Up => (0.0, 1.0),
+            Dir::Down => (0.0, -1.0),
+            Dir::Left => (-1.0, 0.0),
+            Dir::Right => (1.0, 0.0),
+            Dir::UpLeft => (-1.0, 1.0),
+            Dir::UpRight => (1.0, 1.0),
+            Dir::DownLeft => (-1.0, -1.0),
+            Dir::DownRight => (1.0, -1.0),
+        };
+        Vec2 { x, y }
+    }
+}
+
+/// One of the four directions a physical axis or contact can assert.
+///
+/// This is deliberately distinct from [`Dir`]. Hardware reports cardinals;
+/// diagonals are a projection of one vertical and one horizontal cardinal.
+/// Keeping those domains separate prevents an already-projected diagonal from
+/// being fed back into SOCD or four-way projection as if it were raw input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Cardinal {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+impl Cardinal {
+    pub const ALL: [Cardinal; 4] = [
+        Cardinal::Up,
+        Cardinal::Down,
+        Cardinal::Left,
+        Cardinal::Right,
+    ];
+
+    pub const fn direction(self) -> Dir {
+        match self {
+            Cardinal::Up => Dir::Up,
+            Cardinal::Down => Dir::Down,
+            Cardinal::Left => Dir::Left,
+            Cardinal::Right => Dir::Right,
+        }
+    }
+
+    pub const fn opposite(self) -> Cardinal {
+        match self {
+            Cardinal::Up => Cardinal::Down,
+            Cardinal::Down => Cardinal::Up,
+            Cardinal::Left => Cardinal::Right,
+            Cardinal::Right => Cardinal::Left,
+        }
+    }
+
+    pub const fn vector(self) -> Vec2 {
+        self.direction().vector()
+    }
+}
+
+impl TryFrom<Dir> for Cardinal {
+    type Error = ();
+
+    fn try_from(dir: Dir) -> Result<Cardinal, ()> {
+        match dir {
+            Dir::Up => Ok(Cardinal::Up),
+            Dir::Down => Ok(Cardinal::Down),
+            Dir::Left => Ok(Cardinal::Left),
+            Dir::Right => Ok(Cardinal::Right),
+            Dir::UpLeft | Dir::UpRight | Dir::DownLeft | Dir::DownRight => Err(()),
+        }
+    }
+}
+
+/// A set of raw cardinal assertions from a stick, d-pad, or hat.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+pub struct CardinalSet(u8);
+
+impl CardinalSet {
+    pub const EMPTY: CardinalSet = CardinalSet(0);
+
+    pub const fn of(dirs: &[Cardinal]) -> CardinalSet {
+        let (mut bits, mut i) = (0u8, 0);
+        while i < dirs.len() {
+            bits |= 1 << dirs[i] as u8;
+            i += 1;
+        }
+        CardinalSet(bits)
+    }
+
+    pub const fn contains(self, dir: Cardinal) -> bool {
+        self.0 & (1 << dir as u8) != 0
+    }
+
+    pub fn set(&mut self, dir: Cardinal, present: bool) {
+        let bit = 1 << dir as u8;
+        self.0 = if present { self.0 | bit } else { self.0 & !bit };
+    }
+
+    pub fn iter(self) -> impl Iterator<Item = Cardinal> {
+        Cardinal::ALL.into_iter().filter(move |d| self.contains(*d))
+    }
+
+    /// The direction this set asserts on one axis, or `None` when it asserts
+    /// neither or both. Both is not a direction: it is a question for SOCD,
+    /// and nothing here may guess an answer.
+    const fn axis(self, positive: Cardinal, negative: Cardinal) -> Option<Cardinal> {
+        match (self.contains(positive), self.contains(negative)) {
+            (true, false) => Some(positive),
+            (false, true) => Some(negative),
+            _ => None,
+        }
+    }
+
+    /// The single direction a set of cardinals denotes, or `None` if it
+    /// denotes none.
+    ///
+    /// The two axes are resolved separately. An axis asserting both directions
+    /// contributes nothing, but it must not take the other axis down with it:
+    /// a hitbox holding Left+Right while pushing Up is still pushing Up, and
+    /// collapsing that to "no direction at all" would release a control the
+    /// user never let go of.
+    pub const fn single(self) -> Option<Dir> {
+        match (
+            self.axis(Cardinal::Up, Cardinal::Down),
+            self.axis(Cardinal::Right, Cardinal::Left),
+        ) {
+            (Some(vertical), Some(horizontal)) => Some(combine(vertical, horizontal)),
+            (Some(found), None) | (None, Some(found)) => Some(found.direction()),
+            (None, None) => None,
+        }
+    }
+
+    /// The directions that reach the layout in the requested mode.
+    pub fn projected(self, mode: DirMode) -> impl Iterator<Item = Dir> {
+        let single = self.single();
+        Dir::ALL.into_iter().filter(move |dir| match mode {
+            DirMode::FourWay => Cardinal::try_from(*dir).is_ok_and(|d| self.contains(d)),
+            DirMode::EightWay => single == Some(*dir),
+        })
+    }
+
+    /// Where this set points, with components in `-1..=1`. A d-pad reads as a
+    /// stick this way, so both drive the same continuous projection.
+    pub fn vector(self) -> Vec2 {
+        self.iter()
+            .map(Cardinal::vector)
+            .fold(Vec2::ZERO, |total, v| total + v)
+    }
+}
+
+/// The diagonal two cardinals make. Only reachable with one vertical and one
+/// horizontal, which is the only way [`CardinalSet::single`] calls it.
+const fn combine(a: Cardinal, b: Cardinal) -> Dir {
+    match (a, b) {
+        (Cardinal::Up, Cardinal::Left) | (Cardinal::Left, Cardinal::Up) => Dir::UpLeft,
+        (Cardinal::Up, Cardinal::Right) | (Cardinal::Right, Cardinal::Up) => Dir::UpRight,
+        (Cardinal::Down, Cardinal::Left) | (Cardinal::Left, Cardinal::Down) => Dir::DownLeft,
+        (Cardinal::Down, Cardinal::Right) | (Cardinal::Right, Cardinal::Down) => Dir::DownRight,
+        _ => unreachable!(),
+    }
+}
+
+impl BitOr for CardinalSet {
+    type Output = CardinalSet;
+    fn bitor(self, other: CardinalSet) -> CardinalSet {
+        CardinalSet(self.0 | other.0)
+    }
+}
+
+impl fmt::Debug for CardinalSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+
+/// A digital control with a portable meaning.
+///
+/// Every name is positional: [`PadButton::South`] is the lower face button
+/// whatever glyph the vendor printed on it, so one configuration works across
+/// a DualSense, an Xbox pad and a Switch Pro pad without edits. The d-pad is
+/// not here: its four contacts point a direction, so it is a [`Directional`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum PadButton {
+    /// Lower face button: Cross, A, or B depending on the vendor.
+    South,
+    /// Right face button: Circle, B, or A.
+    East,
+    /// Left face button: Square, X, or Y.
+    West,
+    /// Upper face button: Triangle, Y, or X.
+    North,
+    /// Extra face buttons present on some six-button pads.
+    C,
+    Z,
+    /// Upper shoulder buttons.
+    L1,
+    R1,
+    /// Triggers, as digital controls. See [`Side::trigger`].
+    L2,
+    R2,
+    Select,
+    Start,
+    /// The vendor button: PS, Guide, Home.
+    Mode,
+    /// Stick clicks.
+    L3,
+    R3,
+}
+
+impl PadButton {
+    pub const ALL: [PadButton; 15] = [
+        PadButton::South,
+        PadButton::East,
+        PadButton::West,
+        PadButton::North,
+        PadButton::C,
+        PadButton::Z,
+        PadButton::L1,
+        PadButton::R1,
+        PadButton::L2,
+        PadButton::R2,
+        PadButton::Select,
+        PadButton::Start,
+        PadButton::Mode,
+        PadButton::L3,
+        PadButton::R3,
+    ];
+}
+

--- a/parser/src/gamepad/mod.rs
+++ b/parser/src/gamepad/mod.rs
@@ -803,3 +803,157 @@ impl GamepadConfig {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Everything else here is index arithmetic over the reserved range, so
+    /// this is the assumption the whole module rests on.
+    #[test]
+    fn pad_codes_tile_the_reserved_range() {
+        let mut seen = Vec::new();
+        let codes = PadButton::ALL
+            .map(|b| (PadCode::button(b), PadControl::Button(b)))
+            .into_iter()
+            .chain(Directional::ALL.into_iter().flat_map(|c| {
+                Dir::ALL.map(move |d| (PadCode::direction(c, d), PadControl::Direction(c, d)))
+            }))
+            .chain(
+                (0..PadCode::SLOTS)
+                    .map(|i| (PadCode::slot(i).expect("below SLOTS"), PadControl::Slot(i))),
+            );
+        for (code, control) in codes {
+            assert_eq!(code.control(), control, "{code} misclassified");
+            assert_eq!(PadCode::from_os_code(code.os_code()), Some(code));
+            seen.push(code);
+        }
+        seen.sort();
+        seen.dedup();
+        assert_eq!(seen.len(), OsCode::GAMEPAD_COUNT as usize, "codes overlap");
+        assert_eq!(PadCode::slot(PadCode::SLOTS), None);
+        for not_a_pad in [OsCode::KEY_A, OsCode::BTN_LEFT, OsCode::KEY_MAX] {
+            assert_eq!(PadCode::from_os_code(not_a_pad), None, "{not_a_pad}");
+        }
+    }
+
+    #[test]
+    fn cardinal_and_projected_directions_are_distinct_and_total() {
+        for dir in Dir::ALL {
+            assert_eq!(dir.opposite().opposite(), dir);
+            assert_ne!(dir.opposite(), dir);
+            assert_eq!(Cardinal::try_from(dir).is_err(), dir.is_diagonal());
+        }
+        for cardinal in Cardinal::ALL {
+            assert_eq!(cardinal.opposite().opposite(), cardinal);
+            assert_eq!(Cardinal::try_from(cardinal.direction()), Ok(cardinal));
+        }
+        assert_eq!(CardinalSet::EMPTY.single(), None);
+    }
+
+    #[test]
+    fn an_opposed_axis_denotes_no_direction() {
+        // Up+Down is not a direction, it is a question for SOCD, and the
+        // eight-way collapse may not guess an answer.
+        for pair in [
+            CardinalSet::of(&[Cardinal::Up, Cardinal::Down]),
+            CardinalSet::of(&[Cardinal::Left, Cardinal::Right]),
+        ] {
+            assert_eq!(pair.single(), None, "{pair:?}");
+            assert_eq!(pair.projected(DirMode::EightWay).count(), 0);
+            assert_eq!(
+                pair.projected(DirMode::FourWay).collect::<Vec<_>>(),
+                pair.iter().map(Cardinal::direction).collect::<Vec<_>>(),
+                "4way passes raw cardinals on"
+            );
+        }
+        let up_down_left = CardinalSet::of(&[Cardinal::Up, Cardinal::Down, Cardinal::Left]);
+        assert_eq!(up_down_left.single(), Some(Dir::Left));
+        assert_eq!(
+            up_down_left
+                .projected(DirMode::EightWay)
+                .collect::<Vec<_>>(),
+            vec![Dir::Left],
+            "an opposed axis must not erase the independent axis"
+        );
+    }
+
+    #[test]
+    fn eight_way_replaces_a_diagonals_components_with_the_diagonal() {
+        let up_right = CardinalSet::of(&[Cardinal::Up, Cardinal::Right]);
+        assert_eq!(
+            up_right.projected(DirMode::EightWay).collect::<Vec<_>>(),
+            vec![Dir::UpRight]
+        );
+        assert_eq!(
+            up_right.projected(DirMode::FourWay).collect::<Vec<_>>(),
+            vec![Dir::Up, Dir::Right]
+        );
+        // A straight push still presses its cardinal in eight-way, so every
+        // direction stays reachable.
+        let up = CardinalSet::of(&[Cardinal::Up]);
+        assert_eq!(
+            up.projected(DirMode::EightWay).collect::<Vec<_>>(),
+            vec![Dir::Up]
+        );
+        // And a set reads as a vector, which is what lets a d-pad drive the
+        // pointer; an opposed pair cancels there too.
+        assert_eq!(up_right.vector(), Vec2 { x: 1.0, y: 1.0 });
+        assert_eq!(
+            CardinalSet::of(&[Cardinal::Up, Cardinal::Down]).vector(),
+            Vec2::ZERO
+        );
+    }
+
+    #[test]
+    fn a_pad_set_diffs_into_edges_that_release_before_they_press() {
+        // A four-way stick moving from Up to Left must never hold both, which
+        // a game reads as a diagonal.
+        let up = PadCode::direction(Directional::LeftStick, Dir::Up);
+        let left = PadCode::direction(Directional::LeftStick, Dir::Left);
+        let (mut before, mut after) = (PadSet::EMPTY, PadSet::EMPTY);
+        assert!(before.is_empty());
+        before.insert(up);
+        after.set(left, true);
+        assert!(before.contains(up) && !before.contains(left));
+        assert_eq!(
+            before.edges(after).collect::<Vec<_>>(),
+            vec![
+                PadEdge {
+                    code: up,
+                    pressed: false
+                },
+                PadEdge {
+                    code: left,
+                    pressed: true
+                },
+            ]
+        );
+        assert_eq!(before.edges(before).count(), 0, "no change, no edges");
+        assert_eq!((before | after).iter().count(), 2);
+    }
+
+    #[test]
+    fn a_default_config_projects_only_the_dpad() {
+        let mut cfg = GamepadConfig::default();
+        assert!(!cfg.drives_motion());
+        assert_eq!(cfg.projection(Directional::LeftStick), &Projection::OFF);
+        assert!(cfg.projection(Directional::Dpad).digital.is_some());
+        assert_eq!(cfg.slot_of(0x2c0), None);
+
+        cfg.projection_mut(Directional::LeftStick).digital = Some(Digital::default());
+        assert!(!cfg.drives_motion(), "a digital projection is not motion");
+        // A trigger driving the wheel counts too, which is the case a check
+        // that only looked at sticks would miss.
+        cfg.trigger_mut(Side::Right).motions.set(
+            MotionKind::Scroll,
+            TriggerMotion {
+                direction: Cardinal::Down,
+                motion: Motion::SCROLL,
+            },
+        );
+        assert!(cfg.drives_motion());
+
+        cfg.slots[3] = Some(0x2c0);
+        assert_eq!(cfg.slot_of(0x2c0), PadCode::slot(3));
+    }
+}

--- a/parser/src/gamepad/mod.rs
+++ b/parser/src/gamepad/mod.rs
@@ -1,0 +1,115 @@
+//! Game controller support: the control vocabulary and the configuration tree
+//! `defgamepad` produces.
+//!
+//! ```text
+//! backend (gilrs)
+//!   -> PadInput   one whole reading, already normalized
+//!   -> Projector  deadzones, thresholds, SOCD
+//!   -> PadSet     every control held right now, in one u64
+//!   -> PadEdge    the diff against last time  -> the keyberon graph
+//!   -> Demand     a rate  -> kanata's existing mouse primitives, per tick
+//! ```
+//!
+//! Analog values never become keys: an `OsCode` is a binary coordinate in a
+//! layout row, so only threshold crossings and digital controls enter the
+//! layout and the value itself stays in `f32` to the point of use. And
+//! `defgamepad` only declares controls -- what a projected control *does* is
+//! `defsrc`, `deflayer` and every action kanata already has, which is why
+//! `pad-south` composes with `tap-hold`, layers and macros for free.
+//!
+//! Everything from `PadInput` onwards is arithmetic with no platform type
+//! anywhere, so it can be tested from recorded traces rather than from a
+//! controller on someone's desk. The parser half lives here because configs
+//! are parsed in builds with no backend; the runtime half is
+//! `kanata::gamepad`.
+
+pub mod analog;
+pub mod project;
+
+use core::fmt;
+use core::ops::{BitOr, BitOrAssign};
+use std::num::NonZeroU8;
+
+use crate::keys::OsCode;
+
+pub use analog::{AxisValue, Curve, Demand, Motion, MotionKind, StickPosition, Unit, Vec2};
+pub use project::{PadInput, Projector};
+
+// ---------------------------------------------------------------- vocabulary
+
+/// Which of a paired control -- a stick, a trigger -- is meant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Side {
+    Left,
+    Right,
+}
+
+impl Side {
+    pub const ALL: [Side; 2] = [Side::Left, Side::Right];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Side::Left => "left",
+            Side::Right => "right",
+        }
+    }
+
+    /// The control this side's trigger presses once past its band.
+    ///
+    /// Most hardware reports a trigger twice, as a button and as an analog
+    /// axis. Both drive this control and the projector holds it while either
+    /// says so, so a pad reporting one still works and a pad reporting both
+    /// does not double-fire.
+    pub const fn trigger(self) -> PadButton {
+        match self {
+            Side::Left => PadButton::L2,
+            Side::Right => PadButton::R2,
+        }
+    }
+
+    pub const fn stick(self) -> Directional {
+        match self {
+            Side::Left => Directional::LeftStick,
+            Side::Right => Directional::RightStick,
+        }
+    }
+}
+
+/// A control that points a direction: the two sticks and the d-pad.
+///
+/// One type for all three because they project identically -- thresholds,
+/// SOCD, four- or eight-way, and an optional continuous output. A d-pad is a
+/// stick that only knows nine positions, and treating it as one is what gives
+/// it eight-way output and pointer control without a second code path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Directional {
+    LeftStick,
+    RightStick,
+    Dpad,
+}
+
+impl Directional {
+    pub const ALL: [Directional; 3] = [
+        Directional::LeftStick,
+        Directional::RightStick,
+        Directional::Dpad,
+    ];
+
+    /// The side this is a stick of, or `None` for the d-pad. Also the index
+    /// into the per-stick state a d-pad does not have.
+    pub const fn side(self) -> Option<Side> {
+        match self {
+            Directional::LeftStick => Some(Side::Left),
+            Directional::RightStick => Some(Side::Right),
+            Directional::Dpad => None,
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Directional::LeftStick => "left stick",
+            Directional::RightStick => "right stick",
+            Directional::Dpad => "d-pad",
+        }
+    }
+}

--- a/parser/src/gamepad/mod.rs
+++ b/parser/src/gamepad/mod.rs
@@ -582,3 +582,224 @@ impl fmt::Debug for PadSet {
     }
 }
 
+// ------------------------------------------------------------------- config
+//
+// A description of physical controls and their projections, and nothing else:
+// it never names an output key.
+
+/// How many cardinals a diagonal presses.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DirMode {
+    /// A diagonal presses two cardinal controls, the way holding two keys
+    /// does. Right for WASD-style movement.
+    #[default]
+    FourWay,
+    /// A diagonal presses one dedicated diagonal control instead; a straight
+    /// push still presses its cardinal. Right when a diagonal has to be
+    /// distinguishable from its components.
+    EightWay,
+}
+
+/// How to resolve a control asserting both directions of an axis at once.
+///
+/// Only a control with independent contacts can do that -- a d-pad, or a
+/// hitbox-style stick replacement. A stick reports each axis as one signed
+/// number, so the setting is inert there.
+///
+/// The default is to pass both through, because both contacts really are down;
+/// the other modes exist for people who want a game's semantics. Resolution is
+/// per controller: two pads pressing opposite directions is two players, not a
+/// conflict, and the engine unions them afterwards.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Socd {
+    /// Both directions reach the layout. The default.
+    #[default]
+    Off,
+    /// Neither direction survives. The fighting-game convention.
+    Neutral,
+    /// The most recently pressed direction wins, and takes over immediately.
+    Last,
+    /// The direction already held wins; the newcomer is ignored until the
+    /// incumbent releases.
+    First,
+    /// Up and Right always win.
+    Positive,
+    /// Down and Left always win.
+    Negative,
+}
+
+/// Threshold crossings become `pad-lstick-*`, `pad-rstick-*` or `pad-dpad-*`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Digital {
+    pub mode: DirMode,
+    pub socd: Socd,
+    /// Where each axis presses. Compared against the *raw* reading, so
+    /// `(threshold 0.5)` means half of physical deflection and nothing
+    /// -- deadzone or curve -- can silently move it. Ignored by a d-pad, which
+    /// is digital before it arrives.
+    pub threshold: Unit,
+}
+
+/// At most one projection for each continuous output domain.
+///
+/// A typed two-slot map is both less error-prone than an
+/// `Option<(MotionKind, T)>` and more capable: a control may intentionally
+/// drive the pointer and wheel together, while duplicate declarations of the
+/// same kind remain a parser error.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Motions<T>([Option<T>; MotionKind::ALL.len()]);
+
+impl<T> Default for Motions<T> {
+    fn default() -> Motions<T> {
+        Motions([None, None])
+    }
+}
+
+impl<T: Copy> Motions<T> {
+    pub fn get(&self, kind: MotionKind) -> Option<T> {
+        self.0[kind as usize]
+    }
+
+    pub fn set(&mut self, kind: MotionKind, value: T) {
+        self.0[kind as usize] = Some(value);
+    }
+
+    pub fn contains(self, kind: MotionKind) -> bool {
+        self.get(kind).is_some()
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.0.iter().all(Option::is_none)
+    }
+}
+
+impl Default for Digital {
+    fn default() -> Digital {
+        Digital {
+            mode: DirMode::default(),
+            socd: Socd::default(),
+            threshold: Unit::new(0.50),
+        }
+    }
+}
+
+/// What a stick or d-pad does.
+///
+/// The two halves are independent and a control may have both: a stick can
+/// drive the pointer *and* press a key at full deflection, because the
+/// threshold and the displacement read the same value without disturbing each
+/// other.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Projection {
+    pub digital: Option<Digital>,
+    pub motions: Motions<Motion>,
+}
+
+impl Projection {
+    /// What a stick starts with: nothing. Its values are still tracked, so a
+    /// live reload can begin using it without waiting for the user to move it.
+    pub const OFF: Projection = Projection {
+        digital: None,
+        motions: Motions([None, None]),
+    };
+}
+
+/// What a trigger's analog half does.
+///
+/// Crossing the threshold presses `pad-l2` / `pad-r2`. A trigger is one number
+/// rather than a vector, so a continuous projection has to be told which way
+/// to push -- which is also what makes `(trigger right (scroll down ...))` a
+/// pressure-sensitive scroll wheel.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Trigger {
+    pub threshold: Unit,
+    pub motions: Motions<TriggerMotion>,
+}
+
+/// A scalar trigger projected along one cardinal direction.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TriggerMotion {
+    pub direction: Cardinal,
+    pub motion: Motion,
+}
+
+impl Default for Trigger {
+    fn default() -> Trigger {
+        // A trigger actuates much earlier than a stick.
+        Trigger {
+            threshold: Unit::new(0.30),
+            motions: Motions::default(),
+        }
+    }
+}
+
+/// Everything `defgamepad` declares.
+///
+/// `Copy` on purpose: it is handed to a projector per connected controller and
+/// replaced wholesale on live reload, and neither path should have to think
+/// about sharing.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GamepadConfig {
+    /// Restricts this declaration to one `definputdevices` entry. `None` means
+    /// every connected controller feeds the same controls, which is what a
+    /// single-pad user wants and a two-pad user overrides.
+    pub device: Option<NonZeroU8>,
+    /// Indexed by [`Directional`].
+    pub directionals: [Projection; Directional::ALL.len()],
+    /// Indexed by [`Side`].
+    pub triggers: [Trigger; Side::ALL.len()],
+    /// The backend code bound to each `pad-button-N`.
+    ///
+    /// Controllers expose paddles, extra hats and vendor buttons that no
+    /// portable name can describe. Rather than invent an unstable
+    /// auto-numbering, kanata offers slots and lets the user bind a code to
+    /// each; the codes it cannot name are printed to the log as they arrive.
+    pub slots: [Option<u32>; PadCode::SLOTS as usize],
+}
+
+impl Default for GamepadConfig {
+    fn default() -> GamepadConfig {
+        let mut directionals = [Projection::OFF; Directional::ALL.len()];
+        // A d-pad needs no declaration: it is digital hardware, and there is
+        // nothing to decide before it can press a key.
+        directionals[Directional::Dpad as usize].digital = Some(Digital::default());
+        GamepadConfig {
+            device: None,
+            directionals,
+            triggers: [Trigger::default(); Side::ALL.len()],
+            slots: [None; PadCode::SLOTS as usize],
+        }
+    }
+}
+
+impl GamepadConfig {
+    pub fn projection(&self, control: Directional) -> &Projection {
+        &self.directionals[control as usize]
+    }
+
+    pub fn projection_mut(&mut self, control: Directional) -> &mut Projection {
+        &mut self.directionals[control as usize]
+    }
+
+    pub fn trigger(&self, side: Side) -> &Trigger {
+        &self.triggers[side as usize]
+    }
+
+    pub fn trigger_mut(&mut self, side: Side) -> &mut Trigger {
+        &mut self.triggers[side as usize]
+    }
+
+    /// The slot a backend code is bound to, if any.
+    pub fn slot_of(&self, code: u32) -> Option<PadCode> {
+        let index = self.slots.iter().position(|bound| *bound == Some(code))?;
+        PadCode::slot(index as u8)
+    }
+
+    /// Whether anything drives the pointer or the wheel, and so whether the
+    /// tick loop has to sample the controller at all.
+    pub fn drives_motion(&self) -> bool {
+        self.directionals.iter().any(|p| !p.motions.is_empty())
+            || self.triggers.iter().any(|t| !t.motions.is_empty())
+    }
+}
+

--- a/parser/src/gamepad/project.rs
+++ b/parser/src/gamepad/project.rs
@@ -321,3 +321,398 @@ impl Projector {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gamepad::analog::{Curve, Motion, MotionKind, Vec2};
+    use crate::gamepad::{Digital, Dir, DirMode, PadControl};
+
+    /// Drive a trace and report what is held afterwards, plus every edge as
+    /// `(code, pressed)`.
+    fn run(config: GamepadConfig, trace: &[PadInput]) -> (Vec<PadCode>, Vec<(PadCode, bool)>) {
+        let mut projector = Projector::new(config);
+        let mut edges = Vec::new();
+        for input in trace {
+            let before = projector.held();
+            edges.extend(
+                before
+                    .edges(projector.feed(*input))
+                    .map(|e| (e.code, e.pressed)),
+            );
+        }
+        (projector.held().iter().collect(), edges)
+    }
+
+    fn held(config: GamepadConfig, trace: &[PadInput]) -> Vec<PadCode> {
+        run(config, trace).0
+    }
+
+    fn digital(control: Directional, digital: Digital) -> GamepadConfig {
+        let mut config = GamepadConfig::default();
+        config.projection_mut(control).digital = Some(digital);
+        config
+    }
+
+    fn eight_way(control: Directional) -> GamepadConfig {
+        digital(
+            control,
+            Digital {
+                mode: DirMode::EightWay,
+                ..Digital::default()
+            },
+        )
+    }
+
+    fn stick(x: f32, y: f32) -> PadInput {
+        PadInput::Stick {
+            side: Side::Left,
+            value: StickPosition::new(x, y),
+        }
+    }
+
+    fn trigger(side: Side, value: f32) -> PadInput {
+        PadInput::Trigger {
+            side,
+            value: Unit::new(value),
+        }
+    }
+
+    fn fast(speed: f32) -> Motion {
+        Motion {
+            deadzone: Unit::ZERO,
+            speed: speed * 1000.0,
+            curve: Curve::Linear,
+            invert: Vec2::KEEP,
+        }
+    }
+
+    fn lstick(dir: Dir) -> PadCode {
+        PadCode::direction(Directional::LeftStick, dir)
+    }
+
+    fn dpad(dir: Dir) -> PadCode {
+        PadCode::direction(Directional::Dpad, dir)
+    }
+
+    fn button(button: PadButton, pressed: bool) -> PadInput {
+        PadInput::Button { button, pressed }
+    }
+
+    #[test]
+    fn a_press_is_one_edge_and_a_repeat_is_none() {
+        let south = PadCode::button(PadButton::South);
+        let (held, edges) = run(
+            GamepadConfig::default(),
+            &[
+                button(PadButton::South, true),
+                button(PadButton::South, true),
+                button(PadButton::South, false),
+                button(PadButton::South, false),
+            ],
+        );
+        assert!(held.is_empty());
+        assert_eq!(edges, vec![(south, true), (south, false)]);
+    }
+
+    #[test]
+    fn a_trigger_reported_as_both_a_button_and_an_axis_fires_once() {
+        // Most pads report a trigger twice. Firing on each would double every
+        // press; firing on neither when only one arrives would drop it.
+        let l2 = vec![PadCode::button(PadButton::L2)];
+        let cfg = GamepadConfig::default();
+        assert_eq!(held(cfg, &[trigger(Side::Left, 1.0)]), l2, "axis alone");
+        assert_eq!(
+            held(cfg, &[button(PadButton::L2, true)]),
+            l2,
+            "button alone"
+        );
+        assert_eq!(
+            run(
+                cfg,
+                &[
+                    button(PadButton::L2, true),
+                    trigger(Side::Left, 1.0),
+                    trigger(Side::Left, 0.0),
+                    button(PadButton::L2, false),
+                ]
+            )
+            .1
+            .len(),
+            2,
+            "together they must still be one press and one release"
+        );
+
+        // A slow squeeze crosses the band once each way rather than chattering.
+        let squeeze: Vec<_> = (0..=100)
+            .chain((0..100).rev())
+            .map(|i| trigger(Side::Right, i as f32 / 100.0))
+            .collect();
+        let (held, edges) = run(cfg, &squeeze);
+        assert!(held.is_empty());
+        assert_eq!(edges.len(), 2, "squeeze chattered: {edges:?}");
+    }
+
+    #[test]
+    fn four_way_presses_both_cardinals_and_eight_way_presses_the_diagonal() {
+        let four = digital(Directional::LeftStick, Digital::default());
+        assert_eq!(
+            held(four, &[stick(0.8, 0.8)]),
+            vec![lstick(Dir::Up), lstick(Dir::Right)]
+        );
+        let eight = eight_way(Directional::LeftStick);
+        assert_eq!(held(eight, &[stick(0.8, 0.8)]), vec![lstick(Dir::UpRight)]);
+        // A straight push still presses its cardinal, so all eight are usable.
+        assert_eq!(held(eight, &[stick(0.0, 0.8)]), vec![lstick(Dir::Up)]);
+    }
+
+    #[test]
+    fn a_stick_never_asserts_both_directions_of_an_axis() {
+        // Each axis is one signed number, so there is nothing for SOCD to
+        // arbitrate on a stick -- which is why the mode is inert there.
+        let config = digital(Directional::LeftStick, Digital::default());
+        for step in -12i32..=12 {
+            let (x, y) = (step as f32 / 8.0, (12 - step.abs()) as f32 / 8.0);
+            let set = Projector::new(config).feed(stick(x, y));
+            for (a, b) in [(Dir::Up, Dir::Down), (Dir::Left, Dir::Right)] {
+                assert!(
+                    !(set.contains(lstick(a)) && set.contains(lstick(b))),
+                    "({x}, {y}) asserted both of {a:?}/{b:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_stick_moving_between_cardinals_releases_before_it_presses() {
+        // Holding both for even one event is a diagonal as far as a game is
+        // concerned.
+        let config = digital(Directional::LeftStick, Digital::default());
+        assert_eq!(
+            run(config, &[stick(0.0, 1.0), stick(-1.0, 0.0)]).1,
+            vec![
+                (lstick(Dir::Up), true),
+                (lstick(Dir::Up), false),
+                (lstick(Dir::Left), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_stick_resting_exactly_on_its_threshold_does_not_chatter() {
+        let config = digital(Directional::LeftStick, Digital::default());
+        let threshold = Digital::default().threshold.get();
+        let trace: Vec<_> = (0..500).map(|_| stick(0.0, threshold)).collect();
+        assert!(
+            run(config, &trace).1.is_empty(),
+            "a threshold rested at its boundary must stay quiet"
+        );
+    }
+
+    #[test]
+    fn a_dpad_needs_no_declaration_and_unifies_its_two_reportings() {
+        // It is digital hardware, and controllers report it either as four
+        // contacts or as a hat axis depending on the driver.
+        let (held, edges) = run(
+            GamepadConfig::default(),
+            &[
+                PadInput::Contacts(CardinalSet::of(&[Cardinal::Up])),
+                PadInput::Hat(CardinalSet::of(&[Cardinal::Up])),
+                PadInput::Contacts(CardinalSet::EMPTY),
+            ],
+        );
+        assert_eq!(edges.len(), 1, "the second source re-pressed: {edges:?}");
+        assert_eq!(held, vec![dpad(Dir::Up)]);
+
+        // And it takes the sticks' eight-way mode, because it is the same kind
+        // of control.
+        assert_eq!(
+            self::held(
+                eight_way(Directional::Dpad),
+                &[PadInput::Hat(CardinalSet::of(&[
+                    Cardinal::Down,
+                    Cardinal::Left,
+                ]))]
+            ),
+            vec![dpad(Dir::DownLeft)]
+        );
+    }
+
+    /// The d-pad directions held after driving a contact trace.
+    fn socd_after(mode: Socd, trace: &[(Dir, bool)]) -> Vec<Dir> {
+        let config = digital(
+            Directional::Dpad,
+            Digital {
+                socd: mode,
+                ..Digital::default()
+            },
+        );
+        let mut contacts = CardinalSet::EMPTY;
+        let inputs: Vec<_> = trace
+            .iter()
+            .map(|(dir, pressed)| {
+                contacts.set(
+                    Cardinal::try_from(*dir).expect("test trace uses cardinals"),
+                    *pressed,
+                );
+                PadInput::Contacts(contacts)
+            })
+            .collect();
+        held(config, &inputs)
+            .into_iter()
+            .map(|code| match code.control() {
+                PadControl::Direction(Directional::Dpad, dir) => dir,
+                other => panic!("unexpected {other:?}"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn socd_resolves_an_opposed_axis_the_way_the_mode_says() {
+        let opposed = [(Dir::Left, true), (Dir::Right, true)];
+        for (mode, expected) in [
+            (Socd::Off, vec![Dir::Left, Dir::Right]),
+            (Socd::Neutral, vec![]),
+            (Socd::Last, vec![Dir::Right]),
+            (Socd::First, vec![Dir::Left]),
+            (Socd::Positive, vec![Dir::Right]),
+            (Socd::Negative, vec![Dir::Left]),
+        ] {
+            assert_eq!(socd_after(mode, &opposed), expected, "{mode:?}");
+        }
+        // `last` and `first` follow the order the contacts arrived in, which is
+        // why resolution keeps state at all.
+        let reversed = [
+            (Dir::Left, true),
+            (Dir::Right, true),
+            (Dir::Right, false),
+            (Dir::Left, false),
+            (Dir::Right, true),
+            (Dir::Left, true),
+        ];
+        assert_eq!(socd_after(Socd::Last, &reversed), vec![Dir::Left]);
+        assert_eq!(socd_after(Socd::First, &reversed), vec![Dir::Right]);
+    }
+
+    #[test]
+    fn simultaneous_opposites_do_not_invent_an_order() {
+        let both = PadInput::Contacts(CardinalSet::of(&[Cardinal::Left, Cardinal::Right]));
+        for mode in [Socd::Last, Socd::First] {
+            let config = digital(
+                Directional::Dpad,
+                Digital {
+                    socd: mode,
+                    ..Digital::default()
+                },
+            );
+            assert!(
+                held(config, &[both]).is_empty(),
+                "{mode:?} invented a winner"
+            );
+        }
+    }
+
+    #[test]
+    fn socd_only_rewrites_the_axis_that_is_opposed() {
+        // A genuine diagonal is an answer, not a conflict.
+        for mode in [Socd::Neutral, Socd::Last, Socd::First, Socd::Positive] {
+            assert_eq!(
+                socd_after(mode, &[(Dir::Up, true), (Dir::Right, true)]),
+                vec![Dir::Up, Dir::Right],
+                "{mode:?} disturbed a diagonal"
+            );
+        }
+        assert_eq!(
+            socd_after(
+                Socd::Neutral,
+                &[(Dir::Up, true), (Dir::Left, true), (Dir::Right, true)]
+            ),
+            vec![Dir::Up],
+            "the unopposed axis should survive"
+        );
+    }
+
+    #[test]
+    fn a_reset_or_a_reload_releases_everything_and_forgets_the_history() {
+        let config = digital(Directional::LeftStick, Digital::default());
+        let mut projector = Projector::new(config);
+        projector.feed(button(PadButton::South, true));
+        let before = projector.feed(stick(1.0, 0.0));
+        assert!(!before.is_empty());
+
+        projector.reset();
+        assert!(projector.held().is_empty());
+        assert!(
+            before.edges(projector.held()).all(|edge| !edge.pressed),
+            "a reset may only release"
+        );
+        // The stick has to re-cross its threshold rather than resume held.
+        assert!(projector.feed(stick(0.4, 0.0)).is_empty());
+
+        // A reload to a declaration without that stick is the same, plus the
+        // stick stops projecting: this is what a deleted `defgamepad` lands on.
+        projector.feed(stick(1.0, 0.0));
+        projector.reconfigure(GamepadConfig::default());
+        assert!(projector.held().is_empty());
+        assert!(projector.feed(stick(1.0, 1.0)).is_empty());
+    }
+
+    #[test]
+    fn only_a_bound_backend_code_reaches_a_slot() {
+        let mut config = GamepadConfig::default();
+        config.slots[2] = Some(0x2c0);
+        let press = |code| PadInput::Native {
+            code,
+            pressed: true,
+        };
+        assert_eq!(
+            held(config, &[press(0x2c0)]),
+            vec![PadCode::slot(2).expect("a slot")]
+        );
+        assert!(held(config, &[press(0x2c1)]).is_empty(), "unbound code");
+    }
+
+    #[test]
+    fn every_kind_of_control_can_drive_motion() {
+        // The threshold and the displacement read the same value without
+        // disturbing each other, so a stick may do both; a d-pad reads as a
+        // stick at full deflection; and a trigger is a scalar pushed along the
+        // direction it was given.
+        let mut config = digital(Directional::LeftStick, Digital::default());
+        config
+            .projection_mut(Directional::LeftStick)
+            .motions
+            .set(MotionKind::Mouse, fast(10.0));
+        config
+            .projection_mut(Directional::LeftStick)
+            .motions
+            .set(MotionKind::Scroll, fast(2.0));
+        config
+            .projection_mut(Directional::Dpad)
+            .motions
+            .set(MotionKind::Mouse, fast(6.0));
+        config.trigger_mut(Side::Right).motions.set(
+            MotionKind::Scroll,
+            crate::gamepad::TriggerMotion {
+                direction: Cardinal::Down,
+                motion: fast(4.0),
+            },
+        );
+
+        let mut projector = Projector::new(config);
+        assert!(projector.demand().is_idle());
+
+        let held = projector.feed(stick(1.0, 0.0)).iter().collect::<Vec<_>>();
+        assert_eq!(held, vec![lstick(Dir::Right)], "the stick still presses");
+        assert!((projector.demand()[MotionKind::Mouse].x - 10.0).abs() < 1e-3);
+        assert!((projector.demand()[MotionKind::Scroll].x - 2.0).abs() < 1e-3);
+
+        projector.feed(PadInput::Hat(CardinalSet::of(&[Cardinal::Right])));
+        assert!((projector.demand()[MotionKind::Mouse].x - 16.0).abs() < 1e-3);
+
+        projector.feed(trigger(Side::Right, 0.5));
+        assert_eq!(
+            projector.demand()[MotionKind::Scroll],
+            Vec2 { x: 2.0, y: -2.0 }
+        );
+    }
+}

--- a/parser/src/gamepad/project.rs
+++ b/parser/src/gamepad/project.rs
@@ -1,0 +1,323 @@
+//! Projection: controller readings in, the set of held controls out.
+//!
+//! Every reading updates [`PadState`] -- what the controller has told us,
+//! untransformed -- and then the whole [`PadSet`] is recomputed from it. That
+//! is a handful of comparisons over one `u64`, and it removes the class of bug
+//! where one control group's edge logic disagrees with another's: one place
+//! decides what is held, and the caller diffs the result.
+//!
+//! Two unifications live here because both are invisible to the user and
+//! neither belongs in a backend. A **trigger** is reported by most pads twice,
+//! as a digital button and as an analog axis; a **d-pad** is reported either
+//! as four contacts or as a hat axis. Both halves are kept and unioned, so a
+//! pad reporting one still works and a pad reporting both does not
+//! double-fire.
+
+use super::analog::{Demand, StickPosition, Unit};
+use super::{
+    Cardinal, CardinalSet, Directional, GamepadConfig, PadButton, PadCode, PadSet, Side, Socd,
+};
+
+/// One reading from a controller, already normalized by the backend.
+///
+/// Axis values are y-up and in `[-1, 1]`; trigger values are in `[0, 1]`.
+/// Multi-axis controls arrive whole rather than one axis at a time, so a
+/// diagonal push never momentarily looks like a cardinal one.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PadInput {
+    /// A digital control the backend could name.
+    Button {
+        button: PadButton,
+        pressed: bool,
+    },
+    Stick {
+        side: Side,
+        value: StickPosition,
+    },
+    /// A trigger's analog half.
+    Trigger {
+        side: Side,
+        value: Unit,
+    },
+    /// The d-pad, as its four independent contacts.
+    Contacts(CardinalSet),
+    /// The d-pad, as a hat axis.
+    Hat(CardinalSet),
+    /// A control with no portable name, identified by its backend code.
+    Native {
+        code: u32,
+        pressed: bool,
+    },
+}
+
+/// Everything a controller has told us, untransformed.
+///
+/// Raw on purpose: every consumer applies its own transformations, so no site
+/// has to ask which ones have already happened. Kept even for controls with
+/// no projection, so a live reload can begin using one without waiting for
+/// the user to move it.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct PadState {
+    /// One bit per [`PadButton`].
+    buttons: u16,
+    /// The d-pad from its contacts and from its hat, kept apart so one going
+    /// quiet cannot clear the other.
+    dpad: [CardinalSet; 2],
+    sticks: [StickPosition; Side::ALL.len()],
+    triggers: [Unit; Side::ALL.len()],
+    /// Slots already resolved from backend codes, so the projection does not
+    /// have to consult the bindings again.
+    slots: PadSet,
+}
+
+impl PadState {
+    fn apply(&mut self, input: PadInput, config: &GamepadConfig) {
+        match input {
+            PadInput::Button { button, pressed } => {
+                let bit = 1u16 << button as u16;
+                self.buttons = match pressed {
+                    true => self.buttons | bit,
+                    false => self.buttons & !bit,
+                };
+            }
+            PadInput::Stick { side, value } => self.sticks[side as usize] = value,
+            PadInput::Trigger { side, value } => self.triggers[side as usize] = value,
+            PadInput::Contacts(dirs) => self.dpad[0] = dirs,
+            PadInput::Hat(dirs) => self.dpad[1] = dirs,
+            // An unbound code is dropped here. The backend logs it so it can
+            // be discovered and bound; letting it through would mean every
+            // paddle and vendor button claiming a control nobody asked for.
+            PadInput::Native { code, pressed } => {
+                if let Some(slot) = config.slot_of(code) {
+                    self.slots.set(slot, pressed);
+                }
+            }
+        }
+    }
+
+    fn holds(&self, button: PadButton) -> bool {
+        self.buttons & (1 << button as u16) != 0
+    }
+
+    /// The d-pad's contacts, before arbitration.
+    fn dpad(&self) -> CardinalSet {
+        self.dpad[0] | self.dpad[1]
+    }
+}
+
+/// Which direction of each opposed pair arrived most recently.
+///
+/// `Last` and `First` are history-dependent, which is the only reason
+/// resolution needs state at all.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct SocdMemory {
+    previous: CardinalSet,
+    newest: [Option<Cardinal>; 2],
+}
+
+/// The two opposed pairs, positive direction first so that `Positive` and
+/// `Negative` have one place to consult.
+const PAIRS: [(Cardinal, Cardinal); 2] = [
+    (Cardinal::Up, Cardinal::Down),
+    (Cardinal::Right, Cardinal::Left),
+];
+
+impl SocdMemory {
+    /// Resolve one set of cardinals into the set that should reach the layout.
+    ///
+    /// The mode applies independently to the vertical and horizontal pairs, so
+    /// a genuine diagonal is never disturbed: only an opposed axis is
+    /// rewritten.
+    fn resolve(&mut self, mode: Socd, raw: CardinalSet) -> CardinalSet {
+        let mut resolved = raw;
+        for (axis, (positive, negative)) in PAIRS.into_iter().enumerate() {
+            // Track which direction arrived most recently whether or not the
+            // axis is opposed right now: the press that creates the conflict
+            // may be the one that arrives second.
+            let positive_new = raw.contains(positive) && !self.previous.contains(positive);
+            let negative_new = raw.contains(negative) && !self.previous.contains(negative);
+            self.newest[axis] = match (positive_new, negative_new) {
+                (true, false) => Some(positive),
+                (false, true) => Some(negative),
+                // A snapshot in which both contacts first appear has no
+                // temporal ordering. Picking one based on enum iteration
+                // would pretend to know which was last (and make `first`
+                // pretend the opposite), so history-dependent modes resolve
+                // it neutrally until a later transition establishes order.
+                (true, true) => None,
+                (false, false) => self.newest[axis],
+            };
+            if !(raw.contains(positive) && raw.contains(negative)) {
+                continue;
+            }
+            // With exactly two directions on the axis, the incumbent is
+            // whichever one is not the newcomer.
+            let winner = match mode {
+                Socd::Off => continue,
+                Socd::Neutral => None,
+                Socd::Positive => Some(positive),
+                Socd::Negative => Some(negative),
+                Socd::Last => self.newest[axis],
+                Socd::First => self.newest[axis].map(Cardinal::opposite),
+            };
+            resolved.set(positive, false);
+            resolved.set(negative, false);
+            if let Some(winner) = winner {
+                resolved.set(winner, true);
+            }
+        }
+        self.previous = raw;
+        resolved
+    }
+}
+
+/// Turns one controller's readings into a set of held controls and a motion
+/// demand.
+///
+/// One projector per controller, so a stick on one pad cannot cancel a stick
+/// on another. The runtime merges them.
+#[derive(Clone, Debug)]
+pub struct Projector {
+    config: GamepadConfig,
+    state: PadState,
+    /// Only the d-pad has independent contacts, so it is the only control that
+    /// can assert both directions of an axis and the only one with anything to
+    /// arbitrate.
+    socd: SocdMemory,
+    /// The d-pad's contacts *after* arbitration. Both halves of its projection
+    /// read this one value: the digital half presses these directions and the
+    /// motion half points along them, so `(socd positive)` cannot make them
+    /// disagree about which way the pad is pointing.
+    dpad: CardinalSet,
+    held: PadSet,
+}
+
+impl Projector {
+    pub fn new(config: GamepadConfig) -> Projector {
+        Projector {
+            config,
+            state: PadState::default(),
+            socd: SocdMemory::default(),
+            dpad: CardinalSet::EMPTY,
+            held: PadSet::EMPTY,
+        }
+    }
+
+    /// The controls this controller is holding.
+    pub fn held(&self) -> PadSet {
+        self.held
+    }
+
+    /// Feed one reading and get the new held set.
+    pub fn feed(&mut self, input: PadInput) -> PadSet {
+        self.state.apply(input, &self.config);
+        self.recompute()
+    }
+
+    /// Let go of everything and forget all history.
+    ///
+    /// Used on disconnect, on live reload and on shutdown, where continuing to
+    /// trust the old state would strand a key down. Recomputing from an empty
+    /// [`PadState`] is what makes this correct by construction rather than by
+    /// remembering to release each control group.
+    pub fn reset(&mut self) {
+        *self = Projector::new(self.config);
+    }
+
+    /// Swap in a reloaded declaration, keeping nothing.
+    pub fn reconfigure(&mut self, config: GamepadConfig) {
+        *self = Projector::new(config);
+    }
+
+    /// What the continuous projections want this tick.
+    ///
+    /// Sampled rather than pushed: a deflection is a rate, so how fast the
+    /// pointer moves should depend on the clock and not on how often a
+    /// particular controller happens to report.
+    pub fn demand(&self) -> Demand {
+        let mut demand = Demand::default();
+        for control in Directional::ALL {
+            for kind in super::MotionKind::ALL {
+                let Some(motion) = self.config.projection(control).motions.get(kind) else {
+                    continue;
+                };
+                // A d-pad points along its arbitrated contacts, so it reads as
+                // a stick at full deflection and the two halves of its
+                // projection agree about which way it is pointing.
+                let pointing = match control.side() {
+                    Some(side) => self.state.sticks[side as usize].vector(),
+                    None => self.dpad.vector(),
+                };
+                demand[kind] += motion.displace(pointing);
+            }
+        }
+        for side in Side::ALL {
+            for kind in super::MotionKind::ALL {
+                let Some(projected) = self.config.trigger(side).motions.get(kind) else {
+                    continue;
+                };
+                let rate = projected
+                    .motion
+                    .rate(self.state.triggers[side as usize].get());
+                demand[kind] += projected.direction.vector() * rate;
+            }
+        }
+        demand
+    }
+
+    /// Rebuild the held set from the raw state.
+    fn recompute(&mut self) -> PadSet {
+        let mut set = self.state.slots;
+        for button in PadButton::ALL {
+            set.set(PadCode::button(button), self.state.holds(button));
+        }
+        for side in Side::ALL {
+            if self.state.triggers[side as usize] > self.config.trigger(side).threshold {
+                set.insert(PadCode::button(side.trigger()));
+            }
+        }
+        // Arbitrated before the loop, and unconditionally, because `demand`
+        // reads the result too: a d-pad with a motion projection and no
+        // digital one still has to point somewhere.
+        let dpad = self.config.projection(Directional::Dpad).digital;
+        let socd = dpad.map_or(Socd::default(), |digital| digital.socd);
+        self.dpad = self.socd.resolve(socd, self.state.dpad());
+
+        for control in Directional::ALL {
+            let Some(digital) = self.config.projection(control).digital else {
+                continue;
+            };
+            let dirs = match control.side() {
+                Some(side) => self.threshold(side, digital.threshold),
+                None => self.dpad,
+            };
+            for dir in dirs.projected(digital.mode) {
+                set.insert(PadCode::direction(control, dir));
+            }
+        }
+        self.held = set;
+        set
+    }
+
+    /// The cardinals a stick is asserting.
+    ///
+    /// Compared component by component rather than by radius -- a stick pushed
+    /// fully right is at full radius but is not pressing Up -- and against the
+    /// *raw* reading, so `(threshold 0.5)` means half of physical deflection and a
+    /// deadzone cannot silently move it.
+    fn threshold(&self, side: Side, threshold: Unit) -> CardinalSet {
+        let value = self.state.sticks[side as usize];
+        let mut out = CardinalSet::EMPTY;
+        let components = [
+            value.y().get(),
+            -value.y().get(),
+            -value.x().get(),
+            value.x().get(),
+        ];
+        for (dir, magnitude) in Cardinal::ALL.into_iter().zip(components) {
+            out.set(dir, Unit::new(magnitude) > threshold);
+        }
+        out
+    }
+}
+

--- a/parser/src/gamepad/project.rs
+++ b/parser/src/gamepad/project.rs
@@ -189,7 +189,18 @@ pub struct Projector {
     /// motion half points along them, so `(socd positive)` cannot make them
     /// disagree about which way the pad is pointing.
     dpad: CardinalSet,
+    /// Analog controls that have crossed their threshold and stayed there.
+    stable_analog: PadSet,
+    /// A pending change for each analog control. A change only becomes stable
+    /// after its configured grace period has elapsed uninterrupted.
+    pending: [Option<Pending>; PadCode::COUNT],
     held: PadSet,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Pending {
+    pressed: bool,
+    remaining: u16,
 }
 
 impl Projector {
@@ -199,6 +210,8 @@ impl Projector {
             state: PadState::default(),
             socd: SocdMemory::default(),
             dpad: CardinalSet::EMPTY,
+            stable_analog: PadSet::EMPTY,
+            pending: [None; PadCode::COUNT],
             held: PadSet::EMPTY,
         }
     }
@@ -212,6 +225,31 @@ impl Projector {
     pub fn feed(&mut self, input: PadInput) -> PadSet {
         self.state.apply(input, &self.config);
         self.recompute()
+    }
+
+    /// Advance pending threshold crossings by `milliseconds`.
+    ///
+    /// The processing loop calls this once per millisecond, like Kanata's
+    /// other waiting states. A late tick is still correct because elapsed time
+    /// is subtracted rather than counted as one controller event.
+    pub fn tick(&mut self, milliseconds: u16) -> PadSet {
+        for (index, pending) in self.pending.iter_mut().enumerate() {
+            let Some(change) = pending.as_mut() else {
+                continue;
+            };
+            change.remaining = change.remaining.saturating_sub(milliseconds);
+            if change.remaining == 0 {
+                self.stable_analog
+                    .set(PadCode::from_index(index), change.pressed);
+                *pending = None;
+            }
+        }
+        self.compose_held()
+    }
+
+    /// Whether a threshold crossing still needs the tick loop to run.
+    pub fn has_pending(&self) -> bool {
+        self.pending.iter().any(Option::is_some)
     }
 
     /// Let go of everything and forget all history.
@@ -267,14 +305,9 @@ impl Projector {
 
     /// Rebuild the held set from the raw state.
     fn recompute(&mut self) -> PadSet {
-        let mut set = self.state.slots;
+        let mut direct = self.state.slots;
         for button in PadButton::ALL {
-            set.set(PadCode::button(button), self.state.holds(button));
-        }
-        for side in Side::ALL {
-            if self.state.triggers[side as usize] > self.config.trigger(side).threshold {
-                set.insert(PadCode::button(side.trigger()));
-            }
+            direct.set(PadCode::button(button), self.state.holds(button));
         }
         // Arbitrated before the loop, and unconditionally, because `demand`
         // reads the result too: a d-pad with a motion projection and no
@@ -283,6 +316,13 @@ impl Projector {
         let socd = dpad.map_or(Socd::default(), |digital| digital.socd);
         self.dpad = self.socd.resolve(socd, self.state.dpad());
 
+        let mut desired_analog = PadSet::EMPTY;
+        for side in Side::ALL {
+            let trigger = self.config.trigger(side);
+            let code = PadCode::button(side.trigger());
+            desired_analog.set(code, self.state.triggers[side as usize] > trigger.threshold);
+            self.reconcile(code, desired_analog.contains(code), trigger.debounce);
+        }
         for control in Directional::ALL {
             let Some(digital) = self.config.projection(control).digital else {
                 continue;
@@ -292,11 +332,52 @@ impl Projector {
                 None => self.dpad,
             };
             for dir in dirs.projected(digital.mode) {
-                set.insert(PadCode::direction(control, dir));
+                let code = PadCode::direction(control, dir);
+                match control.side() {
+                    Some(_) => desired_analog.insert(code),
+                    None => direct.insert(code),
+                }
+            }
+            if control.side().is_some() {
+                for dir in super::Dir::ALL {
+                    let code = PadCode::direction(control, dir);
+                    self.reconcile(code, desired_analog.contains(code), digital.debounce);
+                }
             }
         }
-        self.held = set;
-        set
+        self.compose_held_from(direct)
+    }
+
+    fn reconcile(&mut self, code: PadCode, pressed: bool, debounce: u16) {
+        if self.stable_analog.contains(code) == pressed {
+            self.pending[code.0 as usize] = None;
+        } else if debounce == 0 {
+            self.stable_analog.set(code, pressed);
+            self.pending[code.0 as usize] = None;
+        } else if self.pending[code.0 as usize].is_none_or(|pending| pending.pressed != pressed) {
+            self.pending[code.0 as usize] = Some(Pending {
+                pressed,
+                remaining: debounce,
+            });
+        }
+    }
+
+    fn compose_held_from(&mut self, direct: PadSet) -> PadSet {
+        self.held = direct | self.stable_analog;
+        self.held
+    }
+
+    fn compose_held(&mut self) -> PadSet {
+        let mut direct = self.state.slots;
+        for button in PadButton::ALL {
+            direct.set(PadCode::button(button), self.state.holds(button));
+        }
+        if let Some(digital) = self.config.projection(Directional::Dpad).digital {
+            for dir in self.dpad.projected(digital.mode) {
+                direct.insert(PadCode::direction(Directional::Dpad, dir));
+            }
+        }
+        self.compose_held_from(direct)
     }
 
     /// The cardinals a stick is asserting.
@@ -506,6 +587,35 @@ mod tests {
             run(config, &trace).1.is_empty(),
             "a threshold rested at its boundary must stay quiet"
         );
+    }
+
+    #[test]
+    fn debounce_requires_an_uninterrupted_threshold_crossing() {
+        let config = digital(
+            Directional::LeftStick,
+            Digital {
+                debounce: 3,
+                ..Digital::default()
+            },
+        );
+        let mut projector = Projector::new(config);
+        let up = lstick(Dir::Up);
+
+        assert!(projector.feed(stick(0.0, 1.0)).is_empty());
+        assert!(projector.has_pending());
+        assert!(projector.tick(2).is_empty(), "two milliseconds is too soon");
+        assert!(projector.tick(1).contains(up));
+
+        // A brief dip below the threshold starts a release, but returning to
+        // the stable side cancels it before it can create an edge.
+        projector.feed(stick(0.0, 0.0));
+        assert!(projector.has_pending());
+        assert!(projector.feed(stick(0.0, 1.0)).contains(up));
+        assert!(!projector.has_pending());
+
+        projector.feed(stick(0.0, 0.0));
+        assert!(projector.tick(2).contains(up));
+        assert!(projector.tick(1).is_empty());
     }
 
     #[test]

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -404,6 +404,81 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         // position, in conjunction with `mouse-movement-key mvmt`
         "mvmt" | "mousemovement" | "🖰mv" => OsCode::KEY_766,
 
+        // Game controller controls. Input-only: they name a physical control
+        // on a pad, never an output scancode. See docs/config.adoc.
+        //
+        // Every name is positional rather than the glyph a vendor printed, so
+        // one config works on a DualSense, an Xbox pad and a Switch Pro pad.
+        // Face buttons, plus the pair some six-button pads add.
+        "pad-south" | "pad-a" | "pad-cross" => OsCode::PAD_SOUTH,
+        "pad-east" | "pad-b" | "pad-circle" => OsCode::PAD_EAST,
+        "pad-west" | "pad-x" | "pad-square" => OsCode::PAD_WEST,
+        "pad-north" | "pad-y" | "pad-triangle" => OsCode::PAD_NORTH,
+        "pad-c" => OsCode::PAD_C,
+        "pad-z" => OsCode::PAD_Z,
+
+        // Shoulder buttons, and the triggers' digital edge.
+        "pad-l1" | "pad-lb" => OsCode::PAD_L1,
+        "pad-r1" | "pad-rb" => OsCode::PAD_R1,
+        "pad-l2" | "pad-lt" => OsCode::PAD_L2,
+        "pad-r2" | "pad-rt" => OsCode::PAD_R2,
+
+        // Menu buttons and stick clicks.
+        "pad-select" | "pad-share" | "pad-view" | "pad-back" => OsCode::PAD_SELECT,
+        "pad-start" | "pad-options" | "pad-menu" => OsCode::PAD_START,
+        "pad-mode" | "pad-guide" | "pad-home" => OsCode::PAD_MODE,
+        "pad-l3" | "pad-lstick" => OsCode::PAD_L3,
+        "pad-r3" | "pad-rstick" => OsCode::PAD_R3,
+
+        // Left stick directions, from (stick left (digital ...)).
+        "pad-lstick-up" | "pad-ls-up" => OsCode::PAD_LSTICK_UP,
+        "pad-lstick-down" | "pad-ls-down" => OsCode::PAD_LSTICK_DOWN,
+        "pad-lstick-left" | "pad-ls-left" => OsCode::PAD_LSTICK_LEFT,
+        "pad-lstick-right" | "pad-ls-right" => OsCode::PAD_LSTICK_RIGHT,
+        "pad-lstick-upleft" | "pad-ls-upleft" => OsCode::PAD_LSTICK_UPLEFT,
+        "pad-lstick-upright" | "pad-ls-upright" => OsCode::PAD_LSTICK_UPRIGHT,
+        "pad-lstick-downleft" | "pad-ls-downleft" => OsCode::PAD_LSTICK_DOWNLEFT,
+        "pad-lstick-downright" | "pad-ls-downright" => OsCode::PAD_LSTICK_DOWNRIGHT,
+
+        // Right stick directions, from (stick right (digital ...)).
+        "pad-rstick-up" | "pad-rs-up" => OsCode::PAD_RSTICK_UP,
+        "pad-rstick-down" | "pad-rs-down" => OsCode::PAD_RSTICK_DOWN,
+        "pad-rstick-left" | "pad-rs-left" => OsCode::PAD_RSTICK_LEFT,
+        "pad-rstick-right" | "pad-rs-right" => OsCode::PAD_RSTICK_RIGHT,
+        "pad-rstick-upleft" | "pad-rs-upleft" => OsCode::PAD_RSTICK_UPLEFT,
+        "pad-rstick-upright" | "pad-rs-upright" => OsCode::PAD_RSTICK_UPRIGHT,
+        "pad-rstick-downleft" | "pad-rs-downleft" => OsCode::PAD_RSTICK_DOWNLEFT,
+        "pad-rstick-downright" | "pad-rs-downright" => OsCode::PAD_RSTICK_DOWNRIGHT,
+
+        // D-pad, unified across hat-axis and button reporting. The
+        // diagonals need (dpad (digital (mode 8way))).
+        "pad-dpad-up" | "pad-up" => OsCode::PAD_DPAD_UP,
+        "pad-dpad-down" | "pad-down" => OsCode::PAD_DPAD_DOWN,
+        "pad-dpad-left" | "pad-left" => OsCode::PAD_DPAD_LEFT,
+        "pad-dpad-right" | "pad-right" => OsCode::PAD_DPAD_RIGHT,
+        "pad-dpad-upleft" | "pad-upleft" => OsCode::PAD_DPAD_UPLEFT,
+        "pad-dpad-upright" | "pad-upright" => OsCode::PAD_DPAD_UPRIGHT,
+        "pad-dpad-downleft" | "pad-downleft" => OsCode::PAD_DPAD_DOWNLEFT,
+        "pad-dpad-downright" | "pad-downright" => OsCode::PAD_DPAD_DOWNRIGHT,
+
+        // Slots for controls no portable name covers; see (button-slot ...).
+        "pad-button-0" | "pb0" => OsCode::PAD_BUTTON_0,
+        "pad-button-1" | "pb1" => OsCode::PAD_BUTTON_1,
+        "pad-button-2" | "pb2" => OsCode::PAD_BUTTON_2,
+        "pad-button-3" | "pb3" => OsCode::PAD_BUTTON_3,
+        "pad-button-4" | "pb4" => OsCode::PAD_BUTTON_4,
+        "pad-button-5" | "pb5" => OsCode::PAD_BUTTON_5,
+        "pad-button-6" | "pb6" => OsCode::PAD_BUTTON_6,
+        "pad-button-7" | "pb7" => OsCode::PAD_BUTTON_7,
+        "pad-button-8" | "pb8" => OsCode::PAD_BUTTON_8,
+        "pad-button-9" | "pb9" => OsCode::PAD_BUTTON_9,
+        "pad-button-10" | "pb10" => OsCode::PAD_BUTTON_10,
+        "pad-button-11" | "pb11" => OsCode::PAD_BUTTON_11,
+        "pad-button-12" | "pb12" => OsCode::PAD_BUTTON_12,
+        "pad-button-13" | "pb13" => OsCode::PAD_BUTTON_13,
+        "pad-button-14" | "pb14" => OsCode::PAD_BUTTON_14,
+        "pad-button-15" | "pb15" => OsCode::PAD_BUTTON_15,
+
         _ => return None,
     })
 }
@@ -1190,6 +1265,83 @@ pub enum OsCode {
     KEY_766 = 766, // aliased to mvmt as a dummy input for use with mouse-movement-key
 
     KEY_MAX = 767,
+
+    // ---------------------------------------------------------------------
+    // Game controller controls.
+    //
+    // Synthetic: no operating system reports these as a scancode, so
+    // `from_u16` never decodes one and `process-unmapped-keys` can never
+    // sweep one into `defsrc`. They are built only through
+    // `crate::gamepad::PadCode`, which is what makes a name mean the same
+    // physical control on every platform.
+    //
+    // The range is contiguous and grouped: buttons, then eight directions
+    // for each directional control, then the assignable slots. `PadCode` is
+    // an index into it, so this order is load-bearing; `PadCode::control`
+    // inverts it and `pad_codes_tile_the_reserved_range` pins the two
+    // together.
+    //
+    // Analog values never live here: only threshold crossings and digital
+    // controls become codes, and the continuous value stays in the
+    // projector.
+    // ---------------------------------------------------------------------
+    PAD_SOUTH = 768,
+    PAD_EAST = 769,
+    PAD_WEST = 770,
+    PAD_NORTH = 771,
+    PAD_C = 772,
+    PAD_Z = 773,
+    PAD_L1 = 774,
+    PAD_R1 = 775,
+    PAD_L2 = 776,
+    PAD_R2 = 777,
+    PAD_SELECT = 778,
+    PAD_START = 779,
+    PAD_MODE = 780,
+    PAD_L3 = 781,
+    PAD_R3 = 782,
+    PAD_LSTICK_UP = 783,
+    PAD_LSTICK_DOWN = 784,
+    PAD_LSTICK_LEFT = 785,
+    PAD_LSTICK_RIGHT = 786,
+    PAD_LSTICK_UPLEFT = 787,
+    PAD_LSTICK_UPRIGHT = 788,
+    PAD_LSTICK_DOWNLEFT = 789,
+    PAD_LSTICK_DOWNRIGHT = 790,
+    PAD_RSTICK_UP = 791,
+    PAD_RSTICK_DOWN = 792,
+    PAD_RSTICK_LEFT = 793,
+    PAD_RSTICK_RIGHT = 794,
+    PAD_RSTICK_UPLEFT = 795,
+    PAD_RSTICK_UPRIGHT = 796,
+    PAD_RSTICK_DOWNLEFT = 797,
+    PAD_RSTICK_DOWNRIGHT = 798,
+    PAD_DPAD_UP = 799,
+    PAD_DPAD_DOWN = 800,
+    PAD_DPAD_LEFT = 801,
+    PAD_DPAD_RIGHT = 802,
+    PAD_DPAD_UPLEFT = 803,
+    PAD_DPAD_UPRIGHT = 804,
+    PAD_DPAD_DOWNLEFT = 805,
+    PAD_DPAD_DOWNRIGHT = 806,
+    PAD_BUTTON_0 = 807,
+    PAD_BUTTON_1 = 808,
+    PAD_BUTTON_2 = 809,
+    PAD_BUTTON_3 = 810,
+    PAD_BUTTON_4 = 811,
+    PAD_BUTTON_5 = 812,
+    PAD_BUTTON_6 = 813,
+    PAD_BUTTON_7 = 814,
+    PAD_BUTTON_8 = 815,
+    PAD_BUTTON_9 = 816,
+    PAD_BUTTON_10 = 817,
+    PAD_BUTTON_11 = 818,
+    PAD_BUTTON_12 = 819,
+    PAD_BUTTON_13 = 820,
+    PAD_BUTTON_14 = 821,
+    PAD_BUTTON_15 = 822,
+    /// One past the highest `OsCode`. This is the width of a layout row.
+    OSCODE_MAX = 823,
 }
 
 impl OsCode {
@@ -1208,6 +1360,63 @@ impl OsCode {
                 | MouseWheelRight
         )
     }
+
+    /// How many game controller controls the reserved range holds.
+    pub const GAMEPAD_COUNT: u8 = (OsCode::OSCODE_MAX as u16 - OsCode::PAD_SOUTH as u16) as u8;
+
+    /// True for the game controller controls, which occupy one contiguous
+    /// range above every real OS scancode.
+    ///
+    /// They are input-only. No OS can be asked to emit one, so the output path
+    /// ignores them the same way it ignores the reserved macro keys; see
+    /// `output_logic::write_key`.
+    pub const fn is_gamepad_code(self) -> bool {
+        self.gamepad_index().is_some()
+    }
+
+    /// This code's position within the reserved range, or `None` if it is an
+    /// ordinary key.
+    ///
+    /// The pair with [`OsCode::from_gamepad_index`] is what lets
+    /// `gamepad::PadCode` be a small index instead of a lookup table.
+    pub const fn gamepad_index(self) -> Option<u8> {
+        match (self as u16).checked_sub(OsCode::PAD_SOUTH as u16) {
+            Some(index) if index < OsCode::GAMEPAD_COUNT as u16 => Some(index as u8),
+            _ => None,
+        }
+    }
+
+    /// The `index`th control in the reserved range.
+    pub const fn from_gamepad_index(index: u8) -> Option<OsCode> {
+        if index >= OsCode::GAMEPAD_COUNT {
+            return None;
+        }
+        // SAFETY: the reserved range is a contiguous run of discriminants on a
+        // `#[repr(u16)]` enum, so every value in it names a variant. The
+        // `gamepad_indices_round_trip` test walks the whole range.
+        Some(unsafe {
+            core::mem::transmute::<u16, OsCode>(OsCode::PAD_SOUTH as u16 + index as u16)
+        })
+    }
+}
+
+#[test]
+fn gamepad_indices_round_trip() {
+    for index in 0..OsCode::GAMEPAD_COUNT {
+        let osc = OsCode::from_gamepad_index(index).expect("below the count");
+        assert_eq!(osc.gamepad_index(), Some(index));
+        assert_eq!(
+            u16::from(osc),
+            u16::from(OsCode::PAD_SOUTH) + u16::from(index)
+        );
+        // `Debug` on a transmuted value is the cheapest proof that the
+        // discriminant really names a variant.
+        assert!(format!("{osc:?}").starts_with("PAD_"), "{osc:?}");
+    }
+    assert_eq!(OsCode::from_gamepad_index(OsCode::GAMEPAD_COUNT), None);
+    assert_eq!(OsCode::KEY_A.gamepad_index(), None);
+    assert_eq!(OsCode::KEY_MAX.gamepad_index(), None);
+    assert_eq!(OsCode::OSCODE_MAX.gamepad_index(), None);
 }
 
 use core::fmt;
@@ -1224,7 +1433,7 @@ impl fmt::Display for OsCode {
 
 #[test]
 fn parser_key_max_lt_keyberon_key_max() {
-    assert!(u16::from(OsCode::KEY_MAX) < KEY_MAX);
+    assert!(u16::from(OsCode::OSCODE_MAX) < KEY_MAX);
 }
 
 #[cfg(test)]

--- a/parser/src/layers.rs
+++ b/parser/src/layers.rs
@@ -8,8 +8,9 @@ use crate::keys::OsCode;
 
 use std::sync::Arc;
 
-// OsCode::KEY_MAX is the biggest OsCode
-pub const KEYS_IN_ROW: usize = OsCode::KEY_MAX as usize;
+// OsCode::OSCODE_MAX is one past the biggest OsCode, including the synthetic
+// gamepad controls that live above the OS scancode range.
+pub const KEYS_IN_ROW: usize = OsCode::OSCODE_MAX as usize;
 pub const LAYER_ROWS: usize = 2;
 pub const DEFAULT_ACTION: KanataAction = KanataAction::KeyCode(KeyCode::ErrorUndefined);
 

--- a/parser/src/sequences.rs
+++ b/parser/src/sequences.rs
@@ -25,5 +25,12 @@ pub fn mod_mask_for_keycode(kc: KeyCode) -> u16 {
 #[test]
 fn keys_fit_within_mask() {
     use crate::keys::OsCode;
-    assert!(MASK_KEYCODES >= u16::from(OsCode::KEY_MAX));
+    // The mask has to cover the whole `OsCode` range, not just the codes a
+    // sequence can name. A sequence cannot hold a controller control -- the
+    // key list is parsed as actions, and those are rejected in an output
+    // position -- but the mask is applied to raw codes, so it still has to
+    // reach past the reserved range.
+    assert!(MASK_KEYCODES >= u16::from(OsCode::OSCODE_MAX));
+    // And the overlap marker has to stay clear of all of them.
+    const { assert!(KEY_OVERLAP_MARKER > MASK_KEYCODES) };
 }

--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -416,3 +416,278 @@ fn split<T>(amount: i32, positive: T, negative: T) -> Option<(T, u16)> {
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanata_parser::gamepad::{
+        Curve, Directional, Motion, PadButton, PadCode, Side, StickPosition, Unit,
+    };
+
+    fn pad(n: u32) -> PadDeviceId {
+        PadDeviceId::new(n)
+    }
+
+    fn info(name: &str) -> PadDeviceInfo {
+        PadDeviceInfo {
+            name: name.to_string(),
+            vendor_id: Some(0x054c),
+            product_id: Some(0x0ce6),
+        }
+    }
+
+    fn engine() -> PadEngine {
+        PadEngine::new(GamepadConfig::default(), None)
+    }
+
+    fn feed(e: &mut PadEngine, id: PadDeviceId, input: PadInput) -> Vec<PadEdge> {
+        let mut edges = Vec::new();
+        e.feed(id, input, &mut edges);
+        edges
+    }
+
+    fn stick(x: f32) -> PadInput {
+        PadInput::Stick {
+            side: Side::Left,
+            value: StickPosition::new(x, 0.0),
+        }
+    }
+
+    const SOUTH: PadCode = PadCode::button(PadButton::South);
+    const PRESS: PadInput = PadInput::Button {
+        button: PadButton::South,
+        pressed: true,
+    };
+    const RELEASE: PadInput = PadInput::Button {
+        button: PadButton::South,
+        pressed: false,
+    };
+
+    /// A config whose left stick is digital, for the tests that need two pads
+    /// to push one stick different ways.
+    fn digital() -> GamepadConfig {
+        let mut config = GamepadConfig::default();
+        config.projection_mut(Directional::LeftStick).digital = Some(Default::default());
+        config
+    }
+
+    #[test]
+    fn several_controllers_merge_into_one_logical_pad() {
+        let mut e = engine();
+        // A backend can report for a device the engine rejected or never saw.
+        assert!(feed(&mut e, pad(1), PRESS).is_empty());
+
+        e.connect(pad(1), info("one"));
+        e.connect(pad(2), info("two"));
+        assert_eq!(
+            feed(&mut e, pad(1), PRESS).len(),
+            1,
+            "first press is visible"
+        );
+        assert!(
+            feed(&mut e, pad(2), PRESS).is_empty(),
+            "the second controller must not re-press a held control"
+        );
+        assert!(
+            feed(&mut e, pad(1), RELEASE).is_empty(),
+            "still held by the other controller"
+        );
+        assert_eq!(
+            feed(&mut e, pad(2), RELEASE),
+            vec![PadEdge {
+                code: SOUTH,
+                pressed: false
+            }],
+            "the last release must be visible"
+        );
+    }
+
+    #[test]
+    fn one_controllers_stick_does_not_cancel_anothers() {
+        let mut e = PadEngine::new(digital(), None);
+        e.connect(pad(1), info("one"));
+        e.connect(pad(2), info("two"));
+        assert_eq!(feed(&mut e, pad(1), stick(1.0)).len(), 1);
+        // The second pad pushing the opposite way presses its own direction
+        // rather than resolving against the first pad's.
+        let edges = feed(&mut e, pad(2), stick(-1.0));
+        assert_eq!(edges.len(), 1);
+        assert!(edges[0].pressed);
+    }
+
+    #[test]
+    fn disconnecting_releases_only_what_that_controller_held() {
+        // A pad unplugged mid-press leaves a key down with nothing left that
+        // could ever release it.
+        let mut e = engine();
+        e.connect(pad(1), info("one"));
+        e.connect(pad(2), info("two"));
+        feed(&mut e, pad(1), PRESS);
+
+        let mut edges = Vec::new();
+        e.disconnect(pad(2), &mut edges);
+        assert!(edges.is_empty(), "pad 2 held nothing: {edges:?}");
+        e.disconnect(pad(1), &mut edges);
+        assert_eq!(
+            edges,
+            vec![PadEdge {
+                code: SOUTH,
+                pressed: false
+            }]
+        );
+        assert_eq!(e.connected_count(), 0);
+        e.disconnect(pad(9), &mut edges); // an unknown device is harmless
+
+        // And a reconnecting controller starts from a clean slate: if its
+        // projector had survived, this press would be swallowed as a repeat.
+        e.connect(pad(1), info("one"));
+        assert_eq!(feed(&mut e, pad(1), PRESS).len(), 1);
+    }
+
+    #[test]
+    fn every_matcher_field_the_user_gave_has_to_match() {
+        let named = |name: &str| InputDeviceMatcher {
+            name: Some(name.into()),
+            ..Default::default()
+        };
+        for (matcher, expected) in [
+            (named("DualSense"), Connection::Accepted),
+            (named("Xbox"), Connection::NotSelected),
+            (
+                InputDeviceMatcher {
+                    vendor_id: Some(0x054c),
+                    product_id: Some(0x9999),
+                    ..named("DualSense")
+                },
+                Connection::NotSelected,
+            ),
+            // Nothing specified is not a constraint at all.
+            (InputDeviceMatcher::default(), Connection::Accepted),
+        ] {
+            let mut e = PadEngine::new(GamepadConfig::default(), Some(matcher.clone()));
+            assert_eq!(
+                e.connect(pad(1), info("DualSense")),
+                expected,
+                "{matcher:?}"
+            );
+            // A rejected controller never reaches the layout either.
+            assert_eq!(
+                feed(&mut e, pad(1), PRESS).is_empty(),
+                expected == Connection::NotSelected
+            );
+        }
+    }
+
+    #[test]
+    fn reconfigure_releases_across_every_controller() {
+        let mut e = PadEngine::new(digital(), None);
+        e.connect(pad(1), info("one"));
+        e.connect(pad(2), info("two"));
+        feed(&mut e, pad(1), PRESS);
+        feed(&mut e, pad(2), stick(1.0));
+
+        let mut edges = Vec::new();
+        e.reconfigure(GamepadConfig::default(), &mut edges);
+        assert_eq!(edges.len(), 2, "both controllers should release: {edges:?}");
+        assert!(edges.iter().all(|edge| !edge.pressed));
+        // The new declaration is in force, and nothing is stuck held.
+        assert!(feed(&mut e, pad(2), stick(1.0)).is_empty());
+        assert_eq!(feed(&mut e, pad(1), PRESS).len(), 1);
+    }
+
+    #[test]
+    fn motion_demand_sums_across_controllers_and_leaves_with_them() {
+        // Two controllers behave like two hands on one pointer.
+        let mut config = GamepadConfig::default();
+        config.trigger_mut(Side::Right).motions.set(
+            MotionKind::Scroll,
+            kanata_parser::gamepad::TriggerMotion {
+                direction: kanata_parser::gamepad::Cardinal::Up,
+                motion: Motion {
+                    deadzone: Unit::ZERO,
+                    speed: 10_000.0,
+                    curve: Curve::Linear,
+                    invert: Vec2::KEEP,
+                },
+            },
+        );
+        let mut e = PadEngine::new(config, None);
+        e.connect(pad(1), info("one"));
+        e.connect(pad(2), info("two"));
+        assert!(e.demand().is_idle());
+
+        let squeeze = PadInput::Trigger {
+            side: Side::Right,
+            value: Unit::ONE,
+        };
+        feed(&mut e, pad(1), squeeze);
+        assert!((e.demand()[MotionKind::Scroll].y - 10.0).abs() < 1e-3);
+        feed(&mut e, pad(2), squeeze);
+        assert!((e.demand()[MotionKind::Scroll].y - 20.0).abs() < 1e-3);
+        e.disconnect(pad(2), &mut Vec::new());
+        assert!((e.demand()[MotionKind::Scroll].y - 10.0).abs() < 1e-3);
+    }
+
+    fn mouse(x: f32, y: f32) -> Demand {
+        let mut demand = Demand::default();
+        demand[MotionKind::Mouse] = Vec2 { x, y };
+        demand
+    }
+
+    #[test]
+    fn the_accumulator_keeps_the_average_rate_exact() {
+        let mut acc = Accumulator::default();
+        assert!(acc.accrue(Demand::default()).is_empty());
+        // Rounding independently each tick would give 7000 or 8000.
+        let total: i32 = (0..1000)
+            .map(|_| acc.accrue(mouse(7.5, 0.0)).0[MotionKind::Mouse as usize].0)
+            .sum();
+        assert_eq!(total, 7500);
+        // A reset drops the partial move rather than letting it surface as a
+        // stray pixel on the next push.
+        acc.accrue(mouse(0.9, 0.0));
+        acc.reset();
+        assert!(acc.accrue(mouse(0.2, 0.0)).is_empty());
+    }
+
+    #[test]
+    fn accrued_movement_splits_by_axis_and_direction() {
+        let mut acc = Accumulator::default();
+        let mut demand = mouse(-1.0, -2.0);
+        demand[MotionKind::Scroll] = Vec2 { x: 4.0, y: -3.0 };
+        let accrued = acc.accrue(demand);
+
+        assert_eq!(
+            accrued
+                .mouse_moves(|distance| distance)
+                .map(|m| m.map(|m| (m.direction, m.distance))),
+            [Some((MoveDirection::Left, 1)), Some((MoveDirection::Up, 2))]
+        );
+        assert_eq!(
+            accrued.scrolls(),
+            [
+                Some((MWheelDirection::Right, 4)),
+                Some((MWheelDirection::Down, 3))
+            ]
+        );
+        // An axis at rest produces nothing at all, and a controller pointer is
+        // still kanata's pointer, so movemouse-speed has to reach it.
+        let scaled = acc.accrue(mouse(5.0, 0.0)).mouse_moves(|d| d * 2);
+        assert_eq!(scaled.map(|m| m.map(|m| m.distance)), [Some(10), None]);
+    }
+
+    #[test]
+    fn an_extreme_demand_saturates_rather_than_wrapping() {
+        let accrued = Accrued([(i32::MAX, i32::MIN), (i32::MIN, 0)]);
+        let moves = accrued.mouse_moves(|d| d);
+        assert_eq!(moves[0].map(|m| m.distance), Some(u16::MAX));
+        assert_eq!(
+            moves[1].map(|m| (m.direction, m.distance)),
+            Some((MoveDirection::Up, u16::MAX))
+        );
+        assert_eq!(
+            accrued.scrolls()[0],
+            Some((MWheelDirection::Left, u16::MAX))
+        );
+    }
+}

--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -69,6 +69,8 @@ pub struct PadEngine {
     held: PadSet,
     /// Whether the last sample found the controllers asking for movement.
     moving: bool,
+    /// Whether a debounced threshold crossing still needs clock time.
+    pending: bool,
 }
 
 impl PadEngine {
@@ -79,6 +81,7 @@ impl PadEngine {
             pads: HashMap::default(),
             held: PadSet::EMPTY,
             moving: false,
+            pending: false,
         }
     }
 
@@ -97,6 +100,17 @@ impl PadEngine {
         let moving = !self.demand().is_idle();
         let started = moving && !self.moving;
         self.moving = moving;
+        started
+    }
+
+    /// Whether a new debounced crossing needs to wake the processing loop.
+    pub fn take_pending_start(&mut self) -> bool {
+        let pending = self
+            .pads
+            .values()
+            .any(|(projector, _)| projector.has_pending());
+        let started = pending && !self.pending;
+        self.pending = pending;
         started
     }
 
@@ -130,6 +144,10 @@ impl PadEngine {
     /// nothing left that could ever release it.
     pub fn disconnect(&mut self, id: PadDeviceId, edges: &mut Vec<PadEdge>) {
         if self.pads.remove(&id).is_some() {
+            self.pending = self
+                .pads
+                .values()
+                .any(|(projector, _)| projector.has_pending());
             self.merge(edges);
         }
     }
@@ -143,10 +161,29 @@ impl PadEngine {
         }
     }
 
+    /// Advance every pending threshold crossing and publish its edges.
+    pub fn tick(&mut self, milliseconds: u16, edges: &mut Vec<PadEdge>) {
+        for (projector, _) in self.pads.values_mut() {
+            projector.tick(milliseconds);
+        }
+        self.pending = self
+            .pads
+            .values()
+            .any(|(projector, _)| projector.has_pending());
+        self.merge(edges);
+    }
+
+    pub fn has_pending(&self) -> bool {
+        self.pads
+            .values()
+            .any(|(projector, _)| projector.has_pending())
+    }
+
     /// Swap in a new declaration across every connected controller.
     pub fn reconfigure(&mut self, config: GamepadConfig, edges: &mut Vec<PadEdge>) {
         self.config = config;
         self.moving = false;
+        self.pending = false;
         for (projector, _) in self.pads.values_mut() {
             projector.reconfigure(config);
         }
@@ -157,6 +194,7 @@ impl PadEngine {
     /// controllers themselves connected.
     pub fn release_all(&mut self, edges: &mut Vec<PadEdge>) {
         self.moving = false;
+        self.pending = false;
         for (projector, _) in self.pads.values_mut() {
             projector.reset();
         }
@@ -272,6 +310,16 @@ impl GamepadHandle {
     /// What the continuous projections want this tick.
     pub fn demand(&self) -> Demand {
         self.engine.lock().demand()
+    }
+
+    /// Advance pending threshold crossings and collect their key edges.
+    pub fn tick(&self, milliseconds: u16, edges: &mut Vec<PadEdge>) {
+        self.engine.lock().tick(milliseconds, edges);
+    }
+
+    /// Whether a debounced crossing still needs clock time.
+    pub fn has_pending(&self) -> bool {
+        self.engine.lock().has_pending()
     }
 
     /// Offer a controller to the engine, as the backend does on connection.

--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -1,0 +1,200 @@
+//! Game controller input at runtime.
+//!
+//! [`source`] is the only place that knows a controller library exists: it
+//! owns a thread and sends key events straight to the processing loop, so a
+//! controller button has no more latency than a key. [`PadEngine`] merges any
+//! number of controllers into one logical pad -- a control is pressed while
+//! any controller holds it and released when the last one lets go, which is a
+//! bitwise OR of their [`PadSet`]s and one diff for the edges.
+//!
+//! Continuous output is *not* pushed. A stick driving the pointer is a rate,
+//! not an event, so the tick loop samples it once a millisecond through
+//! [`GamepadHandle::demand`]; pushing it would make pointer speed depend on
+//! how often a particular controller happens to report.
+
+pub mod source;
+
+use std::sync::Arc;
+use std::sync::mpsc::SyncSender;
+
+use kanata_parser::cfg::InputDeviceMatcher;
+use kanata_parser::custom_action::{MWheelDirection, MoveDirection};
+use kanata_parser::gamepad::{
+    Demand, GamepadConfig, MotionKind, PadEdge, PadInput, PadSet, Projector, Vec2,
+};
+use parking_lot::Mutex;
+use rustc_hash::FxHashMap as HashMap;
+
+use crate::kanata::{CalculatedMouseMove, MAPPED_KEYS};
+use crate::oskbd::{KeyEvent, KeyValue};
+
+/// A backend-assigned controller identity, stable while the device stays
+/// connected.
+///
+/// Deliberately opaque. An evdev node number or an XInput slot index is not a
+/// stable identity, and letting one become one in a config would bake in a
+/// value that changes when a device is replugged.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PadDeviceId(u32);
+
+impl PadDeviceId {
+    pub const fn new(raw: u32) -> PadDeviceId {
+        PadDeviceId(raw)
+    }
+}
+
+/// What a backend knows about a controller when it connects.
+#[derive(Clone, Debug, Default)]
+pub struct PadDeviceInfo {
+    pub name: String,
+    pub vendor_id: Option<u16>,
+    pub product_id: Option<u16>,
+}
+
+/// The result of offering a newly connected controller to the engine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Connection {
+    Accepted,
+    /// The controller did not match the configured `definputdevices` entry.
+    NotSelected,
+}
+
+/// Every connected controller, merged into one logical pad.
+pub struct PadEngine {
+    config: GamepadConfig,
+    /// The `definputdevices` entry named by `(device N)`, if any.
+    matcher: Option<InputDeviceMatcher>,
+    pads: HashMap<PadDeviceId, (Projector, PadDeviceInfo)>,
+    /// The union last handed to the layout.
+    held: PadSet,
+    /// Whether the last sample found the controllers asking for movement.
+    moving: bool,
+}
+
+impl PadEngine {
+    pub fn new(config: GamepadConfig, matcher: Option<InputDeviceMatcher>) -> PadEngine {
+        PadEngine {
+            config,
+            matcher,
+            pads: HashMap::default(),
+            held: PadSet::EMPTY,
+            moving: false,
+        }
+    }
+
+    /// Whether the controllers have *just* started asking for movement.
+    ///
+    /// A control held at a deflection produces no edges, so a motion
+    /// projection sends nothing down the input channel. The backend nudges the
+    /// processing loop once per transition into movement; from there the tick
+    /// loop keeps itself awake for as long as the demand lasts.
+    ///
+    /// The flag lives here rather than in the backend because the processing
+    /// thread resets projectors behind the backend's back, on live reload and
+    /// on a state clean. A copy cached out there would stay armed across that,
+    /// and the next push would never wake the loop.
+    pub fn take_motion_start(&mut self) -> bool {
+        let moving = !self.demand().is_idle();
+        let started = moving && !self.moving;
+        self.moving = moving;
+        started
+    }
+
+    pub fn connected_count(&self) -> usize {
+        self.pads.len()
+    }
+
+    /// Human-readable description of a connected controller, for logs.
+    pub fn device_name(&self, id: PadDeviceId) -> Option<&str> {
+        self.pads.get(&id).map(|(_, info)| info.name.as_str())
+    }
+
+    /// Offer a newly connected controller to the engine.
+    pub fn connect(&mut self, id: PadDeviceId, info: PadDeviceInfo) -> Connection {
+        if let Some(matcher) = &self.matcher
+            && !matches_device(matcher, &info)
+        {
+            return Connection::NotSelected;
+        }
+        // A backend replaying a connection is not an error; keep the state
+        // that is already tracking the device.
+        self.pads
+            .entry(id)
+            .or_insert_with(|| (Projector::new(self.config), info));
+        Connection::Accepted
+    }
+
+    /// Drop a controller, releasing everything it was holding.
+    ///
+    /// Without this a controller unplugged mid-press leaves a key down with
+    /// nothing left that could ever release it.
+    pub fn disconnect(&mut self, id: PadDeviceId, edges: &mut Vec<PadEdge>) {
+        if self.pads.remove(&id).is_some() {
+            self.merge(edges);
+        }
+    }
+
+    /// Feed one reading from a connected controller. Readings from a device
+    /// the engine never accepted are dropped.
+    pub fn feed(&mut self, id: PadDeviceId, input: PadInput, edges: &mut Vec<PadEdge>) {
+        if let Some((projector, _)) = self.pads.get_mut(&id) {
+            projector.feed(input);
+            self.merge(edges);
+        }
+    }
+
+    /// Swap in a new declaration across every connected controller.
+    pub fn reconfigure(&mut self, config: GamepadConfig, edges: &mut Vec<PadEdge>) {
+        self.config = config;
+        self.moving = false;
+        for (projector, _) in self.pads.values_mut() {
+            projector.reconfigure(config);
+        }
+        self.merge(edges);
+    }
+
+    /// Release every control every controller is holding, keeping the
+    /// controllers themselves connected.
+    pub fn release_all(&mut self, edges: &mut Vec<PadEdge>) {
+        self.moving = false;
+        for (projector, _) in self.pads.values_mut() {
+            projector.reset();
+        }
+        self.merge(edges);
+    }
+
+    /// Sum the motion demand of every controller.
+    ///
+    /// Summing rather than picking one keeps two controllers behaving like two
+    /// hands on one pointer; an idle controller contributes nothing.
+    pub fn demand(&self) -> Demand {
+        self.pads
+            .values()
+            .map(|(projector, _)| projector.demand())
+            .fold(Demand::default(), |total, demand| total + demand)
+    }
+
+    /// Republish the merged set, appending whatever transitions that implies.
+    fn merge(&mut self, edges: &mut Vec<PadEdge>) {
+        let next = self
+            .pads
+            .values()
+            .fold(PadSet::EMPTY, |all, (projector, _)| all | projector.held());
+        edges.extend(self.held.edges(next));
+        self.held = next;
+    }
+}
+
+/// Whether a controller satisfies a `definputdevices` matcher.
+///
+/// Every field the user specified has to match; fields they left out are not
+/// constraints.
+fn matches_device(matcher: &InputDeviceMatcher, info: &PadDeviceInfo) -> bool {
+    matcher.name.as_ref().is_none_or(|name| *name == info.name)
+        && matcher
+            .vendor_id
+            .is_none_or(|vendor| Some(vendor) == info.vendor_id)
+        && matcher
+            .product_id
+            .is_none_or(|product| Some(product) == info.product_id)
+}

--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -198,3 +198,138 @@ fn matches_device(matcher: &InputDeviceMatcher, info: &PadDeviceInfo) -> bool {
             .product_id
             .is_none_or(|product| Some(product) == info.product_id)
 }
+
+/// Kanata's handle on the running controller backend.
+///
+/// Nothing here reaches the processing loop by itself. Every method that can
+/// produce edges hands them back to the caller, because those callers run *on*
+/// the processing thread: pushing releases down the input channel from there
+/// would be a thread sending to itself, which can only be done with a
+/// `try_send` that drops a release when the queue is full.
+pub struct GamepadHandle {
+    engine: Arc<Mutex<PadEngine>>,
+    /// Whether anything drives the pointer or the wheel. Kept out here so the
+    /// tick loop can skip sampling -- and so skip taking the engine lock a
+    /// thousand times a second -- for the common keys-only configuration.
+    drives_motion: bool,
+}
+
+impl GamepadHandle {
+    /// Build the controller state machine, without a backend behind it.
+    ///
+    /// `devices` is the parsed `definputdevices` table, used to resolve the
+    /// `(device N)` reference if the declaration has one.
+    ///
+    /// Separate from [`GamepadHandle::spawn_backend`] so everything downstream
+    /// of the hardware can be driven from a recorded trace; the simulated
+    /// input tests stand in for the backend that way.
+    pub fn new(
+        config: GamepadConfig,
+        devices: Option<&[(std::num::NonZeroU8, InputDeviceMatcher)]>,
+    ) -> GamepadHandle {
+        GamepadHandle {
+            drives_motion: config.drives_motion(),
+            engine: Arc::new(Mutex::new(PadEngine::new(
+                config,
+                resolve_matcher(&config, devices),
+            ))),
+        }
+    }
+
+    /// Start the thread that reads real controllers into this engine.
+    pub fn spawn_backend(&self, tx: SyncSender<KeyEvent>) {
+        source::spawn(self.engine.clone(), tx);
+    }
+
+    /// Swap in a reloaded declaration, returning the edges the caller has to
+    /// apply.
+    ///
+    /// Every control the old declaration held is released first, so a
+    /// projection that disappears cannot strand a key down.
+    ///
+    /// Which controller is selected is fixed at startup and not revisited
+    /// here, matching the existing rule that `definputdevices` is not re-read
+    /// on live reload.
+    pub fn reconfigure(&mut self, config: GamepadConfig, edges: &mut Vec<PadEdge>) {
+        self.drives_motion = config.drives_motion();
+        self.engine.lock().reconfigure(config, edges);
+    }
+
+    /// Let go of everything the controllers are holding, without changing what
+    /// they project.
+    ///
+    /// `drives_motion` deliberately survives: it describes the declaration,
+    /// not the held state.
+    pub fn release_all(&mut self, edges: &mut Vec<PadEdge>) {
+        self.engine.lock().release_all(edges);
+    }
+
+    /// Whether the tick loop has anything to sample.
+    pub fn drives_motion(&self) -> bool {
+        self.drives_motion
+    }
+
+    /// What the continuous projections want this tick.
+    pub fn demand(&self) -> Demand {
+        self.engine.lock().demand()
+    }
+
+    /// Offer a controller to the engine, as the backend does on connection.
+    ///
+    /// Public for the simulated-input tests, which have no hardware to
+    /// connect; the backend thread owns the engine directly.
+    pub fn connect(&self, id: PadDeviceId, info: PadDeviceInfo) -> Connection {
+        self.engine.lock().connect(id, info)
+    }
+
+    /// Feed one reading from a connected controller, as the backend does.
+    pub fn feed(&self, id: PadDeviceId, input: PadInput, edges: &mut Vec<PadEdge>) {
+        self.engine.lock().feed(id, input, edges);
+    }
+}
+
+fn resolve_matcher(
+    config: &GamepadConfig,
+    devices: Option<&[(std::num::NonZeroU8, InputDeviceMatcher)]>,
+) -> Option<InputDeviceMatcher> {
+    let wanted = config.device?;
+    let (_, matcher) = devices?.iter().find(|(id, _)| *id == wanted)?;
+    // `hash` is a keyboard-only concept. Reported rather than silently
+    // ignored, because a config that looks like it selects one device but
+    // actually accepts all of them is worse than a warning.
+    if matcher.hash.is_some() {
+        log::warn!(
+            "gamepad: definputdevices entry {wanted} matches on `hash`, which controllers \
+             do not report. Match on name, vendor_id or product_id instead."
+        );
+    }
+    Some(matcher.clone())
+}
+
+/// Turn the edges a controller produced into input events for the processing
+/// loop, dropping any control `defsrc` does not map.
+///
+/// This is the same gate the keyboard path uses. There is no passthrough
+/// branch because the controller was never seized: the OS already saw the
+/// original event.
+///
+/// Filtering is separated from delivery so that no caller holds the
+/// `MAPPED_KEYS` lock while doing anything that can block. A live reload
+/// replaces `MAPPED_KEYS` from the thread that drains the input channel, so a
+/// send under this lock would let the two wait on each other.
+pub(crate) fn gate_on_defsrc(edges: &[PadEdge], out: &mut Vec<KeyEvent>) {
+    if edges.is_empty() {
+        return;
+    }
+    let mapped = MAPPED_KEYS.lock();
+    out.extend(edges.iter().filter_map(|edge| {
+        let code = edge.code.os_code();
+        mapped.contains(&code).then(|| {
+            let value = match edge.pressed {
+                true => KeyValue::Press,
+                false => KeyValue::Release,
+            };
+            KeyEvent::new(code, value)
+        })
+    }));
+}

--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -333,3 +333,86 @@ pub(crate) fn gate_on_defsrc(edges: &[PadEdge], out: &mut Vec<KeyEvent>) {
         })
     }));
 }
+
+/// Carries fractional pointer and wheel movement between ticks.
+///
+/// A stick at 30% of a 25,000 px/s speed asks for 7.5 pixels a millisecond.
+/// Rounding each tick independently would run permanently slow or fast, and
+/// rounding a small demand to zero would make slow movement impossible rather
+/// than merely slow.
+#[derive(Default)]
+pub struct Accumulator([Vec2; MotionKind::ALL.len()]);
+
+impl Accumulator {
+    /// Add this tick's demand and take whatever whole units have accrued.
+    pub fn accrue(&mut self, demand: Demand) -> Accrued {
+        let mut accrued = Accrued::default();
+        for kind in MotionKind::ALL {
+            let carry = &mut self.0[kind as usize];
+            *carry += demand[kind];
+            accrued.0[kind as usize] = carry.take_whole();
+        }
+        accrued
+    }
+
+    /// Drop any partial movement.
+    ///
+    /// Called when everything returns to rest, so a fraction left over from
+    /// the last push cannot leak into the next one as a stray pixel.
+    pub fn reset(&mut self) {
+        *self = Accumulator::default();
+    }
+}
+
+/// Whole units ready to send to the OS this tick.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Accrued([(i32, i32); MotionKind::ALL.len()]);
+
+impl Accrued {
+    pub fn is_empty(self) -> bool {
+        self.0.iter().all(|axes| *axes == (0, 0))
+    }
+
+    /// The pointer moves this tick, as kanata's mouse primitives take them.
+    ///
+    /// One entry per axis, `None` for an axis that is not moving; the caller
+    /// picks `move_mouse` or `move_mouse_many` from what is present. An array
+    /// rather than a `Vec` keeps the per-millisecond tick path allocation
+    /// free.
+    pub fn mouse_moves(self, scale: impl Fn(u16) -> u16) -> [Option<CalculatedMouseMove>; 2] {
+        let (x, y) = self.0[MotionKind::Mouse as usize];
+        [
+            split(x, MoveDirection::Right, MoveDirection::Left),
+            split(y, MoveDirection::Down, MoveDirection::Up),
+        ]
+        .map(|axis| {
+            axis.map(|(direction, distance)| CalculatedMouseMove {
+                direction,
+                distance: scale(distance),
+            })
+        })
+    }
+
+    /// The wheel notches this tick, as (direction, distance) pairs.
+    pub fn scrolls(self) -> [Option<(MWheelDirection, u16)>; 2] {
+        let (x, y) = self.0[MotionKind::Scroll as usize];
+        [
+            split(x, MWheelDirection::Right, MWheelDirection::Left),
+            // Stick Y and wheel-up are both up-positive, so no flip here. The
+            // user-facing invert-y knob was applied in the projection.
+            split(y, MWheelDirection::Up, MWheelDirection::Down),
+        ]
+    }
+}
+
+/// Split a signed amount into a direction and a distance, or `None` for an
+/// axis that is not moving. Saturating, so an absurd demand cannot wrap.
+fn split<T>(amount: i32, positive: T, negative: T) -> Option<(T, u16)> {
+    match amount {
+        0 => None,
+        _ => Some((
+            if amount > 0 { positive } else { negative },
+            amount.unsigned_abs().min(u16::MAX as u32) as u16,
+        )),
+    }
+}

--- a/src/kanata/sequences.rs
+++ b/src/kanata/sequences.rs
@@ -274,7 +274,9 @@ use kanata_keyberon::key_code::KeyCode::*;
 pub(super) fn do_successful_sequence_termination(
     kbd_out: &mut KbdOut,
     state: &mut SequenceState,
-    layout: &mut Layout<'_, 767, 2, &CustomAction>,
+    // The parser already names this shape; spelling the row width out here
+    // once let it silently desynchronize from the layout.
+    layout: &mut BorrowedKLayout<'_>,
     i: u8,
     j: u16,
     seq_type: EndSequenceType,


### PR DESCRIPTION
#### 5. Runtime Engine (`gamepad/runtime-engine`)

Implements the daemon-level lifecycle and motion aggregation systems.

- **Logical Merging:** `PadEngine` consolidates input from multiple physical gamepads into a singular logical device via a stateful OR operation.
- **Temporal Decoupling:** Advances debounce timers via the runtime's internal millisecond clock rather than hardware input events, ensuring consistent evaluation regardless of device polling rates.
- **Anti-Drift Accumulator:** Handles sub-pixel rounding errors for analog motion. Fractional `Vec2` spatial demand is carried across 1ms ticks; the `Accumulator` then yields discrete pixels or scroll notches only when whole units are reached, ensuring low-magnitude stick pushes maintain accurate average speeds over time.

