### PR TITLE
9. Processing Loop Integration (gamepad/processing-integration)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,6 +73,8 @@ jobs:
         shared-key: "persist-cross-job"
         workspaces: ./
     - run: rustup component add clippy
+    - name: Install libudev
+      run: sudo apt-get update && sudo apt-get install -y libudev-dev
 
     - name: Run tests no features
       run: cargo test --all --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +545,41 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "gilrs"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902fb00d3f6398e635be22e5c837b303c501835cca7ac11a47bba138f7aafdd8"
+dependencies = [
+ "fnv",
+ "gilrs-core",
+ "log",
+ "uuid",
+ "vec_map",
+]
+
+[[package]]
+name = "gilrs-core"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7f0ce6237abcc0523f2a5502b1e3fe5802daaae47ac14e166fe49551301ea9"
+dependencies = [
+ "inotify 0.11.5",
+ "js-sys",
+ "libc",
+ "libudev-sys",
+ "log",
+ "nix 0.31.3",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "rusty-xinput",
+ "uuid",
+ "vec_map",
+ "wasm-bindgen",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -628,10 +669,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify-sys"
-version = "0.1.5"
+name = "inotify"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags 2.9.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -728,8 +780,9 @@ dependencies = [
  "embed-resource",
  "encode_unicode",
  "evdev",
+ "gilrs",
  "indoc",
- "inotify",
+ "inotify 0.10.2",
  "kanata-interception",
  "kanata-keyberon",
  "kanata-parser",
@@ -876,9 +929,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
@@ -888,6 +941,16 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1050,6 +1113,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "objc2-core-image"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1259,17 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1313,6 +1408,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "png"
@@ -1465,6 +1566,17 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-xinput"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3335c2b62e1e48dd927f6c8941705386e3697fa944aabcb10431bea7ee47ef3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -1852,6 +1964,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "vswhom"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +2081,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,18 @@ kanata-keyberon = { path = "keyberon", version = "0.1121.0" }
 kanata-parser =   { path = "parser", version = "0.1121.0" }
 kanata-tcp-protocol = { path = "tcp_protocol", version = "0.1121.0" }
 
+# Controller input. One crate covers evdev, IOKit and XInput, which is why
+# src/gamepad has no per-OS branches at all.
+#
+# `xinput` is selected over gilrs's default Windows.Gaming.Input backend on
+# purpose: WGI only delivers input to the focused window, which is unusable for
+# a background daemon, while XInput has no such restriction. The tradeoff is
+# that XInput sees only XUSB-compatible pads; DirectInput-only devices need the
+# Raw Input backend noted as follow-up work in docs/config.adoc. The feature is
+# inert on Linux and macOS, but gilrs-core fails to build with neither backend
+# feature selected on any platform, so it is set unconditionally.
+gilrs = { version = "0.11.2", default-features = false, features = ["xinput"] }
+
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 arboard = "3.4"
 
@@ -144,7 +156,6 @@ gui = ["win_manifest","kanata-parser/gui",
   "native-windows-gui/tray-notification","native-windows-gui/message-window","native-windows-gui/menu","native-windows-gui/cursor","native-windows-gui/high-dpi","native-windows-gui/embed-resource","native-windows-gui/image-decoder","native-windows-gui/notice","native-windows-gui/animation-timer",
 ]
 zippychord = ["kanata-parser/zippychord"]
-
 [profile.release]
 opt-level = "z"
 lto = "fat"

--- a/keyberon/src/key_code.rs
+++ b/keyberon/src/key_code.rs
@@ -5,7 +5,7 @@ pub const KEY_MAX: u16 = 850;
 
 #[test]
 fn keycode_max_test() {
-    assert!((KeyCode::KeyMax as u16) < KEY_MAX);
+    assert!((KeyCode::KeyCodeMax as u16) < KEY_MAX);
 }
 
 #[allow(missing_docs)]
@@ -782,6 +782,69 @@ pub enum KeyCode {
     K765 = 765,
     K766 = 766,
     KeyMax = 767,
+
+    // Codes above the OS scancode range. kanata reserves these for inputs no
+    // operating system reports as a scancode -- currently the game controller
+    // controls named in `kanata_parser::keys::OsCode`. `From<OsCode>` and
+    // `From<KeyCode>` transmute between the two enums, so this range has to
+    // cover every `OsCode` discriminant.
+    K768 = 768,
+    K769 = 769,
+    K770 = 770,
+    K771 = 771,
+    K772 = 772,
+    K773 = 773,
+    K774 = 774,
+    K775 = 775,
+    K776 = 776,
+    K777 = 777,
+    K778 = 778,
+    K779 = 779,
+    K780 = 780,
+    K781 = 781,
+    K782 = 782,
+    K783 = 783,
+    K784 = 784,
+    K785 = 785,
+    K786 = 786,
+    K787 = 787,
+    K788 = 788,
+    K789 = 789,
+    K790 = 790,
+    K791 = 791,
+    K792 = 792,
+    K793 = 793,
+    K794 = 794,
+    K795 = 795,
+    K796 = 796,
+    K797 = 797,
+    K798 = 798,
+    K799 = 799,
+    K800 = 800,
+    K801 = 801,
+    K802 = 802,
+    K803 = 803,
+    K804 = 804,
+    K805 = 805,
+    K806 = 806,
+    K807 = 807,
+    K808 = 808,
+    K809 = 809,
+    K810 = 810,
+    K811 = 811,
+    K812 = 812,
+    K813 = 813,
+    K814 = 814,
+    K815 = 815,
+    K816 = 816,
+    K817 = 817,
+    K818 = 818,
+    K819 = 819,
+    K820 = 820,
+    K821 = 821,
+    K822 = 822,
+    /// One past the highest variant.
+    KeyCodeMax = 823,
 }
 
 impl KeyCode {

--- a/parser/src/cfg/arbitrary_code.rs
+++ b/parser/src/cfg/arbitrary_code.rs
@@ -15,6 +15,11 @@ pub(crate) fn parse_arbitrary_code(
         .atom(s.vars())
         .map(str::parse::<u16>)
         .and_then(|c| c.ok())
+        // The range in the message was never enforced. It has to be now: this
+        // writes the code straight to the OS, and everything at or above
+        // `PAD_SOUTH` begins the synthetic controller range, which has no
+        // scancodes behind it.
+        .filter(|code| *code < OsCode::PAD_SOUTH as u16)
         .ok_or_else(|| anyhow!("{ERR_MSG}: got {:?}", ac_params[0]))?;
     custom(CustomAction::SendArbitraryCode(code), &s.a)
 }

--- a/parser/src/cfg/defgamepad.rs
+++ b/parser/src/cfg/defgamepad.rs
@@ -291,10 +291,12 @@ fn digital(control: Directional, args: &[SExpr], vars: &HashMap<String, SExpr>) 
     for arg in args {
         let (keyword, values) = keyed(arg, vars, "a digital option such as (mode 8way)")?;
         match keyword {
-            "mode" | "socd" | "threshold" => once(&mut seen, arg, format!("({keyword} ...)"))?,
+            "mode" | "socd" | "threshold" | "debounce" => {
+                once(&mut seen, arg, format!("({keyword} ...)"))?
+            }
             _ => bail_expr!(
                 arg,
-                "unknown digital option: {keyword}\nvalid options: mode, socd, threshold"
+                "unknown digital option: {keyword}\nvalid options: mode, socd, threshold, debounce"
             ),
         }
         match keyword {
@@ -313,11 +315,14 @@ fn digital(control: Directional, args: &[SExpr], vars: &HashMap<String, SExpr>) 
             }
             _ if control == Directional::Dpad => bail_expr!(
                 arg,
-                "a d-pad has no {keyword} threshold: its contacts are digital before \
-                 they reach kanata, so there is no analog value to compare"
+                "a d-pad has no {keyword}: its contacts are digital before they reach \
+                 kanata, so there is no analog value to compare or debounce"
             ),
             "threshold" => {
                 digital.threshold = unit(value(values, arg, keyword)?, vars, keyword)?;
+            }
+            "debounce" => {
+                digital.debounce = milliseconds(value(values, arg, keyword)?, vars, keyword)?;
             }
             _ => unreachable!("validated above"),
         }
@@ -354,14 +359,19 @@ fn trigger(args: &[SExpr], vars: &HashMap<String, SExpr>) -> Result<Trigger> {
                     },
                 );
             }
-            ("threshold", _) => {
+            ("threshold" | "debounce", _) => {
                 once(&mut seen, arg, format!("({keyword} ...)"))?;
-                trigger.threshold = unit(value(values, arg, keyword)?, vars, keyword)?;
+                let value = value(values, arg, keyword)?;
+                match keyword {
+                    "threshold" => trigger.threshold = unit(value, vars, keyword)?,
+                    "debounce" => trigger.debounce = milliseconds(value, vars, keyword)?,
+                    _ => unreachable!("validated above"),
+                }
             }
             _ => bail_expr!(
                 arg,
                 "unknown trigger option: {keyword}\n\
-                 valid options: threshold, mouse, scroll"
+                 valid options: threshold, debounce, mouse, scroll"
             ),
         }
     }
@@ -576,6 +586,19 @@ fn number(expr: &SExpr, vars: &HashMap<String, SExpr>, what: &str, max: f32) -> 
 /// never responds and no clue why.
 fn unit(expr: &SExpr, vars: &HashMap<String, SExpr>, what: &str) -> Result<Unit> {
     Ok(Unit::new(number(expr, vars, what, 1.0)?))
+}
+
+/// A duration in milliseconds. Zero means that a crossing takes effect now.
+fn milliseconds(expr: &SExpr, vars: &HashMap<String, SExpr>, what: &str) -> Result<u16> {
+    atom(expr, vars, "milliseconds")?
+        .parse()
+        .ok()
+        .ok_or_else(|| {
+            anyhow_expr!(
+                expr,
+                "{what} must be a whole number of milliseconds, 0-65535"
+            )
+        })
 }
 
 fn device_id(expr: &SExpr, vars: &HashMap<String, SExpr>) -> Result<NonZeroU8> {

--- a/parser/src/cfg/defgamepad.rs
+++ b/parser/src/cfg/defgamepad.rs
@@ -198,3 +198,275 @@ fn hint(cfg: &GamepadConfig, control: Directional, inner: &str) -> String {
     }
 }
 
+// ------------------------------------------------------------------- items
+
+/// Refuse a second `what`, at every level of the grammar.
+///
+/// Letting the later one quietly win makes a typo look like a working
+/// configuration. Mouse and scroll are distinct projections; repeating either
+/// one is still almost certainly a typo.
+fn once(seen: &mut Vec<String>, at: &SExpr, what: impl Into<String>) -> Result<()> {
+    let what = what.into();
+    if seen.contains(&what) {
+        bail_expr!(at, "duplicate {what}");
+    }
+    seen.push(what);
+    Ok(())
+}
+
+/// Split `(<item> left|right ...)` into the side and the remaining options.
+fn sided<'a>(
+    rest: &'a [SExpr],
+    at: &SExpr,
+    vars: &HashMap<String, SExpr>,
+    what: &str,
+) -> Result<(Side, &'a [SExpr])> {
+    let Some((side, options)) = rest.split_first() else {
+        bail_expr!(
+            at,
+            "{what} needs a side: ({what} left ...) or ({what} right ...)"
+        );
+    };
+    Ok((one_of(side, vars, "side", &SIDES)?, options))
+}
+
+/// Parse the projections of a stick or the d-pad.
+///
+/// A control may take both halves: a stick can drive the pointer *and* press a
+/// key at full deflection, because the threshold and the displacement read the
+/// same value without disturbing each other.
+fn projection(
+    control: Directional,
+    mut projection: Projection,
+    args: &[SExpr],
+    at: &SExpr,
+    vars: &HashMap<String, SExpr>,
+) -> Result<Projection> {
+    if args.is_empty() {
+        bail_expr!(at, "the {} needs one of {PROJECTIONS}", control.as_str());
+    }
+    // `off` is the one bare-atom form, and it is exclusive. `(stick left
+    // (digital) off)` reads to a user exactly like `(stick left off
+    // (digital))` but silently produces the opposite, so neither is allowed.
+    let is_off = |arg: &SExpr| arg.atom(Some(vars)).map(str::trim_atom_quotes) == Some("off");
+    if args.len() > 1 {
+        if let Some(off) = args.iter().find(|arg| is_off(arg)) {
+            bail_expr!(
+                off,
+                "`off` is the whole projection: a control that does nothing has nothing \
+                 else to declare"
+            );
+        }
+    }
+
+    let mut seen: Vec<String> = Vec::new();
+    for arg in args {
+        if is_off(arg) {
+            return Ok(Projection::OFF);
+        }
+        let (keyword, options) = keyed(arg, vars, PROJECTIONS)?;
+        match motion_kind(keyword) {
+            Some(kind) => {
+                once(&mut seen, arg, format!("({} ...)", motion_name(kind)))?;
+                projection
+                    .motions
+                    .set(kind, motion(kind, Axes::Two, options, vars)?);
+            }
+            None if keyword == "digital" => {
+                once(&mut seen, arg, "(digital ...)")?;
+                projection.digital = Some(digital(control, options, vars)?);
+            }
+            None => bail_expr!(
+                arg,
+                "unknown projection: {keyword}\na stick or d-pad takes {PROJECTIONS}"
+            ),
+        }
+    }
+    Ok(projection)
+}
+
+fn digital(control: Directional, args: &[SExpr], vars: &HashMap<String, SExpr>) -> Result<Digital> {
+    let mut digital = Digital::default();
+    let mut seen: Vec<String> = Vec::new();
+    for arg in args {
+        let (keyword, values) = keyed(arg, vars, "a digital option such as (mode 8way)")?;
+        match keyword {
+            "mode" | "socd" | "threshold" => once(&mut seen, arg, format!("({keyword} ...)"))?,
+            _ => bail_expr!(
+                arg,
+                "unknown digital option: {keyword}\nvalid options: mode, socd, threshold"
+            ),
+        }
+        match keyword {
+            "mode" => digital.mode = one_of(value(values, arg, keyword)?, vars, "mode", &MODES)?,
+            // Only a control with independent contacts can assert an opposed
+            // pair, and a stick reports each axis as one signed number.
+            // Accepting this there would be a knob that never fires.
+            "socd" if control.side().is_some() => bail_expr!(
+                arg,
+                "socd belongs to the d-pad: a stick reads each axis as one number, so it \
+                 can never report two opposite directions at once.\n\
+                 Use (dpad (digital (socd ...)))."
+            ),
+            "socd" => {
+                digital.socd = one_of(value(values, arg, keyword)?, vars, "socd mode", &SOCDS)?
+            }
+            _ if control == Directional::Dpad => bail_expr!(
+                arg,
+                "a d-pad has no {keyword} threshold: its contacts are digital before \
+                 they reach kanata, so there is no analog value to compare"
+            ),
+            "threshold" => {
+                digital.threshold = unit(value(values, arg, keyword)?, vars, keyword)?;
+            }
+            _ => unreachable!("validated above"),
+        }
+    }
+    Ok(digital)
+}
+
+fn trigger(args: &[SExpr], vars: &HashMap<String, SExpr>) -> Result<Trigger> {
+    let mut trigger = Trigger::default();
+    let mut seen: Vec<String> = Vec::new();
+    for arg in args {
+        let (keyword, values) = keyed(arg, vars, "a trigger option such as (threshold 0.3)")?;
+        match (keyword, motion_kind(keyword)) {
+            (_, Some(kind)) => {
+                once(&mut seen, arg, format!("({} ...)", motion_name(kind)))?;
+                // The direction has to be an atom, so a leading option is a
+                // missing direction rather than an unreadable one.
+                let named = values
+                    .split_first()
+                    .filter(|(dir, _)| dir.atom(Some(vars)).is_some());
+                let Some((dir, rest)) = named else {
+                    bail_expr!(
+                        arg,
+                        "({keyword} ...) on a trigger needs a direction to push: a trigger is \
+                         one number, not a vector, e.g. ({keyword} down (speed 30))"
+                    );
+                };
+                let dir = one_of(dir, vars, "direction", &PUSH)?;
+                trigger.motions.set(
+                    kind,
+                    TriggerMotion {
+                        direction: dir,
+                        motion: motion(kind, Axes::One, rest, vars)?,
+                    },
+                );
+            }
+            ("threshold", _) => {
+                once(&mut seen, arg, format!("({keyword} ...)"))?;
+                trigger.threshold = unit(value(values, arg, keyword)?, vars, keyword)?;
+            }
+            _ => bail_expr!(
+                arg,
+                "unknown trigger option: {keyword}\n\
+                 valid options: threshold, mouse, scroll"
+            ),
+        }
+    }
+    Ok(trigger)
+}
+
+/// How many axes the control being projected has.
+///
+/// A trigger is a single number that already names the direction it pushes, so
+/// `invert-x` / `invert-y` there would be a second knob for the same thing --
+/// and, since the trigger path never reads `Motion::invert`, one that did
+/// nothing at all.
+#[derive(Clone, Copy, PartialEq)]
+enum Axes {
+    One,
+    Two,
+}
+
+fn motion(
+    kind: MotionKind,
+    axes: Axes,
+    args: &[SExpr],
+    vars: &HashMap<String, SExpr>,
+) -> Result<Motion> {
+    let mut motion = Motion::of(kind);
+    let mut seen: Vec<String> = Vec::new();
+    for arg in args {
+        let (keyword, values) = keyed(arg, vars, "a motion option such as (speed 1200)")?;
+        match keyword {
+            "invert-x" | "invert-y" if axes == Axes::One => bail_expr!(
+                arg,
+                "a trigger has no {keyword}: it is one number, and the direction after \
+                 ({} ...) already says which way it pushes",
+                motion_name(kind)
+            ),
+            "deadzone" | "speed" | "curve" | "invert-x" | "invert-y" => {
+                once(&mut seen, arg, format!("({keyword} ...)"))?
+            }
+            _ => bail_expr!(
+                arg,
+                "unknown {} option: {keyword}\n\
+                 valid options: deadzone, speed, curve, invert-x, invert-y",
+                motion_name(kind)
+            ),
+        }
+        // The value is read after the name is known to be one we handle, so
+        // that an unknown option is reported as one rather than as an arity
+        // error about a name that means nothing here.
+        let value = value(values, arg, keyword)?;
+        match keyword {
+            "deadzone" => motion.deadzone = unit(value, vars, keyword)?,
+            "speed" => motion.speed = number(value, vars, keyword, Motion::MAX_SPEED)?,
+            "curve" => motion.curve = one_of(value, vars, "curve", &CURVES)?,
+            "invert-x" => motion.invert.x = sign(one_of(value, vars, keyword, &BOOLS)?),
+            _ => motion.invert.y = sign(one_of(value, vars, keyword, &BOOLS)?),
+        }
+    }
+    Ok(motion)
+}
+
+fn slot(
+    rest: &[SExpr],
+    at: &SExpr,
+    vars: &HashMap<String, SExpr>,
+    cfg: &mut GamepadConfig,
+) -> Result<()> {
+    let [index_expr, code_expr] = rest else {
+        bail_expr!(
+            at,
+            "button-slot takes a slot index and a backend code, e.g. (button-slot 0 0x2c0)\n\
+             kanata logs the backend code of every control it cannot name"
+        );
+    };
+    let index: u8 = atom(index_expr, vars, "slot index")?
+        .parse()
+        .ok()
+        .filter(|index| *index < PadCode::SLOTS)
+        .ok_or_else(|| {
+            anyhow_expr!(
+                index_expr,
+                "slot index must be 0-{}; that is how many pad-button-N controls exist",
+                PadCode::SLOTS - 1
+            )
+        })?;
+    let text = atom(code_expr, vars, "backend code")?;
+    let code = match text.strip_prefix("0x").or_else(|| text.strip_prefix("0X")) {
+        Some(hex) => u32::from_str_radix(hex, 16).ok(),
+        None => text.parse().ok(),
+    }
+    .ok_or_else(|| {
+        anyhow_expr!(
+            code_expr,
+            "backend code must be a number or 0x-prefixed hex"
+        )
+    })?;
+
+    if cfg.slots[index as usize].is_some() {
+        bail_expr!(index_expr, "duplicate button-slot: pad-button-{index}");
+    }
+    if let Some(taken) = cfg.slots.iter().position(|bound| *bound == Some(code)) {
+        bail_expr!(
+            code_expr,
+            "backend code {code} is already bound to pad-button-{taken}"
+        );
+    }
+    cfg.slots[index as usize] = Some(code);
+    Ok(())
+}

--- a/parser/src/cfg/defgamepad.rs
+++ b/parser/src/cfg/defgamepad.rs
@@ -470,3 +470,123 @@ fn slot(
     cfg.slots[index as usize] = Some(code);
     Ok(())
 }
+
+// ----------------------------------------------------------------- helpers
+
+fn motion_kind(keyword: &str) -> Option<MotionKind> {
+    match keyword {
+        "mouse" => Some(MotionKind::Mouse),
+        "scroll" => Some(MotionKind::Scroll),
+        _ => None,
+    }
+}
+
+const fn motion_name(kind: MotionKind) -> &'static str {
+    match kind {
+        MotionKind::Mouse => "mouse",
+        MotionKind::Scroll => "scroll",
+    }
+}
+
+/// `invert-x yes` as the axis sign it becomes: `Motion::invert` is a pair of
+/// multipliers, so applying it is one componentwise multiply.
+fn sign(invert: bool) -> f32 {
+    match invert {
+        true => -1.0,
+        false => 1.0,
+    }
+}
+
+/// Destructure `(keyword rest ...)`, which every item and option is.
+fn keyed<'a>(
+    expr: &'a SExpr,
+    vars: &'a HashMap<String, SExpr>,
+    expected: &str,
+) -> Result<(&'a str, &'a [SExpr])> {
+    let (head, rest) = expr
+        .list(Some(vars))
+        .and_then(|list| list.split_first())
+        .ok_or_else(|| anyhow_expr!(expr, "expected {expected}"))?;
+    let keyword = head
+        .atom(Some(vars))
+        .ok_or_else(|| anyhow_expr!(head, "expected an option name"))?;
+    Ok((keyword, rest))
+}
+
+/// The single value of `(keyword value)`.
+fn value<'a>(values: &'a [SExpr], at: &SExpr, keyword: &str) -> Result<&'a SExpr> {
+    match values {
+        [value] => Ok(value),
+        _ => bail_expr!(at, "{keyword} takes exactly one value"),
+    }
+}
+
+fn atom<'a>(expr: &'a SExpr, vars: &'a HashMap<String, SExpr>, what: &str) -> Result<&'a str> {
+    expr.atom(Some(vars))
+        .map(|atom| atom.trim_atom_quotes())
+        .ok_or_else(|| anyhow_expr!(expr, "expected {what}"))
+}
+
+/// Look one of a fixed set of names up, and list them all if it is not there.
+///
+/// Every enumerated option goes through here, so the spellings a name accepts
+/// and the spellings its error message offers cannot drift apart.
+fn one_of<T: Copy>(
+    expr: &SExpr,
+    vars: &HashMap<String, SExpr>,
+    what: &str,
+    table: &[(&str, T)],
+) -> Result<T> {
+    let text = atom(expr, vars, what)?;
+    table
+        .iter()
+        .find(|(name, _)| *name == text)
+        .map(|(_, value)| *value)
+        .ok_or_else(|| {
+            anyhow_expr!(
+                expr,
+                "unknown {what}: {text}\nvalid: {}",
+                table
+                    .iter()
+                    .map(|(name, _)| *name)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })
+}
+
+fn number(expr: &SExpr, vars: &HashMap<String, SExpr>, what: &str, max: f32) -> Result<f32> {
+    let text = atom(expr, vars, "a number")?;
+    let parsed: f32 = text
+        .parse()
+        .ok()
+        .filter(|value: &f32| value.is_finite())
+        .ok_or_else(|| anyhow_expr!(expr, "expected a number for {what}, got: {text}"))?;
+    if !(0.0..=max).contains(&parsed) {
+        bail_expr!(expr, "{what} must be between 0 and {max}, got: {parsed}");
+    }
+    Ok(parsed)
+}
+
+/// A value that must land in `[0, 1]`.
+///
+/// Out of range is an error rather than a clamp: at runtime clamping protects
+/// against misbehaving hardware, but in a configuration it is always a typo,
+/// and silently reading `(deadzone 15)` as `1.0` would leave a stick that
+/// never responds and no clue why.
+fn unit(expr: &SExpr, vars: &HashMap<String, SExpr>, what: &str) -> Result<Unit> {
+    Ok(Unit::new(number(expr, vars, what, 1.0)?))
+}
+
+fn device_id(expr: &SExpr, vars: &HashMap<String, SExpr>) -> Result<NonZeroU8> {
+    atom(expr, vars, "device ID")?
+        .parse::<u8>()
+        .ok()
+        .and_then(NonZeroU8::new)
+        .ok_or_else(|| {
+            anyhow_expr!(
+                expr,
+                "device ID must be a number 1-255 matching an entry in definputdevices"
+            )
+        })
+}

--- a/parser/src/cfg/defgamepad.rs
+++ b/parser/src/cfg/defgamepad.rs
@@ -1,0 +1,200 @@
+//! Parsing for the `defgamepad` declaration, which says what physical
+//! controls exist and how they project. It never names an output key.
+//!
+//! ```lisp
+//! (defgamepad
+//!   (stick left  (digital (mode 4way)))
+//!   (stick right (mouse (deadzone 0.12) (speed 1200)))
+//!   (dpad        (digital (mode 8way) (socd neutral)))
+//!   (trigger right (threshold 0.30) (scroll down (speed 30))))
+//! ```
+//!
+//! The three directional controls take the same options because they project
+//! the same way, so there is one grammar rather than one per control.
+
+use super::*;
+use crate::gamepad::{
+    Cardinal, Curve, Digital, DirMode, Directional, GamepadConfig, Motion, MotionKind, PadCode,
+    PadControl, Projection, Side, Socd, Trigger, TriggerMotion, Unit,
+};
+use crate::{anyhow_expr, bail, bail_expr};
+
+use std::f32::consts::SQRT_2;
+use std::num::NonZeroU8;
+
+const ITEM: &str = "a defgamepad item such as (stick left (digital))";
+const PROJECTIONS: &str = "(digital ...), (mouse ...), (scroll ...), or the bare atom `off`";
+
+const SIDES: [(&str, Side); 2] = [("left", Side::Left), ("right", Side::Right)];
+const MODES: [(&str, DirMode); 4] = [
+    ("4way", DirMode::FourWay),
+    ("four-way", DirMode::FourWay),
+    ("8way", DirMode::EightWay),
+    ("eight-way", DirMode::EightWay),
+];
+const SOCDS: [(&str, Socd); 6] = [
+    ("off", Socd::Off),
+    ("neutral", Socd::Neutral),
+    ("last", Socd::Last),
+    ("first", Socd::First),
+    ("positive", Socd::Positive),
+    ("negative", Socd::Negative),
+];
+const CURVES: [(&str, Curve); 3] = [
+    ("linear", Curve::Linear),
+    ("quadratic", Curve::Quadratic),
+    ("cubic", Curve::Cubic),
+];
+const BOOLS: [(&str, bool); 4] = [
+    ("yes", true),
+    ("true", true),
+    ("no", false),
+    ("false", false),
+];
+/// A trigger is one number, so a continuous projection has to be told which
+/// way to push. Cardinals only: a diagonal would run 41% fast unless it were
+/// normalized, and naming one is asking for a stick anyway.
+const PUSH: [(&str, Cardinal); 4] = [
+    ("up", Cardinal::Up),
+    ("down", Cardinal::Down),
+    ("left", Cardinal::Left),
+    ("right", Cardinal::Right),
+];
+
+pub fn parse_defgamepad(expr: &[SExpr], vars: &HashMap<String, SExpr>) -> Result<GamepadConfig> {
+    let mut cfg = GamepadConfig::default();
+    let mut seen: Vec<String> = Vec::new();
+
+    for item in check_first_expr(expr.iter(), "defgamepad")? {
+        let (keyword, rest) = keyed(item, vars, ITEM)?;
+        match keyword {
+            "device" => {
+                once(&mut seen, item, "(device ...)")?;
+                cfg.device = Some(device_id(value(rest, item, keyword)?, vars)?);
+            }
+            "stick" => {
+                let (side, rest) = sided(rest, item, vars, keyword)?;
+                once(&mut seen, item, format!("(stick {} ...)", side.as_str()))?;
+                let control = side.stick();
+                *cfg.projection_mut(control) =
+                    projection(control, Projection::OFF, rest, item, vars)?;
+            }
+            "dpad" => {
+                once(&mut seen, item, "(dpad ...)")?;
+                // Starts from the default rather than from nothing: a d-pad
+                // presses keys with no declaration at all, so `(dpad (scroll
+                // ...))` must add the wheel without taking that away.
+                let control = Directional::Dpad;
+                let base = *cfg.projection(control);
+                *cfg.projection_mut(control) = projection(control, base, rest, item, vars)?;
+            }
+            "trigger" => {
+                let (side, rest) = sided(rest, item, vars, keyword)?;
+                once(&mut seen, item, format!("(trigger {} ...)", side.as_str()))?;
+                *cfg.trigger_mut(side) = trigger(rest, vars)?;
+            }
+            "button-slot" => slot(rest, item, vars, &mut cfg)?,
+            _ => bail_expr!(
+                item,
+                "unknown defgamepad item: {keyword}\n\
+                 valid items: device, stick, dpad, trigger, button-slot"
+            ),
+        }
+    }
+    Ok(cfg)
+}
+
+/// Check a parsed `defgamepad` against the rest of the configuration.
+///
+/// The failures caught here are the ones that otherwise present as "kanata
+/// runs, my controller does nothing": a direction mapped in `defsrc` with no
+/// projection that could ever produce it, or a device ID that matches no
+/// `definputdevices` entry.
+pub fn validate_gamepad(
+    cfg: &GamepadConfig,
+    input_devices: Option<&[(NonZeroU8, InputDeviceMatcher)]>,
+    mapped_keys: &MappedKeys,
+) -> Result<()> {
+    let unknown = cfg.device.filter(|device| {
+        !input_devices.is_some_and(|devices| devices.iter().any(|(id, _)| id == device))
+    });
+    if let Some(device) = unknown {
+        bail!(
+            "defgamepad refers to (device {device}) but definputdevices has no entry \
+             with that ID.\n\
+             Either add one, or remove the (device ...) line to accept every connected \
+             controller."
+        );
+    }
+
+    for osc in mapped_keys.iter() {
+        let Some(control) = PadCode::from_os_code(*osc).map(PadCode::control) else {
+            continue;
+        };
+        match control {
+            PadControl::Direction(control, dir) => {
+                let name = control.as_str();
+                let Some(digital) = cfg.projection(control).digital else {
+                    bail!(
+                        "defsrc maps {osc}, but the {name} has no digital projection.\n{}",
+                        hint(cfg, control, "(digital)")
+                    );
+                };
+                if dir.is_diagonal() {
+                    // Four-way presses two cardinals for a diagonal and never
+                    // the diagonal control itself. Eight-way still presses a
+                    // cardinal for a straight push, so there every direction
+                    // is reachable.
+                    if digital.mode == DirMode::FourWay {
+                        bail!(
+                            "defsrc maps {osc}, but the {name} is in 4way mode, which never \
+                             presses a diagonal control.\n{}\n\
+                             Or map the cardinal controls instead.",
+                            hint(cfg, control, "(digital (mode 8way))")
+                        );
+                    }
+                    // Both components have to clear the threshold at once, so
+                    // a diagonal needs `threshold * sqrt(2)` of deflection. Past
+                    // full deflection only a square-gated stick can reach one,
+                    // and this is otherwise another silent "my controller does
+                    // nothing".
+                    let threshold = digital.threshold.get();
+                    if control.side().is_some() && threshold * SQRT_2 > 1.0 {
+                        log::warn!(
+                            "defsrc maps {osc}, but the {name} presses at {threshold:.2}, and \
+                             holding two axes there at once needs {:.2} of deflection. Most \
+                             sticks have a circular gate and cannot reach that; lower \
+                             (threshold ...) to {:.2} or below.",
+                            threshold * SQRT_2,
+                            1.0 / SQRT_2
+                        );
+                    }
+                }
+            }
+            PadControl::Slot(index) if cfg.slots[index as usize].is_none() => bail!(
+                "defsrc maps {osc}, but no (button-slot {index} ...) binds it to a control.\n\
+                 Press the control you want and check the log for its backend code, then \
+                 add (button-slot {index} <code>)."
+            ),
+            PadControl::Button(_) | PadControl::Slot(_) => {}
+        }
+    }
+    Ok(())
+}
+
+/// What to tell the user to write.
+///
+/// A control that already has an item cannot be given a second one -- that is
+/// a duplicate -- so once it has any projection the hint has to say "add this
+/// to the item you have" rather than offering a line that would be rejected.
+fn hint(cfg: &GamepadConfig, control: Directional, inner: &str) -> String {
+    let item = match control.side() {
+        Some(side) => format!("(stick {} ", side.as_str()),
+        None => "(dpad ".to_string(),
+    };
+    match *cfg.projection(control) == Projection::OFF {
+        true => format!("Add {item}{inner}) to defgamepad."),
+        false => format!("Add {inner} to the {item}...) you already have."),
+    }
+}
+

--- a/parser/src/cfg/defsrc.rs
+++ b/parser/src/cfg/defsrc.rs
@@ -51,6 +51,9 @@ pub(crate) fn parse_defsrc(
     log::info!("process unmapped keys: {}", defcfg.process_unmapped_keys);
     if defcfg.process_unmapped_keys {
         for osc in 0..KEYS_IN_ROW as u16 {
+            // Controller controls need no exclusion here: they are synthetic,
+            // so `from_u16` never decodes one. `gamepad_controls_are_never_swept_in`
+            // pins that down.
             if let Some(osc) = OsCode::from_u16(osc) {
                 if osc.is_mouse_code() {
                     // Bugfix #1879:

--- a/parser/src/cfg/mod.rs
+++ b/parser/src/cfg/mod.rs
@@ -56,6 +56,8 @@ mod custom_tap_hold;
 use custom_tap_hold::*;
 mod defcfg;
 pub use defcfg::*;
+mod defgamepad;
+pub use defgamepad::*;
 mod definputdevices;
 pub use definputdevices::*;
 mod defhands;
@@ -316,6 +318,10 @@ pub struct Cfg {
     pub zippy: Option<(ZchPossibleChords, ZchConfig)>,
     /// Input device ID mappings from `definputdevices`.
     pub input_devices: Option<Vec<(std::num::NonZeroU8, InputDeviceMatcher)>>,
+    /// Effective controller configuration. Present for a `defgamepad`
+    /// declaration or any mapped `pad-*` input; `None` lets a keyboard-only
+    /// configuration skip opening controller devices.
+    pub gamepad: Option<crate::gamepad::GamepadConfig>,
 }
 
 /// Parse a new configuration from a file.
@@ -410,6 +416,7 @@ fn populate_cfg_with_icfg(icfg: IntermediateCfg, s: ParserState) -> Cfg {
         max_key_timing_check,
         zippy: icfg.zippy,
         input_devices: s.input_devices,
+        gamepad: s.gamepad,
     }
 }
 
@@ -677,6 +684,45 @@ pub fn parse_cfg_raw_string(
         .map(|expr| parse_definputdevices(expr, &vars))
         .transpose()?;
 
+    if let Some(spanned) = spanned_root_exprs
+        .iter()
+        .filter(gen_first_atom_filter_spanned("defgamepad"))
+        .nth(1)
+    {
+        bail_span!(
+            spanned,
+            "Only one defgamepad is allowed, found more. Delete the extras."
+        )
+    }
+    // Parsed after defvar so thresholds can be written as variables, and after
+    // definputdevices so a (device N) reference can be checked against a real
+    // declaration rather than failing at runtime with no controller attached.
+    let declared_gamepad = root_exprs
+        .iter()
+        .find(gen_first_atom_filter("defgamepad"))
+        .map(|expr| parse_defgamepad(expr, &vars))
+        .transpose()?;
+    // Validated even when there is no declaration at all. The defaults are a
+    // real configuration -- a four-way d-pad and nothing else -- so mapping
+    // `pad-lstick-up` or a d-pad diagonal without a defgamepad is the same
+    // mistake as mapping it with one, and deserves the same error naming the
+    // line that would fix it rather than a warning that cannot.
+    validate_gamepad(
+        &declared_gamepad.unwrap_or_default(),
+        input_devices.as_deref(),
+        &mapped_keys,
+    )?;
+    // A declaration is needed only for analog projections and selection.
+    // Portable buttons and d-pad cardinals deliberately work from `defsrc`
+    // alone, but they still need the backend to be started. Retain the default
+    // configuration whenever a mapped controller code makes the feature live.
+    let gamepad = declared_gamepad.or_else(|| {
+        mapped_keys
+            .iter()
+            .any(|code| code.is_gamepad_code())
+            .then(crate::gamepad::GamepadConfig::default)
+    });
+
     let deflayer_labels = [DEFLAYER, DEFLAYER_MAPPED];
     let deflayer_filter = |exprs: &&Vec<SExpr>| -> bool {
         if exprs.is_empty() {
@@ -786,6 +832,7 @@ pub fn parse_cfg_raw_string(
         vars,
         max_key_timing_check: Cell::new(cfg.rapid_event_delay),
         input_devices,
+        gamepad,
         ..Default::default()
     };
 
@@ -1063,7 +1110,8 @@ fn error_on_unknown_top_level_atoms(exprs: &[Spanned<Vec<SExpr>>]) -> Result<()>
                 | "defzippy-experimental"
                 | "defseq"
                 | "defhands"
-                | "definputdevices" => Ok(()),
+                | "definputdevices"
+                | "defgamepad" => Ok(()),
                 _ => err_span!(expr, "Found unknown configuration item"),
             })
             .ok_or_else(|| {
@@ -1188,6 +1236,7 @@ pub struct ParserState {
     /// (via `Cfg::emits_mouse_buttons`) to gate installing the mouse event tap.
     emits_mouse_buttons: Cell<bool>,
     input_devices: Option<Vec<(std::num::NonZeroU8, InputDeviceMatcher)>>,
+    gamepad: Option<crate::gamepad::GamepadConfig>,
     pctx: ParserContext,
     pub lsp_hints: RefCell<LspHints>,
     hand_map: Option<&'static custom_tap_hold::HandMap>,
@@ -1222,6 +1271,7 @@ impl Default for ParserState {
             multi_action_nest_count: Cell::new(0),
             emits_mouse_buttons: Cell::new(false),
             input_devices: None,
+            gamepad: None,
             lsp_hints: Default::default(),
             hand_map: None,
             a: unsafe { Allocations::new() },
@@ -1493,6 +1543,11 @@ fn parse_action_atom(ac_span: &Spanned<String>, s: &ParserState) -> Result<&'sta
         _ => {}
     };
     if let Some(oscode) = str_to_oscode(ac) {
+        // Same rule as mvmt: a controller control names a physical input on a
+        // pad, and no OS can be asked to emit one.
+        if oscode.is_gamepad_code() {
+            bail_span!(ac_span, "{ac} can only be used as an input")
+        }
         if matches!(ac, "comp" | "cmp") {
             log::warn!(
                 "comp/cmp/cmps is not actually a compose key even though its correpsonding code is KEY_COMPOSE. Its actual functionality is context menu which somewhat behaves like right-click.\nTo remove this warning, replace this usage with an equivalent key name such as: menu"
@@ -1556,6 +1611,9 @@ fn parse_action_atom(ac_span: &Spanned<String>, s: &ParserState) -> Result<&'sta
     );
     if keys.contains(&KEY_OVERLAP) {
         bail!("O- is only valid in sequences for lists of keys");
+    }
+    if OsCode::from(keys[keys.len() - 1]).is_gamepad_code() {
+        bail_span!(ac_span, "{unparsed_str} can only be used as an input")
     }
     Ok(s.a.sref(Action::MultipleKeyCodes(s.a.sref(s.a.sref_vec(keys)))))
 }

--- a/parser/src/cfg/override.rs
+++ b/parser/src/cfg/override.rs
@@ -54,6 +54,12 @@ pub(crate) fn parse_override_inout_keys(
                     .ok_or_else(|| {
                         anyhow_expr!(key_expr, "Unknown output key name, must use known keys")
                     })?;
+                // The same rule every other output position enforces: a
+                // controller control names a physical input on a pad, and no
+                // OS can be asked to emit one.
+                if key.is_gamepad_code() {
+                    bail_expr!(key_expr, "{key} can only be used as an input");
+                }
                 keys.push(key);
                 Ok(keys)
             })?;

--- a/parser/src/cfg/tests.rs
+++ b/parser/src/cfg/tests.rs
@@ -7,6 +7,7 @@ use std::sync::{Mutex, MutexGuard};
 
 mod ambiguous;
 mod defcfg;
+mod defgamepad;
 mod defhands;
 mod device_detect;
 mod environment;

--- a/parser/src/cfg/tests/defcfg.rs
+++ b/parser/src/cfg/tests/defcfg.rs
@@ -311,3 +311,33 @@ fn per_action_require_prior_idle_on_tap_hold_release_tap_keys_release() {
         .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
         .expect("passes");
 }
+
+#[test]
+fn gamepad_controls_are_never_swept_in() {
+    // A controller is a separate device the user opts into with defsrc, so
+    // `process-unmapped-keys` must claim only the controls defsrc names.
+    let source = "
+(defcfg process-unmapped-keys yes)
+(defsrc pad-a)
+(deflayer base x)
+";
+    let cfg = parse_cfg(source)
+        .map_err(|e| eprintln!("{:?}", miette::Error::from(e)))
+        .expect("passes");
+    let claimed: Vec<_> = cfg
+        .mapped_keys
+        .iter()
+        .filter(|osc| osc.is_gamepad_code())
+        .collect();
+    assert_eq!(claimed, vec![&OsCode::PAD_SOUTH], "swept in {claimed:?}");
+
+    // The mechanism that makes that true: no synthetic code decodes as an OS
+    // scancode, on any platform mapping. A future table that broke this would
+    // put every controller control into every defsrc.
+    for code in OsCode::PAD_SOUTH as u16..OsCode::OSCODE_MAX as u16 {
+        assert!(
+            OsCode::from_u16(code).is_none(),
+            "{code} decodes as an OS scancode"
+        );
+    }
+}

--- a/parser/src/cfg/tests/defgamepad.rs
+++ b/parser/src/cfg/tests/defgamepad.rs
@@ -84,6 +84,7 @@ fn buttons_and_the_dpad_need_no_declaration_at_all() {
     // A trigger with nothing said about it must still actuate, at the early
     // point people expect from a trigger.
     assert_eq!(empty.trigger(Side::Right).threshold, Unit::new(0.30));
+    assert_eq!(empty.trigger(Side::Right).debounce, 0);
 }
 
 #[test]
@@ -91,15 +92,16 @@ fn a_full_declaration_round_trips() {
     let cfg = ok(
         "",
         "(defgamepad
-           (stick left  (digital (mode 8way) (threshold 0.60)))
+           (stick left  (digital (mode 8way) (threshold 0.60) (debounce 8)))
            (stick right (mouse (deadzone 0.20) (speed 40) (curve quadratic) (invert-y no)))
            (dpad (digital (socd neutral)))
-           (trigger left  (threshold 0.10))
+           (trigger left  (threshold 0.10) (debounce 12))
            (button-slot 0 0x2c0))",
     );
     let left = digital(&cfg, Directional::LeftStick);
     assert_eq!(left.mode, DirMode::EightWay);
     assert_eq!(left.threshold, Unit::new(0.60));
+    assert_eq!(left.debounce, 8);
 
     let (kind, right) = motion(&cfg, Directional::RightStick);
     assert_eq!(
@@ -114,9 +116,11 @@ fn a_full_declaration_round_trips() {
 
     assert_eq!(digital(&cfg, Directional::Dpad).socd, Socd::Neutral);
     assert_eq!(cfg.trigger(Side::Left).threshold, Unit::new(0.10));
+    assert_eq!(cfg.trigger(Side::Left).debounce, 12);
     assert_eq!(cfg.slots[0], Some(0x2c0));
     // What was not mentioned keeps its defaults.
     assert_eq!(cfg.trigger(Side::Right).threshold, Unit::new(0.30));
+    assert_eq!(cfg.trigger(Side::Right).debounce, 0);
 }
 
 #[test]
@@ -248,6 +252,25 @@ fn thresholds_have_one_value_and_reject_the_old_two_value_spelling() {
     // reach kanata, so a press point would be a knob that did nothing.
     let dpad = err("", "(defgamepad (dpad (digital (threshold 0.5))))");
     assert!(dpad.contains("no threshold"), "{dpad}");
+}
+
+#[test]
+fn debounce_is_one_optional_millisecond_duration_for_analog_controls() {
+    let cfg = ok(
+        "",
+        "(defgamepad (stick left (digital (debounce 8))) (trigger right (debounce 12)))",
+    );
+    assert_eq!(digital(&cfg, Directional::LeftStick).debounce, 8);
+    assert_eq!(cfg.trigger(Side::Right).debounce, 12);
+
+    for declaration in [
+        "(defgamepad (dpad (digital (debounce 8))))",
+        "(defgamepad (stick left (digital (debounce -1))))",
+        "(defgamepad (trigger left (debounce 65536)))",
+    ] {
+        let message = err("", declaration);
+        assert!(message.contains("debounce"), "{declaration} gave {message}");
+    }
 }
 
 #[test]

--- a/parser/src/cfg/tests/defgamepad.rs
+++ b/parser/src/cfg/tests/defgamepad.rs
@@ -250,3 +250,254 @@ fn thresholds_have_one_value_and_reject_the_old_two_value_spelling() {
     assert!(dpad.contains("no threshold"), "{dpad}");
 }
 
+#[test]
+fn out_of_range_numbers_are_rejected_rather_than_clamped() {
+    // In a config an out-of-range value is always a typo, and reading
+    // `(deadzone 15)` as `1.0` would leave a stick that never responds.
+    for (declaration, expected) in [
+        (
+            "(defgamepad (stick left (mouse (deadzone 15))))",
+            "between 0 and 1",
+        ),
+        (
+            "(defgamepad (stick left (mouse (speed 100001))))",
+            "between 0 and 100000",
+        ),
+        (
+            "(defgamepad (stick left (digital (threshold 2))))",
+            "between 0 and 1",
+        ),
+        (
+            "(defgamepad (stick left (mouse (speed nope))))",
+            "expected a number",
+        ),
+    ] {
+        let message = err("", declaration);
+        assert!(message.contains(expected), "{declaration} gave {message}");
+    }
+}
+
+#[test]
+fn duplicate_declarations_are_rejected() {
+    // Letting the second one quietly win makes a typo look like it worked.
+    for declaration in [
+        "(defgamepad (stick left (digital)) (stick left (mouse)))",
+        "(defgamepad (trigger right (threshold 0.4)) (trigger right (threshold 0.5)))",
+        "(defgamepad (dpad (digital)) (dpad (digital)))",
+        "(defgamepad (device 1) (device 1))",
+    ] {
+        assert!(err("", declaration).contains("duplicate"), "{declaration}");
+    }
+    // But the two sides of one control are not duplicates.
+    ok(
+        "",
+        "(defgamepad (stick left (digital)) (stick right (digital)))",
+    );
+    let two = err("", "(defgamepad) (defgamepad (dpad off))");
+    assert!(two.contains("Only one defgamepad"), "{two}");
+}
+
+#[test]
+fn unknown_names_are_reported_with_the_valid_set() {
+    for (declaration, expected) in [
+        ("(defgamepad (wobble left))", "unknown defgamepad item"),
+        ("(defgamepad (stick middle (digital)))", "unknown side"),
+        ("(defgamepad (stick left (wiggle)))", "unknown projection"),
+        (
+            "(defgamepad (stick left (digital (mode 6way))))",
+            "unknown mode",
+        ),
+        (
+            "(defgamepad (dpad (digital (socd sometimes))))",
+            "unknown socd mode",
+        ),
+        (
+            "(defgamepad (stick left (mouse (curve sigmoid))))",
+            "unknown curve",
+        ),
+        (
+            "(defgamepad (stick left (mouse (spede 3))))",
+            "unknown mouse option",
+        ),
+        // An unknown option is reported as one, rather than as an arity error
+        // about a name that means nothing here.
+        (
+            "(defgamepad (stick left (mouse (spede 3 4))))",
+            "unknown mouse option",
+        ),
+        (
+            "(defgamepad (stick left (digital (jitter 3))))",
+            "unknown digital option",
+        ),
+        (
+            "(defgamepad (trigger left (wobble 3)))",
+            "unknown trigger option",
+        ),
+    ] {
+        let message = err("", declaration);
+        assert!(message.contains(expected), "{declaration} gave {message}");
+    }
+    // And an unknown value lists what would have worked.
+    let listed = err("", "(defgamepad (stick left (mouse (curve sigmoid))))");
+    assert!(listed.contains("linear, quadratic, cubic"), "{listed}");
+}
+
+#[test]
+fn mapping_a_direction_without_a_projection_says_what_would_fix_it() {
+    // These are the failures that otherwise present as "kanata runs, my
+    // controller does nothing".
+    let message = err("pad-lstick-up", "(defgamepad)");
+    assert!(message.contains("no digital projection"), "{message}");
+    assert!(message.contains("(stick left (digital))"), "{message}");
+
+    // Motion alone is not a digital projection: a mouse stick presses nothing.
+    let motion_only = err("pad-rstick-up", "(defgamepad (stick right (mouse)))");
+    assert!(
+        motion_only.contains("no digital projection"),
+        "{motion_only}"
+    );
+    // Adding the digital half makes it legal, on the same stick.
+    ok(
+        "pad-rstick-up",
+        "(defgamepad (stick right (mouse) (digital)))",
+    );
+    // And declaring the left stick must not excuse a mapped right-stick
+    // direction.
+    let other = err("pad-rstick-up", "(defgamepad (stick left (digital)))");
+    assert!(other.contains("right stick"), "{other}");
+}
+
+#[test]
+fn four_way_mode_rejects_a_mapped_diagonal_and_eight_way_accepts_both() {
+    let message = err(
+        "pad-lstick-upleft",
+        "(defgamepad (stick left (digital (mode 4way))))",
+    );
+    assert!(
+        message.contains("4way") && message.contains("(mode 8way)"),
+        "{message}"
+    );
+    ok(
+        "pad-lstick-upleft pad-lstick-up",
+        "(defgamepad (stick left (digital (mode 8way))))",
+    );
+    // The same rule reaches the d-pad, which is the point of sharing a type.
+    let dpad = err("pad-dpad-upleft", "(defgamepad)");
+    assert!(dpad.contains("4way"), "{dpad}");
+    ok(
+        "pad-dpad-upleft",
+        "(defgamepad (dpad (digital (mode 8way))))",
+    );
+}
+
+#[test]
+fn slots_must_be_bound_and_unique() {
+    let unbound = err("pad-button-0", "(defgamepad)");
+    assert!(unbound.contains("(button-slot 0"), "{unbound}");
+    assert_eq!(
+        ok("pad-button-0", "(defgamepad (button-slot 0 0x2c1))").slots[0],
+        Some(0x2c1)
+    );
+    assert_eq!(
+        ok("", "(defgamepad (button-slot 0 705))").slots[0],
+        Some(705)
+    );
+
+    for (declaration, expected) in [
+        (
+            "(defgamepad (button-slot 0 1) (button-slot 0 2))",
+            "duplicate button-slot",
+        ),
+        (
+            "(defgamepad (button-slot 0 1) (button-slot 1 1))",
+            "already bound",
+        ),
+        ("(defgamepad (button-slot 99 1))", "slot index must be 0-15"),
+        ("(defgamepad (button-slot 0))", "button-slot takes"),
+    ] {
+        let message = err("", declaration);
+        assert!(message.contains(expected), "{declaration} gave {message}");
+    }
+}
+
+#[test]
+fn a_device_reference_must_match_definputdevices() {
+    let _lk = lock(&CFG_PARSE_LOCK);
+    let with_devices = |id: &str| {
+        format!(
+            "(defcfg process-unmapped-keys no)
+             (definputdevices 1 ((name \"DualSense\")))
+             (defsrc a) (deflayer base a)
+             (defgamepad (device {id}))"
+        )
+    };
+    assert!(new_from_str(&with_devices("1"), HashMap::default()).is_ok());
+    let message = match new_from_str(&with_devices("2"), HashMap::default()) {
+        Ok(_) => panic!("an undeclared device ID should be rejected"),
+        Err(e) => flatten(&e),
+    };
+    assert!(
+        message.contains("definputdevices has no entry"),
+        "{message}"
+    );
+}
+
+#[test]
+fn digital_values_can_be_written_as_variables() {
+    // defgamepad is parsed after defvar, so this has to work.
+    let cfg = ok(
+        "",
+        "(defvar threshold 0.75 curve linear)
+         (defgamepad (stick left (digital (threshold $threshold)) (mouse (curve $curve))))",
+    );
+    assert_eq!(
+        digital(&cfg, Directional::LeftStick).threshold,
+        Unit::new(0.75)
+    );
+    assert_eq!(motion(&cfg, Directional::LeftStick).1.curve, Curve::Linear);
+}
+
+#[test]
+fn every_reserved_code_is_named_and_input_only() {
+    // The reserved range and the name table are written separately, so a code
+    // with no spelling would be a layout slot nothing could ever occupy. And
+    // no OS can be asked to emit one, so an output position must be refused.
+    let _lk = lock(&CFG_PARSE_LOCK);
+    for index in 0..OsCode::GAMEPAD_COUNT {
+        let osc = OsCode::from_gamepad_index(index).expect("in range");
+        let name = format!("{osc:?}").to_lowercase().replace('_', "-");
+        assert_eq!(str_to_oscode(&name), Some(osc), "{osc} has no name");
+    }
+    for output in ["pad-a", "C-pad-a", "(macro pad-a)", "(unmod pad-a)"] {
+        let src = format!("(defcfg process-unmapped-keys no) (defsrc a) (deflayer base {output})");
+        let message = match new_from_str(&src, HashMap::default()) {
+            Ok(_) => panic!("{output} should be rejected as an output"),
+            Err(e) => flatten(&e),
+        };
+        assert!(
+            message.contains("can only be used as an input"),
+            "{message}"
+        );
+    }
+}
+
+#[test]
+fn pad_names_accept_their_vendor_aliases() {
+    // One positional control, several spellings, so a config written for a
+    // DualSense reads on an Xbox pad.
+    for (canonical, alias) in [
+        ("pad-south", "pad-cross"),
+        ("pad-south", "pad-a"),
+        ("pad-l1", "pad-lb"),
+        ("pad-select", "pad-share"),
+        ("pad-lstick-up", "pad-ls-up"),
+        ("pad-dpad-left", "pad-left"),
+        ("pad-button-3", "pb3"),
+    ] {
+        assert_eq!(
+            str_to_oscode(canonical),
+            str_to_oscode(alias),
+            "{canonical} and {alias} should be one control"
+        );
+    }
+}

--- a/parser/src/cfg/tests/defgamepad.rs
+++ b/parser/src/cfg/tests/defgamepad.rs
@@ -1,0 +1,252 @@
+use super::*;
+
+use crate::gamepad::{
+    Cardinal, Curve, Digital, DirMode, Directional, GamepadConfig, Motion, MotionKind, Projection,
+    Side, Socd, Unit,
+};
+
+/// Parse a configuration and return its `defgamepad` result.
+///
+/// Wraps the declaration in the minimum surrounding config, so each test reads
+/// as just the thing it is about.
+fn gamepad_of(extra_src: &str, declaration: &str) -> MResult<crate::cfg::Cfg> {
+    let _lk = lock(&CFG_PARSE_LOCK);
+    let src = format!(
+        "(defcfg process-unmapped-keys no)
+         (defsrc a {extra_src})
+         (deflayer base a {})
+         {declaration}",
+        vec!["XX"; extra_src.split_whitespace().count()].join(" ")
+    );
+    new_from_str(&src, HashMap::default())
+}
+
+fn ok(extra_src: &str, declaration: &str) -> GamepadConfig {
+    gamepad_of(extra_src, declaration)
+        .unwrap_or_else(|e| panic!("expected the config to parse, got: {e:?}"))
+        .gamepad
+        .expect("defgamepad should be retained on Cfg")
+}
+
+fn err(extra_src: &str, declaration: &str) -> String {
+    match gamepad_of(extra_src, declaration) {
+        Ok(_) => panic!("expected this config to be rejected:\n{declaration}"),
+        Err(e) => flatten(&e),
+    }
+}
+
+/// An error message with its whitespace collapsed, so a test can quote it
+/// without depending on where the renderer happened to wrap the line.
+fn flatten(e: &impl std::fmt::Debug) -> String {
+    format!("{e:?}")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn digital(cfg: &GamepadConfig, control: Directional) -> Digital {
+    cfg.projection(control)
+        .digital
+        .unwrap_or_else(|| panic!("expected the {} to be digital", control.as_str()))
+}
+
+fn motion(cfg: &GamepadConfig, control: Directional) -> (MotionKind, Motion) {
+    for kind in MotionKind::ALL {
+        if let Some(motion) = cfg.projection(control).motions.get(kind) {
+            return (kind, motion);
+        }
+    }
+    panic!("expected the {} to drive motion", control.as_str())
+}
+
+#[test]
+fn buttons_and_the_dpad_need_no_declaration_at_all() {
+    // Nothing about a button or a d-pad contact has to be decided before it
+    // can press a key, so requiring a declaration would be ceremony.
+    let cfg = gamepad_of("pad-a pad-l2 pad-dpad-up", "").expect("parses");
+    assert_eq!(
+        cfg.gamepad,
+        Some(GamepadConfig::default()),
+        "mapped portable controls must start the backend"
+    );
+
+    let keyboard_only = gamepad_of("", "").expect("parses");
+    assert_eq!(
+        keyboard_only.gamepad, None,
+        "a keyboard-only config must not open controller devices"
+    );
+
+    let empty = ok("pad-dpad-up", "(defgamepad)");
+    assert_eq!(empty, GamepadConfig::default());
+    assert!(empty.projection(Directional::Dpad).digital.is_some());
+    assert_eq!(empty.projection(Directional::LeftStick), &Projection::OFF);
+    assert!(empty.slots.iter().all(Option::is_none));
+    // A trigger with nothing said about it must still actuate, at the early
+    // point people expect from a trigger.
+    assert_eq!(empty.trigger(Side::Right).threshold, Unit::new(0.30));
+}
+
+#[test]
+fn a_full_declaration_round_trips() {
+    let cfg = ok(
+        "",
+        "(defgamepad
+           (stick left  (digital (mode 8way) (threshold 0.60)))
+           (stick right (mouse (deadzone 0.20) (speed 40) (curve quadratic) (invert-y no)))
+           (dpad (digital (socd neutral)))
+           (trigger left  (threshold 0.10))
+           (button-slot 0 0x2c0))",
+    );
+    let left = digital(&cfg, Directional::LeftStick);
+    assert_eq!(left.mode, DirMode::EightWay);
+    assert_eq!(left.threshold, Unit::new(0.60));
+
+    let (kind, right) = motion(&cfg, Directional::RightStick);
+    assert_eq!(
+        (kind, right.speed, right.curve),
+        (MotionKind::Mouse, 40.0, Curve::Quadratic)
+    );
+    assert_eq!(right.deadzone, Unit::new(0.20));
+    assert_eq!(
+        right.invert.y, 1.0,
+        "(invert-y no) undoes the mouse default"
+    );
+
+    assert_eq!(digital(&cfg, Directional::Dpad).socd, Socd::Neutral);
+    assert_eq!(cfg.trigger(Side::Left).threshold, Unit::new(0.10));
+    assert_eq!(cfg.slots[0], Some(0x2c0));
+    // What was not mentioned keeps its defaults.
+    assert_eq!(cfg.trigger(Side::Right).threshold, Unit::new(0.30));
+}
+
+#[test]
+fn directional_controls_share_projection_modes_but_only_contacts_have_socd() {
+    // The d-pad is a stick that only knows nine positions, so projection mode
+    // is shared by all three. SOCD is intentionally narrower: only independent
+    // contacts can report opposites simultaneously.
+    for (item, control) in [
+        ("(stick left (digital ", Directional::LeftStick),
+        ("(stick right (digital ", Directional::RightStick),
+        ("(dpad (digital ", Directional::Dpad),
+    ] {
+        let cfg = ok("", &format!("(defgamepad {item}(mode 8way))))"));
+        assert_eq!(digital(&cfg, control).mode, DirMode::EightWay, "{item}");
+    }
+    let cfg = ok("", "(defgamepad (dpad (digital (socd last))))");
+    assert_eq!(digital(&cfg, Directional::Dpad).socd, Socd::Last);
+    let message = err("", "(defgamepad (stick left (digital (socd last))))");
+    assert!(message.contains("socd belongs to the d-pad"), "{message}");
+}
+
+#[test]
+fn a_control_can_press_keys_and_drive_motion_at_once() {
+    let cfg = ok(
+        "",
+        "(defgamepad (stick right (digital (mode 4way)) (mouse (speed 12))))",
+    );
+    assert_eq!(
+        digital(&cfg, Directional::RightStick).mode,
+        DirMode::FourWay
+    );
+    assert_eq!(motion(&cfg, Directional::RightStick).1.speed, 12.0);
+
+    // For the d-pad that means adding a wheel must not take away the keys it
+    // presses with no declaration at all. `off` is how you silence it.
+    let dpad = ok("", "(defgamepad (dpad (scroll (speed 2))))");
+    assert!(dpad.projection(Directional::Dpad).digital.is_some());
+    assert_eq!(motion(&dpad, Directional::Dpad).0, MotionKind::Scroll);
+    let silent = ok("", "(defgamepad (dpad off))");
+    assert_eq!(silent.projection(Directional::Dpad), &Projection::OFF);
+}
+
+#[test]
+fn mouse_and_scroll_are_independent_projections() {
+    let cfg = ok(
+        "",
+        "(defgamepad
+           (stick right (mouse (speed 1200)) (scroll (speed 30)))
+           (trigger left
+             (mouse right (speed 800))
+             (scroll down (speed 20))))",
+    );
+    let stick = cfg.projection(Directional::RightStick);
+    assert_eq!(stick.motions.get(MotionKind::Mouse).unwrap().speed, 1200.0);
+    assert_eq!(stick.motions.get(MotionKind::Scroll).unwrap().speed, 30.0);
+    let trigger = cfg.trigger(Side::Left);
+    assert_eq!(
+        trigger.motions.get(MotionKind::Mouse).unwrap().direction,
+        Cardinal::Right
+    );
+    assert_eq!(
+        trigger.motions.get(MotionKind::Scroll).unwrap().direction,
+        Cardinal::Down
+    );
+
+    for declaration in [
+        "(defgamepad (stick left (mouse) (mouse)))",
+        "(defgamepad (trigger right (scroll up) (scroll down)))",
+    ] {
+        let message = err("", declaration);
+        assert!(
+            message.contains("duplicate"),
+            "{declaration} gave {message}"
+        );
+    }
+}
+
+#[test]
+fn a_trigger_can_drive_the_wheel_in_a_named_direction() {
+    let cfg = ok(
+        "",
+        "(defgamepad (trigger right (scroll down (speed 4) (curve linear))))",
+    );
+    let projected = cfg
+        .trigger(Side::Right)
+        .motions
+        .get(MotionKind::Scroll)
+        .expect("declared");
+    assert_eq!(
+        (projected.direction, projected.motion.speed),
+        (Cardinal::Down, 4.0)
+    );
+    // The band survives alongside it: a trigger still presses pad-r2.
+    assert_eq!(cfg.trigger(Side::Right).threshold, Unit::new(0.30));
+
+    // A trigger is one number, not a vector, so the direction is required.
+    let missing = err("", "(defgamepad (trigger right (scroll (speed 4))))");
+    assert!(missing.contains("needs a direction"), "{missing}");
+    let unknown = err("", "(defgamepad (trigger right (scroll sideways)))");
+    assert!(unknown.contains("unknown direction"), "{unknown}");
+}
+
+#[test]
+fn thresholds_have_one_value_and_reject_the_old_two_value_spelling() {
+    let cfg = ok(
+        "",
+        "(defgamepad (stick left (digital (threshold 0.9))) (trigger left (threshold 0.05)))",
+    );
+    assert_eq!(
+        digital(&cfg, Directional::LeftStick).threshold,
+        Unit::new(0.9)
+    );
+    assert_eq!(cfg.trigger(Side::Left).threshold, Unit::new(0.05));
+
+    for declaration in [
+        "(defgamepad (stick left (digital (press 0.5))))",
+        "(defgamepad (stick left (digital (release 0.5))))",
+        "(defgamepad (trigger right (press 0.2)))",
+        "(defgamepad (trigger right (release 0.2)))",
+    ] {
+        let message = err("", declaration);
+        assert!(
+            message.contains("threshold"),
+            "{declaration} gave {message}"
+        );
+    }
+
+    // A d-pad has no threshold to set: its contacts are digital before they
+    // reach kanata, so a press point would be a knob that did nothing.
+    let dpad = err("", "(defgamepad (dpad (digital (threshold 0.5))))");
+    assert!(dpad.contains("no threshold"), "{dpad}");
+}
+

--- a/parser/src/cfg/unmod.rs
+++ b/parser/src/cfg/unmod.rs
@@ -65,18 +65,22 @@ pub(crate) fn parse_unmod(
     }
 
     let keys: Vec<KeyCode> = params.iter().try_fold(Vec::new(), |mut keys, param| {
-        keys.push(
-            param
-                .atom(s.vars())
-                .and_then(str_to_oscode)
-                .ok_or_else(|| {
-                    anyhow_expr!(
-                        &ac_params[0],
-                        "{unmod_type} {ERR_MSG}\nfound invalid key name"
-                    )
-                })?
-                .into(),
-        );
+        let osc = param
+            .atom(s.vars())
+            .and_then(str_to_oscode)
+            .ok_or_else(|| {
+                anyhow_expr!(
+                    &ac_params[0],
+                    "{unmod_type} {ERR_MSG}\nfound invalid key name"
+                )
+            })?;
+        // These keys are appended to the output list directly rather than
+        // going through an action, so the check `parse_action_atom` makes for
+        // every other output position has to be repeated here.
+        if osc.is_gamepad_code() || osc == OsCode::KEY_766 {
+            bail_expr!(param, "{osc} can only be used as an input");
+        }
+        keys.push(osc.into());
         Ok::<_, ParseError>(keys)
     })?;
     let keys = s.a.sref_vec(keys);

--- a/parser/src/gamepad/analog.rs
+++ b/parser/src/gamepad/analog.rs
@@ -346,3 +346,183 @@ impl Add for Demand {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(x: f32, y: f32) -> Vec2 {
+        Vec2 { x, y }
+    }
+
+    fn plain(speed: f32) -> Motion {
+        Motion {
+            deadzone: Unit::ZERO,
+            speed: speed * 1000.0,
+            curve: Curve::Linear,
+            invert: Vec2::KEEP,
+        }
+    }
+
+    #[test]
+    fn garbage_readings_are_clamped_or_read_as_at_rest() {
+        // Hardware overshoots its own range, and a disconnecting controller
+        // reports NaN. Treating NaN as full deflection would jam a direction
+        // on; letting it reach the deadzone rescale would poison the result.
+        assert_eq!(Unit::new(1.4), Unit::ONE);
+        assert_eq!(Unit::new(-0.2), Unit::ZERO);
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert_eq!(Unit::new(bad), Unit::ZERO);
+        }
+        assert_eq!(AxisValue::new(1.4).get(), 1.0);
+        assert_eq!(AxisValue::new(-1.4).get(), -1.0);
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert_eq!(AxisValue::new(bad), AxisValue::ZERO);
+        }
+        assert_eq!(StickPosition::new(2.0, f32::NAN).vector(), v(1.0, 0.0));
+        for bad in [v(f32::NAN, 0.0), v(0.0, f32::NAN), v(f32::NAN, f32::NAN)] {
+            assert_eq!(Motion::MOUSE.displace(bad), Vec2::ZERO, "{bad:?}");
+        }
+        for bad_speed in [f32::NAN, f32::INFINITY, -1.0] {
+            assert_eq!(
+                Motion {
+                    speed: bad_speed,
+                    ..Motion::MOUSE
+                }
+                .displace(v(1.0, 0.0)),
+                Vec2::ZERO
+            );
+        }
+    }
+
+    #[test]
+    fn the_deadzone_silences_the_center_without_a_jump_at_its_edge() {
+        let dz = Motion {
+            deadzone: Unit::new(0.15),
+            ..plain(1.0)
+        };
+        for inside in [v(0.0, 0.0), v(0.10, 0.0), v(0.10, 0.10), v(-0.14, 0.0)] {
+            assert_eq!(dz.displace(inside), Vec2::ZERO, "{inside:?}");
+        }
+        // Just past the edge is near zero, not near 0.15, and full deflection
+        // survives unattenuated.
+        assert!(dz.displace(v(0.16, 0.0)).x < 0.02);
+        assert!((dz.displace(v(1.0, 0.0)).x - 1.0).abs() < 1e-6);
+        // A deadzone of one silences the control instead of dividing by zero.
+        let all = Motion {
+            deadzone: Unit::ONE,
+            ..plain(1.0)
+        };
+        assert_eq!(all.displace(v(1.0, 1.0)), Vec2::ZERO);
+    }
+
+    #[test]
+    fn a_diagonal_keeps_its_direction_and_does_not_outrun_a_cardinal() {
+        // A hardware corner reads (1, 1), a radius of 1.41. Left alone that
+        // makes a diagonal 41% faster than a straight push.
+        let m = plain(10.0);
+        assert!((m.displace(v(1.0, 0.0)).x - 10.0).abs() < 1e-4);
+        for corner in [v(1.0, 1.0), v(-1.0, 1.0), v(1.0, -1.0)] {
+            let out = m.displace(corner);
+            assert!((out.radius() - 10.0).abs() < 1e-3, "{corner:?} -> {out:?}");
+            assert!((out.x.abs() - out.y.abs()).abs() < 1e-4, "off the diagonal");
+        }
+    }
+
+    #[test]
+    fn the_curve_applies_to_the_magnitude_not_to_each_axis() {
+        // Curving the axes independently would bend a diagonal toward an axis.
+        let cubic = Motion {
+            curve: Curve::Cubic,
+            ..plain(100.0)
+        };
+        let s = std::f32::consts::FRAC_1_SQRT_2 * 0.5;
+        let out = cubic.displace(v(s, s));
+        assert!((out.x - out.y).abs() < 1e-4, "{out:?}");
+        // magnitude 0.5, cubed to 0.125, times 100 units per tick.
+        assert!((out.radius() - 12.5).abs() < 1e-2, "{out:?}");
+        // Steeper curves give finer control near center, and every curve fixes
+        // the endpoints.
+        let half = Unit::new(0.5);
+        assert!(Curve::Cubic.apply(half) < Curve::Quadratic.apply(half));
+        assert!(Curve::Quadratic.apply(half) < Curve::Linear.apply(half));
+        for curve in [Curve::Linear, Curve::Quadratic, Curve::Cubic] {
+            assert_eq!(curve.apply(Unit::ZERO), Unit::ZERO, "{curve:?}");
+            assert_eq!(curve.apply(Unit::ONE), Unit::ONE, "{curve:?}");
+        }
+    }
+
+    #[test]
+    fn inversion_flips_only_the_requested_axis() {
+        assert!(
+            Motion::MOUSE.displace(v(0.0, 1.0)).y < 0.0,
+            "push away moves the pointer up the screen"
+        );
+        assert!(
+            Motion::SCROLL.displace(v(0.0, 1.0)).y > 0.0,
+            "push away scrolls up"
+        );
+        assert_eq!(Motion::MOUSE.invert.x, 1.0, "x is not flipped by default");
+    }
+
+    #[test]
+    fn a_scalar_control_gets_the_same_response_as_an_axis() {
+        // A trigger is one number, but the deadzone, curve and speed have to
+        // mean the same thing there as on a stick.
+        let m = Motion {
+            curve: Curve::Quadratic,
+            ..plain(8.0)
+        };
+        assert_eq!(m.rate(0.0), 0.0);
+        assert!((m.rate(0.5) - 2.0).abs() < 1e-4, "{}", m.rate(0.5));
+        assert!((m.displace(v(1.0, 0.0)).x - m.rate(1.0)).abs() < 1e-4);
+    }
+
+    #[test]
+    fn a_threshold_is_strict_at_its_boundary() {
+        let threshold = Unit::new(0.5);
+        assert!(!(Unit::new(0.49) > threshold));
+        assert!(!(Unit::new(0.50) > threshold));
+        assert!(Unit::new(0.51) > threshold);
+    }
+
+    #[test]
+    fn demands_sum_per_output_and_report_idleness() {
+        let mut a = Demand::default();
+        assert!(a.is_idle());
+        a[MotionKind::Mouse] = v(1.0, 2.0);
+        let mut b = Demand::default();
+        b[MotionKind::Mouse] = v(-1.0, 0.5);
+        b[MotionKind::Scroll] = v(0.0, 3.0);
+        assert!(!a.is_idle());
+        let sum = a + b;
+        assert_eq!(sum[MotionKind::Mouse], v(0.0, 2.5));
+        assert_eq!(sum[MotionKind::Scroll], v(0.0, 3.0));
+    }
+
+    #[test]
+    fn whole_units_accumulate_exactly_across_ticks() {
+        // Rounding each tick independently would make a 7.5 px/ms demand run
+        // permanently 7% slow or 25% fast, and a demand below one unit would
+        // round to nothing forever.
+        let mut carry = Vec2::ZERO;
+        let total: i32 = (0..1000)
+            .map(|_| {
+                carry += v(7.5, 0.0);
+                carry.take_whole().0
+            })
+            .sum();
+        assert_eq!(total, 7500);
+
+        // The two axes carry separately: a fast horizontal push must not drag
+        // the vertical axis along with it.
+        let mut slow = Vec2::ZERO;
+        let crawl: i32 = (0..10)
+            .map(|_| {
+                slow += v(0.25, -0.25);
+                slow.take_whole().0
+            })
+            .sum();
+        assert_eq!(crawl, 2, "0.25 a tick over 10 ticks is 2.5 pixels");
+        assert_eq!(slow.take_whole(), (0, 0));
+    }
+}

--- a/parser/src/gamepad/analog.rs
+++ b/parser/src/gamepad/analog.rs
@@ -1,0 +1,348 @@
+//! Analog values and the transformations that turn them into digital edges
+//! and continuous motion. Everything here is total and hardware-free.
+//!
+//! Two conventions are fixed once, so no call site has to remember them: **y
+//! is up-positive**, converted at the backend boundary, and **values are
+//! clamped, never rejected**, because hardware overshoots its own reported
+//! range and refusing such a reading would drop real input.
+
+use core::ops::{Add, AddAssign, Index, IndexMut, Mul};
+
+/// A magnitude in `[0.0, 1.0]`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
+pub struct Unit(f32);
+
+impl Unit {
+    pub const ZERO: Unit = Unit(0.0);
+    pub const ONE: Unit = Unit(1.0);
+
+    /// Clamp a raw reading into the unit interval. Non-finite values become
+    /// zero: a controller reporting garbage should read as at rest, not as
+    /// fully deflected.
+    pub fn new(value: f32) -> Unit {
+        match value.is_finite() {
+            true => Unit(value.clamp(0.0, 1.0)),
+            false => Unit::ZERO,
+        }
+    }
+
+    pub const fn get(self) -> f32 {
+        self.0
+    }
+}
+
+/// A normalized signed axis reading in `[-1.0, 1.0]`.
+///
+/// Hardware values enter through this constructor, so the projector cannot
+/// represent an infinite, NaN, or out-of-range stick position. Non-finite
+/// readings mean centered: unlike a large finite overshoot, they carry no
+/// recoverable direction.
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
+pub struct AxisValue(f32);
+
+impl AxisValue {
+    pub const ZERO: AxisValue = AxisValue(0.0);
+
+    pub fn new(value: f32) -> AxisValue {
+        match value.is_finite() {
+            true => AxisValue(value.clamp(-1.0, 1.0)),
+            false => AxisValue::ZERO,
+        }
+    }
+
+    pub const fn get(self) -> f32 {
+        self.0
+    }
+}
+
+/// One whole two-axis stick reading, normalized and y-up.
+///
+/// Keeping the pair together avoids exposing transient half-updated diagonals
+/// to projection. [`Vec2`] remains the intentionally unbounded vector used for
+/// rates and displacement; this type is only physical stick position.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct StickPosition {
+    x: AxisValue,
+    y: AxisValue,
+}
+
+impl StickPosition {
+    pub fn new(x: f32, y: f32) -> StickPosition {
+        StickPosition {
+            x: AxisValue::new(x),
+            y: AxisValue::new(y),
+        }
+    }
+
+    pub const fn x(self) -> AxisValue {
+        self.x
+    }
+
+    pub const fn y(self) -> AxisValue {
+        self.y
+    }
+
+    pub const fn vector(self) -> Vec2 {
+        Vec2 {
+            x: self.x.get(),
+            y: self.y.get(),
+        }
+    }
+}
+
+/// A two-axis reading, y-up.
+///
+/// Components are whatever the hardware reported, so the radius of a diagonal
+/// may exceed one until a deadzone normalizes it. Also serves as a
+/// displacement -- pixels or wheel notches -- and as a pair of axis signs.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Vec2 {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Vec2 {
+    pub const ZERO: Vec2 = Vec2 { x: 0.0, y: 0.0 };
+    /// The identity for [`Motion::invert`]: keep both axes as they are.
+    pub const KEEP: Vec2 = Vec2 { x: 1.0, y: 1.0 };
+
+    /// True distance from center, which a hardware corner puts past 1.0.
+    pub fn radius(self) -> f32 {
+        self.x.hypot(self.y)
+    }
+
+    pub fn is_zero(self) -> bool {
+        self.x == 0.0 && self.y == 0.0
+    }
+
+    /// Split into whole units, leaving the fraction in place.
+    ///
+    /// The pointer path carries the remainder between ticks: a stick asking
+    /// for 7.5 pixels a millisecond has to average exactly that, and rounding
+    /// a small demand to zero would make slow movement impossible rather than
+    /// merely slow.
+    pub fn take_whole(&mut self) -> (i32, i32) {
+        // This is the only place a bad reading could become lasting state:
+        // `NaN - NaN` is NaN, so a single poisoned component would leave the
+        // carry NaN and every later take at zero for the rest of the process.
+        // `Motion` already refuses to emit one; this is the backstop.
+        for axis in [&mut self.x, &mut self.y] {
+            if !axis.is_finite() {
+                *axis = 0.0;
+            }
+        }
+        let (x, y) = (self.x.trunc(), self.y.trunc());
+        self.x -= x;
+        self.y -= y;
+        (x as i32, y as i32)
+    }
+}
+
+impl Add for Vec2 {
+    type Output = Vec2;
+    fn add(self, other: Vec2) -> Vec2 {
+        Vec2 {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+}
+
+impl AddAssign for Vec2 {
+    fn add_assign(&mut self, other: Vec2) {
+        *self = *self + other;
+    }
+}
+
+impl Mul<f32> for Vec2 {
+    type Output = Vec2;
+    fn mul(self, scale: f32) -> Vec2 {
+        Vec2 {
+            x: self.x * scale,
+            y: self.y * scale,
+        }
+    }
+}
+
+/// Componentwise, which is what applies per-axis inversion.
+impl Mul<Vec2> for Vec2 {
+    type Output = Vec2;
+    fn mul(self, other: Vec2) -> Vec2 {
+        Vec2 {
+            x: self.x * other.x,
+            y: self.y * other.y,
+        }
+    }
+}
+
+/// The response curve applied to continuous projections.
+///
+/// Digital thresholds are compared *before* any curve, so changing the curve
+/// changes pointer feel without silently moving a press point.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Curve {
+    /// Output tracks deflection directly.
+    Linear,
+    /// Squared: finer control near center.
+    Quadratic,
+    /// Cubed: finest near center, full speed at the rim. The default for
+    /// pointer control, where small corrections matter most.
+    #[default]
+    Cubic,
+}
+
+impl Curve {
+    pub fn apply(self, t: Unit) -> Unit {
+        let t = t.get();
+        Unit::new(match self {
+            Curve::Linear => t,
+            Curve::Quadratic => t * t,
+            Curve::Cubic => t * t * t,
+        })
+    }
+}
+
+/// Which continuous output a projection drives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MotionKind {
+    Mouse,
+    Scroll,
+}
+
+impl MotionKind {
+    pub const ALL: [MotionKind; 2] = [MotionKind::Mouse, MotionKind::Scroll];
+}
+
+/// How a control's deflection becomes pointer or wheel movement.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Motion {
+    /// Radius below which the control reads as at rest. Applied radially
+    /// rather than per-axis: an axial deadzone lets a stick held diagonally at
+    /// low deflection register on one axis but not the other, which produces
+    /// phantom cardinal movement on the way to a diagonal.
+    pub deadzone: Unit,
+    /// Output at full deflection per second: pixels for the pointer, notches
+    /// for the wheel. Converted to the engine's 1 ms tick in [`Motion::rate`].
+    pub speed: f32,
+    pub curve: Curve,
+    /// Per-axis sign. See [`Vec2::KEEP`].
+    pub invert: Vec2,
+}
+
+impl Motion {
+    /// A generous upper bound that still catches an extra zero as a typo.
+    pub const MAX_SPEED: f32 = 100_000.0;
+
+    pub const MOUSE: Motion = Motion {
+        deadzone: Unit(0.15),
+        speed: 1000.0,
+        curve: Curve::Cubic,
+        // Screen coordinates grow downward while a stick's Y grows upward, so
+        // inverting by default makes "push away" mean "move up", which is what
+        // every user expects. `(invert-y no)` restores flight-sim behaviour.
+        invert: Vec2 { x: 1.0, y: -1.0 },
+    };
+
+    pub const SCROLL: Motion = Motion {
+        deadzone: Unit(0.15),
+        speed: 30.0,
+        curve: Curve::Linear,
+        // Stick Y and wheel-up are both up-positive, so no inversion.
+        invert: Vec2::KEEP,
+    };
+
+    pub const fn of(kind: MotionKind) -> Motion {
+        match kind {
+            MotionKind::Mouse => Motion::MOUSE,
+            MotionKind::Scroll => Motion::SCROLL,
+        }
+    }
+
+    /// The output per 1 ms tick a deflection of `magnitude` asks for.
+    ///
+    /// The dead region is removed and what survives is rescaled back to
+    /// `0..=1`, so the first movement past the edge produces the smallest
+    /// possible output instead of jumping straight to the deadzone radius.
+    /// Overshoot past the rim clamps, which is also what stops a stick at a
+    /// hardware corner from outrunning a straight push.
+    pub fn rate(self, magnitude: f32) -> f32 {
+        let dz = self.deadzone.get();
+        // Non-finite readings are spelled out rather than left to the
+        // comparisons below. A disconnecting controller reports NaN, and an
+        // infinite radius would clamp to full deflection and then hit the
+        // `rate / radius` division in `displace`, where `inf * 0.0` is NaN.
+        // They read as at rest rather than as full deflection because no
+        // direction can be recovered from them.
+        if !magnitude.is_finite() || magnitude <= dz || dz >= 1.0 {
+            return 0.0;
+        }
+        let speed = match self.speed.is_finite() {
+            true => self.speed.clamp(0.0, Motion::MAX_SPEED),
+            false => 0.0,
+        };
+        self.curve
+            .apply(Unit::new((magnitude - dz) / (1.0 - dz)))
+            .get()
+            * speed
+            / 1000.0
+    }
+
+    /// A two-axis reading as a per-tick displacement.
+    ///
+    /// The curve applies to the *magnitude* rather than to each axis, so the
+    /// direction the user is pushing survives; curving the axes independently
+    /// would bend a 45-degree push off the diagonal.
+    pub fn displace(self, raw: Vec2) -> Vec2 {
+        let radius = raw.radius();
+        let rate = self.rate(radius);
+        match rate == 0.0 {
+            true => Vec2::ZERO,
+            false => {
+                let displaced = raw * (rate / radius) * self.invert;
+                Vec2 {
+                    x: if displaced.x.is_finite() {
+                        displaced.x
+                    } else {
+                        0.0
+                    },
+                    y: if displaced.y.is_finite() {
+                        displaced.y
+                    } else {
+                        0.0
+                    },
+                }
+            }
+        }
+    }
+}
+
+/// What the continuous projections are asking for this tick.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Demand([Vec2; 2]);
+
+impl Demand {
+    pub fn is_idle(self) -> bool {
+        self.0.iter().all(|v| v.is_zero())
+    }
+}
+
+impl Index<MotionKind> for Demand {
+    type Output = Vec2;
+    fn index(&self, kind: MotionKind) -> &Vec2 {
+        &self.0[kind as usize]
+    }
+}
+
+impl IndexMut<MotionKind> for Demand {
+    fn index_mut(&mut self, kind: MotionKind) -> &mut Vec2 {
+        &mut self.0[kind as usize]
+    }
+}
+
+impl Add for Demand {
+    type Output = Demand;
+    fn add(self, other: Demand) -> Demand {
+        Demand([self.0[0] + other.0[0], self.0[1] + other.0[1]])
+    }
+}
+

--- a/parser/src/gamepad/mod.rs
+++ b/parser/src/gamepad/mod.rs
@@ -388,3 +388,197 @@ impl PadButton {
     ];
 }
 
+// -------------------------------------------------------------------- codes
+
+/// A control on a game controller, as an index into the `OsCode` range
+/// reserved for them.
+///
+/// The only supported way to obtain a controller `OsCode`: keeping the
+/// synthetic range behind a constructor stops it leaking into code that
+/// reasons about real scancodes. The range is laid out as buttons, then eight
+/// directions per [`Directional`], then the slots, so construction and
+/// [`PadCode::control`] are index arithmetic rather than a lookup table.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PadCode(u8);
+
+impl PadCode {
+    /// How many `pad-button-N` slots exist.
+    pub const SLOTS: u8 = 16;
+
+    const DIRECTIONS: u8 = PadButton::ALL.len() as u8;
+    const SLOT_BASE: u8 = PadCode::DIRECTIONS + (Directional::ALL.len() * Dir::ALL.len()) as u8;
+
+    pub const fn button(button: PadButton) -> PadCode {
+        PadCode(button as u8)
+    }
+
+    pub const fn direction(control: Directional, dir: Dir) -> PadCode {
+        PadCode(PadCode::DIRECTIONS + control as u8 * Dir::ALL.len() as u8 + dir as u8)
+    }
+
+    pub const fn slot(index: u8) -> Option<PadCode> {
+        match index < PadCode::SLOTS {
+            true => Some(PadCode(PadCode::SLOT_BASE + index)),
+            false => None,
+        }
+    }
+
+    /// Recover a `PadCode`, rejecting anything outside the reserved range.
+    pub const fn from_os_code(code: OsCode) -> Option<PadCode> {
+        match code.gamepad_index() {
+            Some(index) => Some(PadCode(index)),
+            None => None,
+        }
+    }
+
+    pub const fn os_code(self) -> OsCode {
+        match OsCode::from_gamepad_index(self.0) {
+            Some(code) => code,
+            None => unreachable!(),
+        }
+    }
+
+    /// What this code names: the inverse of the constructors, so callers can
+    /// reason about a code without re-deriving the layout of the range.
+    pub const fn control(self) -> PadControl {
+        let index = self.0;
+        if index < PadCode::DIRECTIONS {
+            return PadControl::Button(PadButton::ALL[index as usize]);
+        }
+        if index < PadCode::SLOT_BASE {
+            let rest = (index - PadCode::DIRECTIONS) as usize;
+            return PadControl::Direction(
+                Directional::ALL[rest / Dir::ALL.len()],
+                Dir::ALL[rest % Dir::ALL.len()],
+            );
+        }
+        PadControl::Slot(index - PadCode::SLOT_BASE)
+    }
+}
+
+/// The vocabulary above and the reserved `OsCode` range are two spellings of
+/// one thing, and every constructor here assumes they agree.
+const _: () = {
+    assert!(
+        PadCode::SLOT_BASE + PadCode::SLOTS == OsCode::GAMEPAD_COUNT,
+        "the reserved OsCode range and the control vocabulary disagree"
+    );
+    assert!(
+        OsCode::GAMEPAD_COUNT as u32 <= u64::BITS,
+        "a PadSet has one bit per control; widen it or shrink the vocabulary"
+    );
+};
+
+/// The three kinds of control the reserved range holds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PadControl {
+    Button(PadButton),
+    Direction(Directional, Dir),
+    /// A user-assignable `pad-button-N`.
+    Slot(u8),
+}
+
+impl From<PadCode> for OsCode {
+    fn from(code: PadCode) -> OsCode {
+        code.os_code()
+    }
+}
+
+impl fmt::Debug for PadCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.os_code())
+    }
+}
+
+impl fmt::Display for PadCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.os_code())
+    }
+}
+
+/// A digital control changing state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PadEdge {
+    pub code: PadCode,
+    pub pressed: bool,
+}
+
+/// The set of controls a controller is holding.
+///
+/// One `u64`, because the reserved range is deliberately smaller than that.
+/// Holding state, merging several controllers and diffing for edges are then
+/// each a single instruction, and nothing on the event path allocates.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+pub struct PadSet(u64);
+
+impl PadSet {
+    pub const EMPTY: PadSet = PadSet(0);
+
+    pub const fn contains(self, code: PadCode) -> bool {
+        self.0 & (1 << code.0) != 0
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    pub fn insert(&mut self, code: PadCode) {
+        self.0 |= 1 << code.0;
+    }
+
+    pub fn set(&mut self, code: PadCode, present: bool) {
+        let bit = 1u64 << code.0;
+        self.0 = if present { self.0 | bit } else { self.0 & !bit };
+    }
+
+    pub fn iter(self) -> impl Iterator<Item = PadCode> {
+        codes(self.0)
+    }
+
+    /// The transitions from `self` to `next`.
+    ///
+    /// Releases come before presses: a four-way stick moving from Up to Left
+    /// must not momentarily hold both, which a game reads as a diagonal. Every
+    /// control group diffs through here, so that rule is written once.
+    pub fn edges(self, next: PadSet) -> impl Iterator<Item = PadEdge> {
+        let released = codes(self.0 & !next.0).map(|code| PadEdge {
+            code,
+            pressed: false,
+        });
+        let pressed = codes(next.0 & !self.0).map(|code| PadEdge {
+            code,
+            pressed: true,
+        });
+        released.chain(pressed)
+    }
+}
+
+fn codes(mut bits: u64) -> impl Iterator<Item = PadCode> {
+    core::iter::from_fn(move || {
+        (bits != 0).then(|| {
+            let index = bits.trailing_zeros() as u8;
+            bits &= bits - 1;
+            PadCode(index)
+        })
+    })
+}
+
+impl BitOr for PadSet {
+    type Output = PadSet;
+    fn bitor(self, other: PadSet) -> PadSet {
+        PadSet(self.0 | other.0)
+    }
+}
+
+impl BitOrAssign for PadSet {
+    fn bitor_assign(&mut self, other: PadSet) {
+        self.0 |= other.0;
+    }
+}
+
+impl fmt::Debug for PadSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+

--- a/parser/src/gamepad/mod.rs
+++ b/parser/src/gamepad/mod.rs
@@ -402,6 +402,8 @@ impl PadButton {
 pub struct PadCode(u8);
 
 impl PadCode {
+    /// The number of controls in the reserved controller range.
+    pub const COUNT: usize = OsCode::GAMEPAD_COUNT as usize;
     /// How many `pad-button-N` slots exist.
     pub const SLOTS: u8 = 16;
 
@@ -429,6 +431,10 @@ impl PadCode {
             Some(index) => Some(PadCode(index)),
             None => None,
         }
+    }
+
+    pub(crate) const fn from_index(index: usize) -> PadCode {
+        PadCode(index as u8)
     }
 
     pub const fn os_code(self) -> OsCode {
@@ -638,6 +644,9 @@ pub struct Digital {
     /// -- deadzone or curve -- can silently move it. Ignored by a d-pad, which
     /// is digital before it arrives.
     pub threshold: Unit,
+    /// How long a raw crossing must remain on its new side before it becomes
+    /// a key edge. Zero preserves immediate threshold behavior.
+    pub debounce: u16,
 }
 
 /// At most one projection for each continuous output domain.
@@ -679,6 +688,7 @@ impl Default for Digital {
             mode: DirMode::default(),
             socd: Socd::default(),
             threshold: Unit::new(0.50),
+            debounce: 0,
         }
     }
 }
@@ -713,6 +723,8 @@ impl Projection {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Trigger {
     pub threshold: Unit,
+    /// See [`Digital::debounce`].
+    pub debounce: u16,
     pub motions: Motions<TriggerMotion>,
 }
 
@@ -728,6 +740,7 @@ impl Default for Trigger {
         // A trigger actuates much earlier than a stick.
         Trigger {
             threshold: Unit::new(0.30),
+            debounce: 0,
             motions: Motions::default(),
         }
     }

--- a/parser/src/gamepad/mod.rs
+++ b/parser/src/gamepad/mod.rs
@@ -113,3 +113,278 @@ impl Directional {
         }
     }
 }
+
+/// One of eight directions a projected control can expose to the layout.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Dir {
+    Up,
+    Down,
+    Left,
+    Right,
+    UpLeft,
+    UpRight,
+    DownLeft,
+    DownRight,
+}
+
+impl Dir {
+    pub const ALL: [Dir; 8] = [
+        Dir::Up,
+        Dir::Down,
+        Dir::Left,
+        Dir::Right,
+        Dir::UpLeft,
+        Dir::UpRight,
+        Dir::DownLeft,
+        Dir::DownRight,
+    ];
+
+    pub const fn is_diagonal(self) -> bool {
+        (self as u8) >= Dir::UpLeft as u8
+    }
+
+    /// The direction that cancels this one, which is what SOCD arbitrates.
+    pub const fn opposite(self) -> Dir {
+        match self {
+            Dir::Up => Dir::Down,
+            Dir::Down => Dir::Up,
+            Dir::Left => Dir::Right,
+            Dir::Right => Dir::Left,
+            Dir::UpLeft => Dir::DownRight,
+            Dir::UpRight => Dir::DownLeft,
+            Dir::DownLeft => Dir::UpRight,
+            Dir::DownRight => Dir::UpLeft,
+        }
+    }
+
+    /// The unit vector this direction points along, y-up.
+    pub const fn vector(self) -> Vec2 {
+        let (x, y) = match self {
+            Dir::Up => (0.0, 1.0),
+            Dir::Down => (0.0, -1.0),
+            Dir::Left => (-1.0, 0.0),
+            Dir::Right => (1.0, 0.0),
+            Dir::UpLeft => (-1.0, 1.0),
+            Dir::UpRight => (1.0, 1.0),
+            Dir::DownLeft => (-1.0, -1.0),
+            Dir::DownRight => (1.0, -1.0),
+        };
+        Vec2 { x, y }
+    }
+}
+
+/// One of the four directions a physical axis or contact can assert.
+///
+/// This is deliberately distinct from [`Dir`]. Hardware reports cardinals;
+/// diagonals are a projection of one vertical and one horizontal cardinal.
+/// Keeping those domains separate prevents an already-projected diagonal from
+/// being fed back into SOCD or four-way projection as if it were raw input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Cardinal {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+impl Cardinal {
+    pub const ALL: [Cardinal; 4] = [
+        Cardinal::Up,
+        Cardinal::Down,
+        Cardinal::Left,
+        Cardinal::Right,
+    ];
+
+    pub const fn direction(self) -> Dir {
+        match self {
+            Cardinal::Up => Dir::Up,
+            Cardinal::Down => Dir::Down,
+            Cardinal::Left => Dir::Left,
+            Cardinal::Right => Dir::Right,
+        }
+    }
+
+    pub const fn opposite(self) -> Cardinal {
+        match self {
+            Cardinal::Up => Cardinal::Down,
+            Cardinal::Down => Cardinal::Up,
+            Cardinal::Left => Cardinal::Right,
+            Cardinal::Right => Cardinal::Left,
+        }
+    }
+
+    pub const fn vector(self) -> Vec2 {
+        self.direction().vector()
+    }
+}
+
+impl TryFrom<Dir> for Cardinal {
+    type Error = ();
+
+    fn try_from(dir: Dir) -> Result<Cardinal, ()> {
+        match dir {
+            Dir::Up => Ok(Cardinal::Up),
+            Dir::Down => Ok(Cardinal::Down),
+            Dir::Left => Ok(Cardinal::Left),
+            Dir::Right => Ok(Cardinal::Right),
+            Dir::UpLeft | Dir::UpRight | Dir::DownLeft | Dir::DownRight => Err(()),
+        }
+    }
+}
+
+/// A set of raw cardinal assertions from a stick, d-pad, or hat.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+pub struct CardinalSet(u8);
+
+impl CardinalSet {
+    pub const EMPTY: CardinalSet = CardinalSet(0);
+
+    pub const fn of(dirs: &[Cardinal]) -> CardinalSet {
+        let (mut bits, mut i) = (0u8, 0);
+        while i < dirs.len() {
+            bits |= 1 << dirs[i] as u8;
+            i += 1;
+        }
+        CardinalSet(bits)
+    }
+
+    pub const fn contains(self, dir: Cardinal) -> bool {
+        self.0 & (1 << dir as u8) != 0
+    }
+
+    pub fn set(&mut self, dir: Cardinal, present: bool) {
+        let bit = 1 << dir as u8;
+        self.0 = if present { self.0 | bit } else { self.0 & !bit };
+    }
+
+    pub fn iter(self) -> impl Iterator<Item = Cardinal> {
+        Cardinal::ALL.into_iter().filter(move |d| self.contains(*d))
+    }
+
+    /// The direction this set asserts on one axis, or `None` when it asserts
+    /// neither or both. Both is not a direction: it is a question for SOCD,
+    /// and nothing here may guess an answer.
+    const fn axis(self, positive: Cardinal, negative: Cardinal) -> Option<Cardinal> {
+        match (self.contains(positive), self.contains(negative)) {
+            (true, false) => Some(positive),
+            (false, true) => Some(negative),
+            _ => None,
+        }
+    }
+
+    /// The single direction a set of cardinals denotes, or `None` if it
+    /// denotes none.
+    ///
+    /// The two axes are resolved separately. An axis asserting both directions
+    /// contributes nothing, but it must not take the other axis down with it:
+    /// a hitbox holding Left+Right while pushing Up is still pushing Up, and
+    /// collapsing that to "no direction at all" would release a control the
+    /// user never let go of.
+    pub const fn single(self) -> Option<Dir> {
+        match (
+            self.axis(Cardinal::Up, Cardinal::Down),
+            self.axis(Cardinal::Right, Cardinal::Left),
+        ) {
+            (Some(vertical), Some(horizontal)) => Some(combine(vertical, horizontal)),
+            (Some(found), None) | (None, Some(found)) => Some(found.direction()),
+            (None, None) => None,
+        }
+    }
+
+    /// The directions that reach the layout in the requested mode.
+    pub fn projected(self, mode: DirMode) -> impl Iterator<Item = Dir> {
+        let single = self.single();
+        Dir::ALL.into_iter().filter(move |dir| match mode {
+            DirMode::FourWay => Cardinal::try_from(*dir).is_ok_and(|d| self.contains(d)),
+            DirMode::EightWay => single == Some(*dir),
+        })
+    }
+
+    /// Where this set points, with components in `-1..=1`. A d-pad reads as a
+    /// stick this way, so both drive the same continuous projection.
+    pub fn vector(self) -> Vec2 {
+        self.iter()
+            .map(Cardinal::vector)
+            .fold(Vec2::ZERO, |total, v| total + v)
+    }
+}
+
+/// The diagonal two cardinals make. Only reachable with one vertical and one
+/// horizontal, which is the only way [`CardinalSet::single`] calls it.
+const fn combine(a: Cardinal, b: Cardinal) -> Dir {
+    match (a, b) {
+        (Cardinal::Up, Cardinal::Left) | (Cardinal::Left, Cardinal::Up) => Dir::UpLeft,
+        (Cardinal::Up, Cardinal::Right) | (Cardinal::Right, Cardinal::Up) => Dir::UpRight,
+        (Cardinal::Down, Cardinal::Left) | (Cardinal::Left, Cardinal::Down) => Dir::DownLeft,
+        (Cardinal::Down, Cardinal::Right) | (Cardinal::Right, Cardinal::Down) => Dir::DownRight,
+        _ => unreachable!(),
+    }
+}
+
+impl BitOr for CardinalSet {
+    type Output = CardinalSet;
+    fn bitor(self, other: CardinalSet) -> CardinalSet {
+        CardinalSet(self.0 | other.0)
+    }
+}
+
+impl fmt::Debug for CardinalSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+
+/// A digital control with a portable meaning.
+///
+/// Every name is positional: [`PadButton::South`] is the lower face button
+/// whatever glyph the vendor printed on it, so one configuration works across
+/// a DualSense, an Xbox pad and a Switch Pro pad without edits. The d-pad is
+/// not here: its four contacts point a direction, so it is a [`Directional`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum PadButton {
+    /// Lower face button: Cross, A, or B depending on the vendor.
+    South,
+    /// Right face button: Circle, B, or A.
+    East,
+    /// Left face button: Square, X, or Y.
+    West,
+    /// Upper face button: Triangle, Y, or X.
+    North,
+    /// Extra face buttons present on some six-button pads.
+    C,
+    Z,
+    /// Upper shoulder buttons.
+    L1,
+    R1,
+    /// Triggers, as digital controls. See [`Side::trigger`].
+    L2,
+    R2,
+    Select,
+    Start,
+    /// The vendor button: PS, Guide, Home.
+    Mode,
+    /// Stick clicks.
+    L3,
+    R3,
+}
+
+impl PadButton {
+    pub const ALL: [PadButton; 15] = [
+        PadButton::South,
+        PadButton::East,
+        PadButton::West,
+        PadButton::North,
+        PadButton::C,
+        PadButton::Z,
+        PadButton::L1,
+        PadButton::R1,
+        PadButton::L2,
+        PadButton::R2,
+        PadButton::Select,
+        PadButton::Start,
+        PadButton::Mode,
+        PadButton::L3,
+        PadButton::R3,
+    ];
+}
+

--- a/parser/src/gamepad/mod.rs
+++ b/parser/src/gamepad/mod.rs
@@ -803,3 +803,157 @@ impl GamepadConfig {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Everything else here is index arithmetic over the reserved range, so
+    /// this is the assumption the whole module rests on.
+    #[test]
+    fn pad_codes_tile_the_reserved_range() {
+        let mut seen = Vec::new();
+        let codes = PadButton::ALL
+            .map(|b| (PadCode::button(b), PadControl::Button(b)))
+            .into_iter()
+            .chain(Directional::ALL.into_iter().flat_map(|c| {
+                Dir::ALL.map(move |d| (PadCode::direction(c, d), PadControl::Direction(c, d)))
+            }))
+            .chain(
+                (0..PadCode::SLOTS)
+                    .map(|i| (PadCode::slot(i).expect("below SLOTS"), PadControl::Slot(i))),
+            );
+        for (code, control) in codes {
+            assert_eq!(code.control(), control, "{code} misclassified");
+            assert_eq!(PadCode::from_os_code(code.os_code()), Some(code));
+            seen.push(code);
+        }
+        seen.sort();
+        seen.dedup();
+        assert_eq!(seen.len(), OsCode::GAMEPAD_COUNT as usize, "codes overlap");
+        assert_eq!(PadCode::slot(PadCode::SLOTS), None);
+        for not_a_pad in [OsCode::KEY_A, OsCode::BTN_LEFT, OsCode::KEY_MAX] {
+            assert_eq!(PadCode::from_os_code(not_a_pad), None, "{not_a_pad}");
+        }
+    }
+
+    #[test]
+    fn cardinal_and_projected_directions_are_distinct_and_total() {
+        for dir in Dir::ALL {
+            assert_eq!(dir.opposite().opposite(), dir);
+            assert_ne!(dir.opposite(), dir);
+            assert_eq!(Cardinal::try_from(dir).is_err(), dir.is_diagonal());
+        }
+        for cardinal in Cardinal::ALL {
+            assert_eq!(cardinal.opposite().opposite(), cardinal);
+            assert_eq!(Cardinal::try_from(cardinal.direction()), Ok(cardinal));
+        }
+        assert_eq!(CardinalSet::EMPTY.single(), None);
+    }
+
+    #[test]
+    fn an_opposed_axis_denotes_no_direction() {
+        // Up+Down is not a direction, it is a question for SOCD, and the
+        // eight-way collapse may not guess an answer.
+        for pair in [
+            CardinalSet::of(&[Cardinal::Up, Cardinal::Down]),
+            CardinalSet::of(&[Cardinal::Left, Cardinal::Right]),
+        ] {
+            assert_eq!(pair.single(), None, "{pair:?}");
+            assert_eq!(pair.projected(DirMode::EightWay).count(), 0);
+            assert_eq!(
+                pair.projected(DirMode::FourWay).collect::<Vec<_>>(),
+                pair.iter().map(Cardinal::direction).collect::<Vec<_>>(),
+                "4way passes raw cardinals on"
+            );
+        }
+        let up_down_left = CardinalSet::of(&[Cardinal::Up, Cardinal::Down, Cardinal::Left]);
+        assert_eq!(up_down_left.single(), Some(Dir::Left));
+        assert_eq!(
+            up_down_left
+                .projected(DirMode::EightWay)
+                .collect::<Vec<_>>(),
+            vec![Dir::Left],
+            "an opposed axis must not erase the independent axis"
+        );
+    }
+
+    #[test]
+    fn eight_way_replaces_a_diagonals_components_with_the_diagonal() {
+        let up_right = CardinalSet::of(&[Cardinal::Up, Cardinal::Right]);
+        assert_eq!(
+            up_right.projected(DirMode::EightWay).collect::<Vec<_>>(),
+            vec![Dir::UpRight]
+        );
+        assert_eq!(
+            up_right.projected(DirMode::FourWay).collect::<Vec<_>>(),
+            vec![Dir::Up, Dir::Right]
+        );
+        // A straight push still presses its cardinal in eight-way, so every
+        // direction stays reachable.
+        let up = CardinalSet::of(&[Cardinal::Up]);
+        assert_eq!(
+            up.projected(DirMode::EightWay).collect::<Vec<_>>(),
+            vec![Dir::Up]
+        );
+        // And a set reads as a vector, which is what lets a d-pad drive the
+        // pointer; an opposed pair cancels there too.
+        assert_eq!(up_right.vector(), Vec2 { x: 1.0, y: 1.0 });
+        assert_eq!(
+            CardinalSet::of(&[Cardinal::Up, Cardinal::Down]).vector(),
+            Vec2::ZERO
+        );
+    }
+
+    #[test]
+    fn a_pad_set_diffs_into_edges_that_release_before_they_press() {
+        // A four-way stick moving from Up to Left must never hold both, which
+        // a game reads as a diagonal.
+        let up = PadCode::direction(Directional::LeftStick, Dir::Up);
+        let left = PadCode::direction(Directional::LeftStick, Dir::Left);
+        let (mut before, mut after) = (PadSet::EMPTY, PadSet::EMPTY);
+        assert!(before.is_empty());
+        before.insert(up);
+        after.set(left, true);
+        assert!(before.contains(up) && !before.contains(left));
+        assert_eq!(
+            before.edges(after).collect::<Vec<_>>(),
+            vec![
+                PadEdge {
+                    code: up,
+                    pressed: false
+                },
+                PadEdge {
+                    code: left,
+                    pressed: true
+                },
+            ]
+        );
+        assert_eq!(before.edges(before).count(), 0, "no change, no edges");
+        assert_eq!((before | after).iter().count(), 2);
+    }
+
+    #[test]
+    fn a_default_config_projects_only_the_dpad() {
+        let mut cfg = GamepadConfig::default();
+        assert!(!cfg.drives_motion());
+        assert_eq!(cfg.projection(Directional::LeftStick), &Projection::OFF);
+        assert!(cfg.projection(Directional::Dpad).digital.is_some());
+        assert_eq!(cfg.slot_of(0x2c0), None);
+
+        cfg.projection_mut(Directional::LeftStick).digital = Some(Digital::default());
+        assert!(!cfg.drives_motion(), "a digital projection is not motion");
+        // A trigger driving the wheel counts too, which is the case a check
+        // that only looked at sticks would miss.
+        cfg.trigger_mut(Side::Right).motions.set(
+            MotionKind::Scroll,
+            TriggerMotion {
+                direction: Cardinal::Down,
+                motion: Motion::SCROLL,
+            },
+        );
+        assert!(cfg.drives_motion());
+
+        cfg.slots[3] = Some(0x2c0);
+        assert_eq!(cfg.slot_of(0x2c0), PadCode::slot(3));
+    }
+}

--- a/parser/src/gamepad/mod.rs
+++ b/parser/src/gamepad/mod.rs
@@ -1,0 +1,115 @@
+//! Game controller support: the control vocabulary and the configuration tree
+//! `defgamepad` produces.
+//!
+//! ```text
+//! backend (gilrs)
+//!   -> PadInput   one whole reading, already normalized
+//!   -> Projector  deadzones, thresholds, SOCD
+//!   -> PadSet     every control held right now, in one u64
+//!   -> PadEdge    the diff against last time  -> the keyberon graph
+//!   -> Demand     a rate  -> kanata's existing mouse primitives, per tick
+//! ```
+//!
+//! Analog values never become keys: an `OsCode` is a binary coordinate in a
+//! layout row, so only threshold crossings and digital controls enter the
+//! layout and the value itself stays in `f32` to the point of use. And
+//! `defgamepad` only declares controls -- what a projected control *does* is
+//! `defsrc`, `deflayer` and every action kanata already has, which is why
+//! `pad-south` composes with `tap-hold`, layers and macros for free.
+//!
+//! Everything from `PadInput` onwards is arithmetic with no platform type
+//! anywhere, so it can be tested from recorded traces rather than from a
+//! controller on someone's desk. The parser half lives here because configs
+//! are parsed in builds with no backend; the runtime half is
+//! `kanata::gamepad`.
+
+pub mod analog;
+pub mod project;
+
+use core::fmt;
+use core::ops::{BitOr, BitOrAssign};
+use std::num::NonZeroU8;
+
+use crate::keys::OsCode;
+
+pub use analog::{AxisValue, Curve, Demand, Motion, MotionKind, StickPosition, Unit, Vec2};
+pub use project::{PadInput, Projector};
+
+// ---------------------------------------------------------------- vocabulary
+
+/// Which of a paired control -- a stick, a trigger -- is meant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Side {
+    Left,
+    Right,
+}
+
+impl Side {
+    pub const ALL: [Side; 2] = [Side::Left, Side::Right];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Side::Left => "left",
+            Side::Right => "right",
+        }
+    }
+
+    /// The control this side's trigger presses once past its band.
+    ///
+    /// Most hardware reports a trigger twice, as a button and as an analog
+    /// axis. Both drive this control and the projector holds it while either
+    /// says so, so a pad reporting one still works and a pad reporting both
+    /// does not double-fire.
+    pub const fn trigger(self) -> PadButton {
+        match self {
+            Side::Left => PadButton::L2,
+            Side::Right => PadButton::R2,
+        }
+    }
+
+    pub const fn stick(self) -> Directional {
+        match self {
+            Side::Left => Directional::LeftStick,
+            Side::Right => Directional::RightStick,
+        }
+    }
+}
+
+/// A control that points a direction: the two sticks and the d-pad.
+///
+/// One type for all three because they project identically -- thresholds,
+/// SOCD, four- or eight-way, and an optional continuous output. A d-pad is a
+/// stick that only knows nine positions, and treating it as one is what gives
+/// it eight-way output and pointer control without a second code path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Directional {
+    LeftStick,
+    RightStick,
+    Dpad,
+}
+
+impl Directional {
+    pub const ALL: [Directional; 3] = [
+        Directional::LeftStick,
+        Directional::RightStick,
+        Directional::Dpad,
+    ];
+
+    /// The side this is a stick of, or `None` for the d-pad. Also the index
+    /// into the per-stick state a d-pad does not have.
+    pub const fn side(self) -> Option<Side> {
+        match self {
+            Directional::LeftStick => Some(Side::Left),
+            Directional::RightStick => Some(Side::Right),
+            Directional::Dpad => None,
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Directional::LeftStick => "left stick",
+            Directional::RightStick => "right stick",
+            Directional::Dpad => "d-pad",
+        }
+    }
+}

--- a/parser/src/gamepad/mod.rs
+++ b/parser/src/gamepad/mod.rs
@@ -582,3 +582,224 @@ impl fmt::Debug for PadSet {
     }
 }
 
+// ------------------------------------------------------------------- config
+//
+// A description of physical controls and their projections, and nothing else:
+// it never names an output key.
+
+/// How many cardinals a diagonal presses.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DirMode {
+    /// A diagonal presses two cardinal controls, the way holding two keys
+    /// does. Right for WASD-style movement.
+    #[default]
+    FourWay,
+    /// A diagonal presses one dedicated diagonal control instead; a straight
+    /// push still presses its cardinal. Right when a diagonal has to be
+    /// distinguishable from its components.
+    EightWay,
+}
+
+/// How to resolve a control asserting both directions of an axis at once.
+///
+/// Only a control with independent contacts can do that -- a d-pad, or a
+/// hitbox-style stick replacement. A stick reports each axis as one signed
+/// number, so the setting is inert there.
+///
+/// The default is to pass both through, because both contacts really are down;
+/// the other modes exist for people who want a game's semantics. Resolution is
+/// per controller: two pads pressing opposite directions is two players, not a
+/// conflict, and the engine unions them afterwards.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Socd {
+    /// Both directions reach the layout. The default.
+    #[default]
+    Off,
+    /// Neither direction survives. The fighting-game convention.
+    Neutral,
+    /// The most recently pressed direction wins, and takes over immediately.
+    Last,
+    /// The direction already held wins; the newcomer is ignored until the
+    /// incumbent releases.
+    First,
+    /// Up and Right always win.
+    Positive,
+    /// Down and Left always win.
+    Negative,
+}
+
+/// Threshold crossings become `pad-lstick-*`, `pad-rstick-*` or `pad-dpad-*`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Digital {
+    pub mode: DirMode,
+    pub socd: Socd,
+    /// Where each axis presses. Compared against the *raw* reading, so
+    /// `(threshold 0.5)` means half of physical deflection and nothing
+    /// -- deadzone or curve -- can silently move it. Ignored by a d-pad, which
+    /// is digital before it arrives.
+    pub threshold: Unit,
+}
+
+/// At most one projection for each continuous output domain.
+///
+/// A typed two-slot map is both less error-prone than an
+/// `Option<(MotionKind, T)>` and more capable: a control may intentionally
+/// drive the pointer and wheel together, while duplicate declarations of the
+/// same kind remain a parser error.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Motions<T>([Option<T>; MotionKind::ALL.len()]);
+
+impl<T> Default for Motions<T> {
+    fn default() -> Motions<T> {
+        Motions([None, None])
+    }
+}
+
+impl<T: Copy> Motions<T> {
+    pub fn get(&self, kind: MotionKind) -> Option<T> {
+        self.0[kind as usize]
+    }
+
+    pub fn set(&mut self, kind: MotionKind, value: T) {
+        self.0[kind as usize] = Some(value);
+    }
+
+    pub fn contains(self, kind: MotionKind) -> bool {
+        self.get(kind).is_some()
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.0.iter().all(Option::is_none)
+    }
+}
+
+impl Default for Digital {
+    fn default() -> Digital {
+        Digital {
+            mode: DirMode::default(),
+            socd: Socd::default(),
+            threshold: Unit::new(0.50),
+        }
+    }
+}
+
+/// What a stick or d-pad does.
+///
+/// The two halves are independent and a control may have both: a stick can
+/// drive the pointer *and* press a key at full deflection, because the
+/// threshold and the displacement read the same value without disturbing each
+/// other.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Projection {
+    pub digital: Option<Digital>,
+    pub motions: Motions<Motion>,
+}
+
+impl Projection {
+    /// What a stick starts with: nothing. Its values are still tracked, so a
+    /// live reload can begin using it without waiting for the user to move it.
+    pub const OFF: Projection = Projection {
+        digital: None,
+        motions: Motions([None, None]),
+    };
+}
+
+/// What a trigger's analog half does.
+///
+/// Crossing the threshold presses `pad-l2` / `pad-r2`. A trigger is one number
+/// rather than a vector, so a continuous projection has to be told which way
+/// to push -- which is also what makes `(trigger right (scroll down ...))` a
+/// pressure-sensitive scroll wheel.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Trigger {
+    pub threshold: Unit,
+    pub motions: Motions<TriggerMotion>,
+}
+
+/// A scalar trigger projected along one cardinal direction.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TriggerMotion {
+    pub direction: Cardinal,
+    pub motion: Motion,
+}
+
+impl Default for Trigger {
+    fn default() -> Trigger {
+        // A trigger actuates much earlier than a stick.
+        Trigger {
+            threshold: Unit::new(0.30),
+            motions: Motions::default(),
+        }
+    }
+}
+
+/// Everything `defgamepad` declares.
+///
+/// `Copy` on purpose: it is handed to a projector per connected controller and
+/// replaced wholesale on live reload, and neither path should have to think
+/// about sharing.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GamepadConfig {
+    /// Restricts this declaration to one `definputdevices` entry. `None` means
+    /// every connected controller feeds the same controls, which is what a
+    /// single-pad user wants and a two-pad user overrides.
+    pub device: Option<NonZeroU8>,
+    /// Indexed by [`Directional`].
+    pub directionals: [Projection; Directional::ALL.len()],
+    /// Indexed by [`Side`].
+    pub triggers: [Trigger; Side::ALL.len()],
+    /// The backend code bound to each `pad-button-N`.
+    ///
+    /// Controllers expose paddles, extra hats and vendor buttons that no
+    /// portable name can describe. Rather than invent an unstable
+    /// auto-numbering, kanata offers slots and lets the user bind a code to
+    /// each; the codes it cannot name are printed to the log as they arrive.
+    pub slots: [Option<u32>; PadCode::SLOTS as usize],
+}
+
+impl Default for GamepadConfig {
+    fn default() -> GamepadConfig {
+        let mut directionals = [Projection::OFF; Directional::ALL.len()];
+        // A d-pad needs no declaration: it is digital hardware, and there is
+        // nothing to decide before it can press a key.
+        directionals[Directional::Dpad as usize].digital = Some(Digital::default());
+        GamepadConfig {
+            device: None,
+            directionals,
+            triggers: [Trigger::default(); Side::ALL.len()],
+            slots: [None; PadCode::SLOTS as usize],
+        }
+    }
+}
+
+impl GamepadConfig {
+    pub fn projection(&self, control: Directional) -> &Projection {
+        &self.directionals[control as usize]
+    }
+
+    pub fn projection_mut(&mut self, control: Directional) -> &mut Projection {
+        &mut self.directionals[control as usize]
+    }
+
+    pub fn trigger(&self, side: Side) -> &Trigger {
+        &self.triggers[side as usize]
+    }
+
+    pub fn trigger_mut(&mut self, side: Side) -> &mut Trigger {
+        &mut self.triggers[side as usize]
+    }
+
+    /// The slot a backend code is bound to, if any.
+    pub fn slot_of(&self, code: u32) -> Option<PadCode> {
+        let index = self.slots.iter().position(|bound| *bound == Some(code))?;
+        PadCode::slot(index as u8)
+    }
+
+    /// Whether anything drives the pointer or the wheel, and so whether the
+    /// tick loop has to sample the controller at all.
+    pub fn drives_motion(&self) -> bool {
+        self.directionals.iter().any(|p| !p.motions.is_empty())
+            || self.triggers.iter().any(|t| !t.motions.is_empty())
+    }
+}
+

--- a/parser/src/gamepad/project.rs
+++ b/parser/src/gamepad/project.rs
@@ -321,3 +321,398 @@ impl Projector {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gamepad::analog::{Curve, Motion, MotionKind, Vec2};
+    use crate::gamepad::{Digital, Dir, DirMode, PadControl};
+
+    /// Drive a trace and report what is held afterwards, plus every edge as
+    /// `(code, pressed)`.
+    fn run(config: GamepadConfig, trace: &[PadInput]) -> (Vec<PadCode>, Vec<(PadCode, bool)>) {
+        let mut projector = Projector::new(config);
+        let mut edges = Vec::new();
+        for input in trace {
+            let before = projector.held();
+            edges.extend(
+                before
+                    .edges(projector.feed(*input))
+                    .map(|e| (e.code, e.pressed)),
+            );
+        }
+        (projector.held().iter().collect(), edges)
+    }
+
+    fn held(config: GamepadConfig, trace: &[PadInput]) -> Vec<PadCode> {
+        run(config, trace).0
+    }
+
+    fn digital(control: Directional, digital: Digital) -> GamepadConfig {
+        let mut config = GamepadConfig::default();
+        config.projection_mut(control).digital = Some(digital);
+        config
+    }
+
+    fn eight_way(control: Directional) -> GamepadConfig {
+        digital(
+            control,
+            Digital {
+                mode: DirMode::EightWay,
+                ..Digital::default()
+            },
+        )
+    }
+
+    fn stick(x: f32, y: f32) -> PadInput {
+        PadInput::Stick {
+            side: Side::Left,
+            value: StickPosition::new(x, y),
+        }
+    }
+
+    fn trigger(side: Side, value: f32) -> PadInput {
+        PadInput::Trigger {
+            side,
+            value: Unit::new(value),
+        }
+    }
+
+    fn fast(speed: f32) -> Motion {
+        Motion {
+            deadzone: Unit::ZERO,
+            speed: speed * 1000.0,
+            curve: Curve::Linear,
+            invert: Vec2::KEEP,
+        }
+    }
+
+    fn lstick(dir: Dir) -> PadCode {
+        PadCode::direction(Directional::LeftStick, dir)
+    }
+
+    fn dpad(dir: Dir) -> PadCode {
+        PadCode::direction(Directional::Dpad, dir)
+    }
+
+    fn button(button: PadButton, pressed: bool) -> PadInput {
+        PadInput::Button { button, pressed }
+    }
+
+    #[test]
+    fn a_press_is_one_edge_and_a_repeat_is_none() {
+        let south = PadCode::button(PadButton::South);
+        let (held, edges) = run(
+            GamepadConfig::default(),
+            &[
+                button(PadButton::South, true),
+                button(PadButton::South, true),
+                button(PadButton::South, false),
+                button(PadButton::South, false),
+            ],
+        );
+        assert!(held.is_empty());
+        assert_eq!(edges, vec![(south, true), (south, false)]);
+    }
+
+    #[test]
+    fn a_trigger_reported_as_both_a_button_and_an_axis_fires_once() {
+        // Most pads report a trigger twice. Firing on each would double every
+        // press; firing on neither when only one arrives would drop it.
+        let l2 = vec![PadCode::button(PadButton::L2)];
+        let cfg = GamepadConfig::default();
+        assert_eq!(held(cfg, &[trigger(Side::Left, 1.0)]), l2, "axis alone");
+        assert_eq!(
+            held(cfg, &[button(PadButton::L2, true)]),
+            l2,
+            "button alone"
+        );
+        assert_eq!(
+            run(
+                cfg,
+                &[
+                    button(PadButton::L2, true),
+                    trigger(Side::Left, 1.0),
+                    trigger(Side::Left, 0.0),
+                    button(PadButton::L2, false),
+                ]
+            )
+            .1
+            .len(),
+            2,
+            "together they must still be one press and one release"
+        );
+
+        // A slow squeeze crosses the band once each way rather than chattering.
+        let squeeze: Vec<_> = (0..=100)
+            .chain((0..100).rev())
+            .map(|i| trigger(Side::Right, i as f32 / 100.0))
+            .collect();
+        let (held, edges) = run(cfg, &squeeze);
+        assert!(held.is_empty());
+        assert_eq!(edges.len(), 2, "squeeze chattered: {edges:?}");
+    }
+
+    #[test]
+    fn four_way_presses_both_cardinals_and_eight_way_presses_the_diagonal() {
+        let four = digital(Directional::LeftStick, Digital::default());
+        assert_eq!(
+            held(four, &[stick(0.8, 0.8)]),
+            vec![lstick(Dir::Up), lstick(Dir::Right)]
+        );
+        let eight = eight_way(Directional::LeftStick);
+        assert_eq!(held(eight, &[stick(0.8, 0.8)]), vec![lstick(Dir::UpRight)]);
+        // A straight push still presses its cardinal, so all eight are usable.
+        assert_eq!(held(eight, &[stick(0.0, 0.8)]), vec![lstick(Dir::Up)]);
+    }
+
+    #[test]
+    fn a_stick_never_asserts_both_directions_of_an_axis() {
+        // Each axis is one signed number, so there is nothing for SOCD to
+        // arbitrate on a stick -- which is why the mode is inert there.
+        let config = digital(Directional::LeftStick, Digital::default());
+        for step in -12i32..=12 {
+            let (x, y) = (step as f32 / 8.0, (12 - step.abs()) as f32 / 8.0);
+            let set = Projector::new(config).feed(stick(x, y));
+            for (a, b) in [(Dir::Up, Dir::Down), (Dir::Left, Dir::Right)] {
+                assert!(
+                    !(set.contains(lstick(a)) && set.contains(lstick(b))),
+                    "({x}, {y}) asserted both of {a:?}/{b:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_stick_moving_between_cardinals_releases_before_it_presses() {
+        // Holding both for even one event is a diagonal as far as a game is
+        // concerned.
+        let config = digital(Directional::LeftStick, Digital::default());
+        assert_eq!(
+            run(config, &[stick(0.0, 1.0), stick(-1.0, 0.0)]).1,
+            vec![
+                (lstick(Dir::Up), true),
+                (lstick(Dir::Up), false),
+                (lstick(Dir::Left), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_stick_resting_exactly_on_its_threshold_does_not_chatter() {
+        let config = digital(Directional::LeftStick, Digital::default());
+        let threshold = Digital::default().threshold.get();
+        let trace: Vec<_> = (0..500).map(|_| stick(0.0, threshold)).collect();
+        assert!(
+            run(config, &trace).1.is_empty(),
+            "a threshold rested at its boundary must stay quiet"
+        );
+    }
+
+    #[test]
+    fn a_dpad_needs_no_declaration_and_unifies_its_two_reportings() {
+        // It is digital hardware, and controllers report it either as four
+        // contacts or as a hat axis depending on the driver.
+        let (held, edges) = run(
+            GamepadConfig::default(),
+            &[
+                PadInput::Contacts(CardinalSet::of(&[Cardinal::Up])),
+                PadInput::Hat(CardinalSet::of(&[Cardinal::Up])),
+                PadInput::Contacts(CardinalSet::EMPTY),
+            ],
+        );
+        assert_eq!(edges.len(), 1, "the second source re-pressed: {edges:?}");
+        assert_eq!(held, vec![dpad(Dir::Up)]);
+
+        // And it takes the sticks' eight-way mode, because it is the same kind
+        // of control.
+        assert_eq!(
+            self::held(
+                eight_way(Directional::Dpad),
+                &[PadInput::Hat(CardinalSet::of(&[
+                    Cardinal::Down,
+                    Cardinal::Left,
+                ]))]
+            ),
+            vec![dpad(Dir::DownLeft)]
+        );
+    }
+
+    /// The d-pad directions held after driving a contact trace.
+    fn socd_after(mode: Socd, trace: &[(Dir, bool)]) -> Vec<Dir> {
+        let config = digital(
+            Directional::Dpad,
+            Digital {
+                socd: mode,
+                ..Digital::default()
+            },
+        );
+        let mut contacts = CardinalSet::EMPTY;
+        let inputs: Vec<_> = trace
+            .iter()
+            .map(|(dir, pressed)| {
+                contacts.set(
+                    Cardinal::try_from(*dir).expect("test trace uses cardinals"),
+                    *pressed,
+                );
+                PadInput::Contacts(contacts)
+            })
+            .collect();
+        held(config, &inputs)
+            .into_iter()
+            .map(|code| match code.control() {
+                PadControl::Direction(Directional::Dpad, dir) => dir,
+                other => panic!("unexpected {other:?}"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn socd_resolves_an_opposed_axis_the_way_the_mode_says() {
+        let opposed = [(Dir::Left, true), (Dir::Right, true)];
+        for (mode, expected) in [
+            (Socd::Off, vec![Dir::Left, Dir::Right]),
+            (Socd::Neutral, vec![]),
+            (Socd::Last, vec![Dir::Right]),
+            (Socd::First, vec![Dir::Left]),
+            (Socd::Positive, vec![Dir::Right]),
+            (Socd::Negative, vec![Dir::Left]),
+        ] {
+            assert_eq!(socd_after(mode, &opposed), expected, "{mode:?}");
+        }
+        // `last` and `first` follow the order the contacts arrived in, which is
+        // why resolution keeps state at all.
+        let reversed = [
+            (Dir::Left, true),
+            (Dir::Right, true),
+            (Dir::Right, false),
+            (Dir::Left, false),
+            (Dir::Right, true),
+            (Dir::Left, true),
+        ];
+        assert_eq!(socd_after(Socd::Last, &reversed), vec![Dir::Left]);
+        assert_eq!(socd_after(Socd::First, &reversed), vec![Dir::Right]);
+    }
+
+    #[test]
+    fn simultaneous_opposites_do_not_invent_an_order() {
+        let both = PadInput::Contacts(CardinalSet::of(&[Cardinal::Left, Cardinal::Right]));
+        for mode in [Socd::Last, Socd::First] {
+            let config = digital(
+                Directional::Dpad,
+                Digital {
+                    socd: mode,
+                    ..Digital::default()
+                },
+            );
+            assert!(
+                held(config, &[both]).is_empty(),
+                "{mode:?} invented a winner"
+            );
+        }
+    }
+
+    #[test]
+    fn socd_only_rewrites_the_axis_that_is_opposed() {
+        // A genuine diagonal is an answer, not a conflict.
+        for mode in [Socd::Neutral, Socd::Last, Socd::First, Socd::Positive] {
+            assert_eq!(
+                socd_after(mode, &[(Dir::Up, true), (Dir::Right, true)]),
+                vec![Dir::Up, Dir::Right],
+                "{mode:?} disturbed a diagonal"
+            );
+        }
+        assert_eq!(
+            socd_after(
+                Socd::Neutral,
+                &[(Dir::Up, true), (Dir::Left, true), (Dir::Right, true)]
+            ),
+            vec![Dir::Up],
+            "the unopposed axis should survive"
+        );
+    }
+
+    #[test]
+    fn a_reset_or_a_reload_releases_everything_and_forgets_the_history() {
+        let config = digital(Directional::LeftStick, Digital::default());
+        let mut projector = Projector::new(config);
+        projector.feed(button(PadButton::South, true));
+        let before = projector.feed(stick(1.0, 0.0));
+        assert!(!before.is_empty());
+
+        projector.reset();
+        assert!(projector.held().is_empty());
+        assert!(
+            before.edges(projector.held()).all(|edge| !edge.pressed),
+            "a reset may only release"
+        );
+        // The stick has to re-cross its threshold rather than resume held.
+        assert!(projector.feed(stick(0.4, 0.0)).is_empty());
+
+        // A reload to a declaration without that stick is the same, plus the
+        // stick stops projecting: this is what a deleted `defgamepad` lands on.
+        projector.feed(stick(1.0, 0.0));
+        projector.reconfigure(GamepadConfig::default());
+        assert!(projector.held().is_empty());
+        assert!(projector.feed(stick(1.0, 1.0)).is_empty());
+    }
+
+    #[test]
+    fn only_a_bound_backend_code_reaches_a_slot() {
+        let mut config = GamepadConfig::default();
+        config.slots[2] = Some(0x2c0);
+        let press = |code| PadInput::Native {
+            code,
+            pressed: true,
+        };
+        assert_eq!(
+            held(config, &[press(0x2c0)]),
+            vec![PadCode::slot(2).expect("a slot")]
+        );
+        assert!(held(config, &[press(0x2c1)]).is_empty(), "unbound code");
+    }
+
+    #[test]
+    fn every_kind_of_control_can_drive_motion() {
+        // The threshold and the displacement read the same value without
+        // disturbing each other, so a stick may do both; a d-pad reads as a
+        // stick at full deflection; and a trigger is a scalar pushed along the
+        // direction it was given.
+        let mut config = digital(Directional::LeftStick, Digital::default());
+        config
+            .projection_mut(Directional::LeftStick)
+            .motions
+            .set(MotionKind::Mouse, fast(10.0));
+        config
+            .projection_mut(Directional::LeftStick)
+            .motions
+            .set(MotionKind::Scroll, fast(2.0));
+        config
+            .projection_mut(Directional::Dpad)
+            .motions
+            .set(MotionKind::Mouse, fast(6.0));
+        config.trigger_mut(Side::Right).motions.set(
+            MotionKind::Scroll,
+            crate::gamepad::TriggerMotion {
+                direction: Cardinal::Down,
+                motion: fast(4.0),
+            },
+        );
+
+        let mut projector = Projector::new(config);
+        assert!(projector.demand().is_idle());
+
+        let held = projector.feed(stick(1.0, 0.0)).iter().collect::<Vec<_>>();
+        assert_eq!(held, vec![lstick(Dir::Right)], "the stick still presses");
+        assert!((projector.demand()[MotionKind::Mouse].x - 10.0).abs() < 1e-3);
+        assert!((projector.demand()[MotionKind::Scroll].x - 2.0).abs() < 1e-3);
+
+        projector.feed(PadInput::Hat(CardinalSet::of(&[Cardinal::Right])));
+        assert!((projector.demand()[MotionKind::Mouse].x - 16.0).abs() < 1e-3);
+
+        projector.feed(trigger(Side::Right, 0.5));
+        assert_eq!(
+            projector.demand()[MotionKind::Scroll],
+            Vec2 { x: 2.0, y: -2.0 }
+        );
+    }
+}

--- a/parser/src/gamepad/project.rs
+++ b/parser/src/gamepad/project.rs
@@ -1,0 +1,323 @@
+//! Projection: controller readings in, the set of held controls out.
+//!
+//! Every reading updates [`PadState`] -- what the controller has told us,
+//! untransformed -- and then the whole [`PadSet`] is recomputed from it. That
+//! is a handful of comparisons over one `u64`, and it removes the class of bug
+//! where one control group's edge logic disagrees with another's: one place
+//! decides what is held, and the caller diffs the result.
+//!
+//! Two unifications live here because both are invisible to the user and
+//! neither belongs in a backend. A **trigger** is reported by most pads twice,
+//! as a digital button and as an analog axis; a **d-pad** is reported either
+//! as four contacts or as a hat axis. Both halves are kept and unioned, so a
+//! pad reporting one still works and a pad reporting both does not
+//! double-fire.
+
+use super::analog::{Demand, StickPosition, Unit};
+use super::{
+    Cardinal, CardinalSet, Directional, GamepadConfig, PadButton, PadCode, PadSet, Side, Socd,
+};
+
+/// One reading from a controller, already normalized by the backend.
+///
+/// Axis values are y-up and in `[-1, 1]`; trigger values are in `[0, 1]`.
+/// Multi-axis controls arrive whole rather than one axis at a time, so a
+/// diagonal push never momentarily looks like a cardinal one.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PadInput {
+    /// A digital control the backend could name.
+    Button {
+        button: PadButton,
+        pressed: bool,
+    },
+    Stick {
+        side: Side,
+        value: StickPosition,
+    },
+    /// A trigger's analog half.
+    Trigger {
+        side: Side,
+        value: Unit,
+    },
+    /// The d-pad, as its four independent contacts.
+    Contacts(CardinalSet),
+    /// The d-pad, as a hat axis.
+    Hat(CardinalSet),
+    /// A control with no portable name, identified by its backend code.
+    Native {
+        code: u32,
+        pressed: bool,
+    },
+}
+
+/// Everything a controller has told us, untransformed.
+///
+/// Raw on purpose: every consumer applies its own transformations, so no site
+/// has to ask which ones have already happened. Kept even for controls with
+/// no projection, so a live reload can begin using one without waiting for
+/// the user to move it.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct PadState {
+    /// One bit per [`PadButton`].
+    buttons: u16,
+    /// The d-pad from its contacts and from its hat, kept apart so one going
+    /// quiet cannot clear the other.
+    dpad: [CardinalSet; 2],
+    sticks: [StickPosition; Side::ALL.len()],
+    triggers: [Unit; Side::ALL.len()],
+    /// Slots already resolved from backend codes, so the projection does not
+    /// have to consult the bindings again.
+    slots: PadSet,
+}
+
+impl PadState {
+    fn apply(&mut self, input: PadInput, config: &GamepadConfig) {
+        match input {
+            PadInput::Button { button, pressed } => {
+                let bit = 1u16 << button as u16;
+                self.buttons = match pressed {
+                    true => self.buttons | bit,
+                    false => self.buttons & !bit,
+                };
+            }
+            PadInput::Stick { side, value } => self.sticks[side as usize] = value,
+            PadInput::Trigger { side, value } => self.triggers[side as usize] = value,
+            PadInput::Contacts(dirs) => self.dpad[0] = dirs,
+            PadInput::Hat(dirs) => self.dpad[1] = dirs,
+            // An unbound code is dropped here. The backend logs it so it can
+            // be discovered and bound; letting it through would mean every
+            // paddle and vendor button claiming a control nobody asked for.
+            PadInput::Native { code, pressed } => {
+                if let Some(slot) = config.slot_of(code) {
+                    self.slots.set(slot, pressed);
+                }
+            }
+        }
+    }
+
+    fn holds(&self, button: PadButton) -> bool {
+        self.buttons & (1 << button as u16) != 0
+    }
+
+    /// The d-pad's contacts, before arbitration.
+    fn dpad(&self) -> CardinalSet {
+        self.dpad[0] | self.dpad[1]
+    }
+}
+
+/// Which direction of each opposed pair arrived most recently.
+///
+/// `Last` and `First` are history-dependent, which is the only reason
+/// resolution needs state at all.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct SocdMemory {
+    previous: CardinalSet,
+    newest: [Option<Cardinal>; 2],
+}
+
+/// The two opposed pairs, positive direction first so that `Positive` and
+/// `Negative` have one place to consult.
+const PAIRS: [(Cardinal, Cardinal); 2] = [
+    (Cardinal::Up, Cardinal::Down),
+    (Cardinal::Right, Cardinal::Left),
+];
+
+impl SocdMemory {
+    /// Resolve one set of cardinals into the set that should reach the layout.
+    ///
+    /// The mode applies independently to the vertical and horizontal pairs, so
+    /// a genuine diagonal is never disturbed: only an opposed axis is
+    /// rewritten.
+    fn resolve(&mut self, mode: Socd, raw: CardinalSet) -> CardinalSet {
+        let mut resolved = raw;
+        for (axis, (positive, negative)) in PAIRS.into_iter().enumerate() {
+            // Track which direction arrived most recently whether or not the
+            // axis is opposed right now: the press that creates the conflict
+            // may be the one that arrives second.
+            let positive_new = raw.contains(positive) && !self.previous.contains(positive);
+            let negative_new = raw.contains(negative) && !self.previous.contains(negative);
+            self.newest[axis] = match (positive_new, negative_new) {
+                (true, false) => Some(positive),
+                (false, true) => Some(negative),
+                // A snapshot in which both contacts first appear has no
+                // temporal ordering. Picking one based on enum iteration
+                // would pretend to know which was last (and make `first`
+                // pretend the opposite), so history-dependent modes resolve
+                // it neutrally until a later transition establishes order.
+                (true, true) => None,
+                (false, false) => self.newest[axis],
+            };
+            if !(raw.contains(positive) && raw.contains(negative)) {
+                continue;
+            }
+            // With exactly two directions on the axis, the incumbent is
+            // whichever one is not the newcomer.
+            let winner = match mode {
+                Socd::Off => continue,
+                Socd::Neutral => None,
+                Socd::Positive => Some(positive),
+                Socd::Negative => Some(negative),
+                Socd::Last => self.newest[axis],
+                Socd::First => self.newest[axis].map(Cardinal::opposite),
+            };
+            resolved.set(positive, false);
+            resolved.set(negative, false);
+            if let Some(winner) = winner {
+                resolved.set(winner, true);
+            }
+        }
+        self.previous = raw;
+        resolved
+    }
+}
+
+/// Turns one controller's readings into a set of held controls and a motion
+/// demand.
+///
+/// One projector per controller, so a stick on one pad cannot cancel a stick
+/// on another. The runtime merges them.
+#[derive(Clone, Debug)]
+pub struct Projector {
+    config: GamepadConfig,
+    state: PadState,
+    /// Only the d-pad has independent contacts, so it is the only control that
+    /// can assert both directions of an axis and the only one with anything to
+    /// arbitrate.
+    socd: SocdMemory,
+    /// The d-pad's contacts *after* arbitration. Both halves of its projection
+    /// read this one value: the digital half presses these directions and the
+    /// motion half points along them, so `(socd positive)` cannot make them
+    /// disagree about which way the pad is pointing.
+    dpad: CardinalSet,
+    held: PadSet,
+}
+
+impl Projector {
+    pub fn new(config: GamepadConfig) -> Projector {
+        Projector {
+            config,
+            state: PadState::default(),
+            socd: SocdMemory::default(),
+            dpad: CardinalSet::EMPTY,
+            held: PadSet::EMPTY,
+        }
+    }
+
+    /// The controls this controller is holding.
+    pub fn held(&self) -> PadSet {
+        self.held
+    }
+
+    /// Feed one reading and get the new held set.
+    pub fn feed(&mut self, input: PadInput) -> PadSet {
+        self.state.apply(input, &self.config);
+        self.recompute()
+    }
+
+    /// Let go of everything and forget all history.
+    ///
+    /// Used on disconnect, on live reload and on shutdown, where continuing to
+    /// trust the old state would strand a key down. Recomputing from an empty
+    /// [`PadState`] is what makes this correct by construction rather than by
+    /// remembering to release each control group.
+    pub fn reset(&mut self) {
+        *self = Projector::new(self.config);
+    }
+
+    /// Swap in a reloaded declaration, keeping nothing.
+    pub fn reconfigure(&mut self, config: GamepadConfig) {
+        *self = Projector::new(config);
+    }
+
+    /// What the continuous projections want this tick.
+    ///
+    /// Sampled rather than pushed: a deflection is a rate, so how fast the
+    /// pointer moves should depend on the clock and not on how often a
+    /// particular controller happens to report.
+    pub fn demand(&self) -> Demand {
+        let mut demand = Demand::default();
+        for control in Directional::ALL {
+            for kind in super::MotionKind::ALL {
+                let Some(motion) = self.config.projection(control).motions.get(kind) else {
+                    continue;
+                };
+                // A d-pad points along its arbitrated contacts, so it reads as
+                // a stick at full deflection and the two halves of its
+                // projection agree about which way it is pointing.
+                let pointing = match control.side() {
+                    Some(side) => self.state.sticks[side as usize].vector(),
+                    None => self.dpad.vector(),
+                };
+                demand[kind] += motion.displace(pointing);
+            }
+        }
+        for side in Side::ALL {
+            for kind in super::MotionKind::ALL {
+                let Some(projected) = self.config.trigger(side).motions.get(kind) else {
+                    continue;
+                };
+                let rate = projected
+                    .motion
+                    .rate(self.state.triggers[side as usize].get());
+                demand[kind] += projected.direction.vector() * rate;
+            }
+        }
+        demand
+    }
+
+    /// Rebuild the held set from the raw state.
+    fn recompute(&mut self) -> PadSet {
+        let mut set = self.state.slots;
+        for button in PadButton::ALL {
+            set.set(PadCode::button(button), self.state.holds(button));
+        }
+        for side in Side::ALL {
+            if self.state.triggers[side as usize] > self.config.trigger(side).threshold {
+                set.insert(PadCode::button(side.trigger()));
+            }
+        }
+        // Arbitrated before the loop, and unconditionally, because `demand`
+        // reads the result too: a d-pad with a motion projection and no
+        // digital one still has to point somewhere.
+        let dpad = self.config.projection(Directional::Dpad).digital;
+        let socd = dpad.map_or(Socd::default(), |digital| digital.socd);
+        self.dpad = self.socd.resolve(socd, self.state.dpad());
+
+        for control in Directional::ALL {
+            let Some(digital) = self.config.projection(control).digital else {
+                continue;
+            };
+            let dirs = match control.side() {
+                Some(side) => self.threshold(side, digital.threshold),
+                None => self.dpad,
+            };
+            for dir in dirs.projected(digital.mode) {
+                set.insert(PadCode::direction(control, dir));
+            }
+        }
+        self.held = set;
+        set
+    }
+
+    /// The cardinals a stick is asserting.
+    ///
+    /// Compared component by component rather than by radius -- a stick pushed
+    /// fully right is at full radius but is not pressing Up -- and against the
+    /// *raw* reading, so `(threshold 0.5)` means half of physical deflection and a
+    /// deadzone cannot silently move it.
+    fn threshold(&self, side: Side, threshold: Unit) -> CardinalSet {
+        let value = self.state.sticks[side as usize];
+        let mut out = CardinalSet::EMPTY;
+        let components = [
+            value.y().get(),
+            -value.y().get(),
+            -value.x().get(),
+            value.x().get(),
+        ];
+        for (dir, magnitude) in Cardinal::ALL.into_iter().zip(components) {
+            out.set(dir, Unit::new(magnitude) > threshold);
+        }
+        out
+    }
+}
+

--- a/parser/src/gamepad/project.rs
+++ b/parser/src/gamepad/project.rs
@@ -189,7 +189,18 @@ pub struct Projector {
     /// motion half points along them, so `(socd positive)` cannot make them
     /// disagree about which way the pad is pointing.
     dpad: CardinalSet,
+    /// Analog controls that have crossed their threshold and stayed there.
+    stable_analog: PadSet,
+    /// A pending change for each analog control. A change only becomes stable
+    /// after its configured grace period has elapsed uninterrupted.
+    pending: [Option<Pending>; PadCode::COUNT],
     held: PadSet,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Pending {
+    pressed: bool,
+    remaining: u16,
 }
 
 impl Projector {
@@ -199,6 +210,8 @@ impl Projector {
             state: PadState::default(),
             socd: SocdMemory::default(),
             dpad: CardinalSet::EMPTY,
+            stable_analog: PadSet::EMPTY,
+            pending: [None; PadCode::COUNT],
             held: PadSet::EMPTY,
         }
     }
@@ -212,6 +225,31 @@ impl Projector {
     pub fn feed(&mut self, input: PadInput) -> PadSet {
         self.state.apply(input, &self.config);
         self.recompute()
+    }
+
+    /// Advance pending threshold crossings by `milliseconds`.
+    ///
+    /// The processing loop calls this once per millisecond, like Kanata's
+    /// other waiting states. A late tick is still correct because elapsed time
+    /// is subtracted rather than counted as one controller event.
+    pub fn tick(&mut self, milliseconds: u16) -> PadSet {
+        for (index, pending) in self.pending.iter_mut().enumerate() {
+            let Some(change) = pending.as_mut() else {
+                continue;
+            };
+            change.remaining = change.remaining.saturating_sub(milliseconds);
+            if change.remaining == 0 {
+                self.stable_analog
+                    .set(PadCode::from_index(index), change.pressed);
+                *pending = None;
+            }
+        }
+        self.compose_held()
+    }
+
+    /// Whether a threshold crossing still needs the tick loop to run.
+    pub fn has_pending(&self) -> bool {
+        self.pending.iter().any(Option::is_some)
     }
 
     /// Let go of everything and forget all history.
@@ -267,14 +305,9 @@ impl Projector {
 
     /// Rebuild the held set from the raw state.
     fn recompute(&mut self) -> PadSet {
-        let mut set = self.state.slots;
+        let mut direct = self.state.slots;
         for button in PadButton::ALL {
-            set.set(PadCode::button(button), self.state.holds(button));
-        }
-        for side in Side::ALL {
-            if self.state.triggers[side as usize] > self.config.trigger(side).threshold {
-                set.insert(PadCode::button(side.trigger()));
-            }
+            direct.set(PadCode::button(button), self.state.holds(button));
         }
         // Arbitrated before the loop, and unconditionally, because `demand`
         // reads the result too: a d-pad with a motion projection and no
@@ -283,6 +316,13 @@ impl Projector {
         let socd = dpad.map_or(Socd::default(), |digital| digital.socd);
         self.dpad = self.socd.resolve(socd, self.state.dpad());
 
+        let mut desired_analog = PadSet::EMPTY;
+        for side in Side::ALL {
+            let trigger = self.config.trigger(side);
+            let code = PadCode::button(side.trigger());
+            desired_analog.set(code, self.state.triggers[side as usize] > trigger.threshold);
+            self.reconcile(code, desired_analog.contains(code), trigger.debounce);
+        }
         for control in Directional::ALL {
             let Some(digital) = self.config.projection(control).digital else {
                 continue;
@@ -292,11 +332,52 @@ impl Projector {
                 None => self.dpad,
             };
             for dir in dirs.projected(digital.mode) {
-                set.insert(PadCode::direction(control, dir));
+                let code = PadCode::direction(control, dir);
+                match control.side() {
+                    Some(_) => desired_analog.insert(code),
+                    None => direct.insert(code),
+                }
+            }
+            if control.side().is_some() {
+                for dir in super::Dir::ALL {
+                    let code = PadCode::direction(control, dir);
+                    self.reconcile(code, desired_analog.contains(code), digital.debounce);
+                }
             }
         }
-        self.held = set;
-        set
+        self.compose_held_from(direct)
+    }
+
+    fn reconcile(&mut self, code: PadCode, pressed: bool, debounce: u16) {
+        if self.stable_analog.contains(code) == pressed {
+            self.pending[code.0 as usize] = None;
+        } else if debounce == 0 {
+            self.stable_analog.set(code, pressed);
+            self.pending[code.0 as usize] = None;
+        } else if self.pending[code.0 as usize].is_none_or(|pending| pending.pressed != pressed) {
+            self.pending[code.0 as usize] = Some(Pending {
+                pressed,
+                remaining: debounce,
+            });
+        }
+    }
+
+    fn compose_held_from(&mut self, direct: PadSet) -> PadSet {
+        self.held = direct | self.stable_analog;
+        self.held
+    }
+
+    fn compose_held(&mut self) -> PadSet {
+        let mut direct = self.state.slots;
+        for button in PadButton::ALL {
+            direct.set(PadCode::button(button), self.state.holds(button));
+        }
+        if let Some(digital) = self.config.projection(Directional::Dpad).digital {
+            for dir in self.dpad.projected(digital.mode) {
+                direct.insert(PadCode::direction(Directional::Dpad, dir));
+            }
+        }
+        self.compose_held_from(direct)
     }
 
     /// The cardinals a stick is asserting.
@@ -506,6 +587,35 @@ mod tests {
             run(config, &trace).1.is_empty(),
             "a threshold rested at its boundary must stay quiet"
         );
+    }
+
+    #[test]
+    fn debounce_requires_an_uninterrupted_threshold_crossing() {
+        let config = digital(
+            Directional::LeftStick,
+            Digital {
+                debounce: 3,
+                ..Digital::default()
+            },
+        );
+        let mut projector = Projector::new(config);
+        let up = lstick(Dir::Up);
+
+        assert!(projector.feed(stick(0.0, 1.0)).is_empty());
+        assert!(projector.has_pending());
+        assert!(projector.tick(2).is_empty(), "two milliseconds is too soon");
+        assert!(projector.tick(1).contains(up));
+
+        // A brief dip below the threshold starts a release, but returning to
+        // the stable side cancels it before it can create an edge.
+        projector.feed(stick(0.0, 0.0));
+        assert!(projector.has_pending());
+        assert!(projector.feed(stick(0.0, 1.0)).contains(up));
+        assert!(!projector.has_pending());
+
+        projector.feed(stick(0.0, 0.0));
+        assert!(projector.tick(2).contains(up));
+        assert!(projector.tick(1).is_empty());
     }
 
     #[test]

--- a/parser/src/keys/mod.rs
+++ b/parser/src/keys/mod.rs
@@ -404,6 +404,81 @@ pub fn str_to_oscode(s: &str) -> Option<OsCode> {
         // position, in conjunction with `mouse-movement-key mvmt`
         "mvmt" | "mousemovement" | "🖰mv" => OsCode::KEY_766,
 
+        // Game controller controls. Input-only: they name a physical control
+        // on a pad, never an output scancode. See docs/config.adoc.
+        //
+        // Every name is positional rather than the glyph a vendor printed, so
+        // one config works on a DualSense, an Xbox pad and a Switch Pro pad.
+        // Face buttons, plus the pair some six-button pads add.
+        "pad-south" | "pad-a" | "pad-cross" => OsCode::PAD_SOUTH,
+        "pad-east" | "pad-b" | "pad-circle" => OsCode::PAD_EAST,
+        "pad-west" | "pad-x" | "pad-square" => OsCode::PAD_WEST,
+        "pad-north" | "pad-y" | "pad-triangle" => OsCode::PAD_NORTH,
+        "pad-c" => OsCode::PAD_C,
+        "pad-z" => OsCode::PAD_Z,
+
+        // Shoulder buttons, and the triggers' digital edge.
+        "pad-l1" | "pad-lb" => OsCode::PAD_L1,
+        "pad-r1" | "pad-rb" => OsCode::PAD_R1,
+        "pad-l2" | "pad-lt" => OsCode::PAD_L2,
+        "pad-r2" | "pad-rt" => OsCode::PAD_R2,
+
+        // Menu buttons and stick clicks.
+        "pad-select" | "pad-share" | "pad-view" | "pad-back" => OsCode::PAD_SELECT,
+        "pad-start" | "pad-options" | "pad-menu" => OsCode::PAD_START,
+        "pad-mode" | "pad-guide" | "pad-home" => OsCode::PAD_MODE,
+        "pad-l3" | "pad-lstick" => OsCode::PAD_L3,
+        "pad-r3" | "pad-rstick" => OsCode::PAD_R3,
+
+        // Left stick directions, from (stick left (digital ...)).
+        "pad-lstick-up" | "pad-ls-up" => OsCode::PAD_LSTICK_UP,
+        "pad-lstick-down" | "pad-ls-down" => OsCode::PAD_LSTICK_DOWN,
+        "pad-lstick-left" | "pad-ls-left" => OsCode::PAD_LSTICK_LEFT,
+        "pad-lstick-right" | "pad-ls-right" => OsCode::PAD_LSTICK_RIGHT,
+        "pad-lstick-upleft" | "pad-ls-upleft" => OsCode::PAD_LSTICK_UPLEFT,
+        "pad-lstick-upright" | "pad-ls-upright" => OsCode::PAD_LSTICK_UPRIGHT,
+        "pad-lstick-downleft" | "pad-ls-downleft" => OsCode::PAD_LSTICK_DOWNLEFT,
+        "pad-lstick-downright" | "pad-ls-downright" => OsCode::PAD_LSTICK_DOWNRIGHT,
+
+        // Right stick directions, from (stick right (digital ...)).
+        "pad-rstick-up" | "pad-rs-up" => OsCode::PAD_RSTICK_UP,
+        "pad-rstick-down" | "pad-rs-down" => OsCode::PAD_RSTICK_DOWN,
+        "pad-rstick-left" | "pad-rs-left" => OsCode::PAD_RSTICK_LEFT,
+        "pad-rstick-right" | "pad-rs-right" => OsCode::PAD_RSTICK_RIGHT,
+        "pad-rstick-upleft" | "pad-rs-upleft" => OsCode::PAD_RSTICK_UPLEFT,
+        "pad-rstick-upright" | "pad-rs-upright" => OsCode::PAD_RSTICK_UPRIGHT,
+        "pad-rstick-downleft" | "pad-rs-downleft" => OsCode::PAD_RSTICK_DOWNLEFT,
+        "pad-rstick-downright" | "pad-rs-downright" => OsCode::PAD_RSTICK_DOWNRIGHT,
+
+        // D-pad, unified across hat-axis and button reporting. The
+        // diagonals need (dpad (digital (mode 8way))).
+        "pad-dpad-up" | "pad-up" => OsCode::PAD_DPAD_UP,
+        "pad-dpad-down" | "pad-down" => OsCode::PAD_DPAD_DOWN,
+        "pad-dpad-left" | "pad-left" => OsCode::PAD_DPAD_LEFT,
+        "pad-dpad-right" | "pad-right" => OsCode::PAD_DPAD_RIGHT,
+        "pad-dpad-upleft" | "pad-upleft" => OsCode::PAD_DPAD_UPLEFT,
+        "pad-dpad-upright" | "pad-upright" => OsCode::PAD_DPAD_UPRIGHT,
+        "pad-dpad-downleft" | "pad-downleft" => OsCode::PAD_DPAD_DOWNLEFT,
+        "pad-dpad-downright" | "pad-downright" => OsCode::PAD_DPAD_DOWNRIGHT,
+
+        // Slots for controls no portable name covers; see (button-slot ...).
+        "pad-button-0" | "pb0" => OsCode::PAD_BUTTON_0,
+        "pad-button-1" | "pb1" => OsCode::PAD_BUTTON_1,
+        "pad-button-2" | "pb2" => OsCode::PAD_BUTTON_2,
+        "pad-button-3" | "pb3" => OsCode::PAD_BUTTON_3,
+        "pad-button-4" | "pb4" => OsCode::PAD_BUTTON_4,
+        "pad-button-5" | "pb5" => OsCode::PAD_BUTTON_5,
+        "pad-button-6" | "pb6" => OsCode::PAD_BUTTON_6,
+        "pad-button-7" | "pb7" => OsCode::PAD_BUTTON_7,
+        "pad-button-8" | "pb8" => OsCode::PAD_BUTTON_8,
+        "pad-button-9" | "pb9" => OsCode::PAD_BUTTON_9,
+        "pad-button-10" | "pb10" => OsCode::PAD_BUTTON_10,
+        "pad-button-11" | "pb11" => OsCode::PAD_BUTTON_11,
+        "pad-button-12" | "pb12" => OsCode::PAD_BUTTON_12,
+        "pad-button-13" | "pb13" => OsCode::PAD_BUTTON_13,
+        "pad-button-14" | "pb14" => OsCode::PAD_BUTTON_14,
+        "pad-button-15" | "pb15" => OsCode::PAD_BUTTON_15,
+
         _ => return None,
     })
 }
@@ -1190,6 +1265,83 @@ pub enum OsCode {
     KEY_766 = 766, // aliased to mvmt as a dummy input for use with mouse-movement-key
 
     KEY_MAX = 767,
+
+    // ---------------------------------------------------------------------
+    // Game controller controls.
+    //
+    // Synthetic: no operating system reports these as a scancode, so
+    // `from_u16` never decodes one and `process-unmapped-keys` can never
+    // sweep one into `defsrc`. They are built only through
+    // `crate::gamepad::PadCode`, which is what makes a name mean the same
+    // physical control on every platform.
+    //
+    // The range is contiguous and grouped: buttons, then eight directions
+    // for each directional control, then the assignable slots. `PadCode` is
+    // an index into it, so this order is load-bearing; `PadCode::control`
+    // inverts it and `pad_codes_tile_the_reserved_range` pins the two
+    // together.
+    //
+    // Analog values never live here: only threshold crossings and digital
+    // controls become codes, and the continuous value stays in the
+    // projector.
+    // ---------------------------------------------------------------------
+    PAD_SOUTH = 768,
+    PAD_EAST = 769,
+    PAD_WEST = 770,
+    PAD_NORTH = 771,
+    PAD_C = 772,
+    PAD_Z = 773,
+    PAD_L1 = 774,
+    PAD_R1 = 775,
+    PAD_L2 = 776,
+    PAD_R2 = 777,
+    PAD_SELECT = 778,
+    PAD_START = 779,
+    PAD_MODE = 780,
+    PAD_L3 = 781,
+    PAD_R3 = 782,
+    PAD_LSTICK_UP = 783,
+    PAD_LSTICK_DOWN = 784,
+    PAD_LSTICK_LEFT = 785,
+    PAD_LSTICK_RIGHT = 786,
+    PAD_LSTICK_UPLEFT = 787,
+    PAD_LSTICK_UPRIGHT = 788,
+    PAD_LSTICK_DOWNLEFT = 789,
+    PAD_LSTICK_DOWNRIGHT = 790,
+    PAD_RSTICK_UP = 791,
+    PAD_RSTICK_DOWN = 792,
+    PAD_RSTICK_LEFT = 793,
+    PAD_RSTICK_RIGHT = 794,
+    PAD_RSTICK_UPLEFT = 795,
+    PAD_RSTICK_UPRIGHT = 796,
+    PAD_RSTICK_DOWNLEFT = 797,
+    PAD_RSTICK_DOWNRIGHT = 798,
+    PAD_DPAD_UP = 799,
+    PAD_DPAD_DOWN = 800,
+    PAD_DPAD_LEFT = 801,
+    PAD_DPAD_RIGHT = 802,
+    PAD_DPAD_UPLEFT = 803,
+    PAD_DPAD_UPRIGHT = 804,
+    PAD_DPAD_DOWNLEFT = 805,
+    PAD_DPAD_DOWNRIGHT = 806,
+    PAD_BUTTON_0 = 807,
+    PAD_BUTTON_1 = 808,
+    PAD_BUTTON_2 = 809,
+    PAD_BUTTON_3 = 810,
+    PAD_BUTTON_4 = 811,
+    PAD_BUTTON_5 = 812,
+    PAD_BUTTON_6 = 813,
+    PAD_BUTTON_7 = 814,
+    PAD_BUTTON_8 = 815,
+    PAD_BUTTON_9 = 816,
+    PAD_BUTTON_10 = 817,
+    PAD_BUTTON_11 = 818,
+    PAD_BUTTON_12 = 819,
+    PAD_BUTTON_13 = 820,
+    PAD_BUTTON_14 = 821,
+    PAD_BUTTON_15 = 822,
+    /// One past the highest `OsCode`. This is the width of a layout row.
+    OSCODE_MAX = 823,
 }
 
 impl OsCode {
@@ -1208,6 +1360,63 @@ impl OsCode {
                 | MouseWheelRight
         )
     }
+
+    /// How many game controller controls the reserved range holds.
+    pub const GAMEPAD_COUNT: u8 = (OsCode::OSCODE_MAX as u16 - OsCode::PAD_SOUTH as u16) as u8;
+
+    /// True for the game controller controls, which occupy one contiguous
+    /// range above every real OS scancode.
+    ///
+    /// They are input-only. No OS can be asked to emit one, so the output path
+    /// ignores them the same way it ignores the reserved macro keys; see
+    /// `output_logic::write_key`.
+    pub const fn is_gamepad_code(self) -> bool {
+        self.gamepad_index().is_some()
+    }
+
+    /// This code's position within the reserved range, or `None` if it is an
+    /// ordinary key.
+    ///
+    /// The pair with [`OsCode::from_gamepad_index`] is what lets
+    /// `gamepad::PadCode` be a small index instead of a lookup table.
+    pub const fn gamepad_index(self) -> Option<u8> {
+        match (self as u16).checked_sub(OsCode::PAD_SOUTH as u16) {
+            Some(index) if index < OsCode::GAMEPAD_COUNT as u16 => Some(index as u8),
+            _ => None,
+        }
+    }
+
+    /// The `index`th control in the reserved range.
+    pub const fn from_gamepad_index(index: u8) -> Option<OsCode> {
+        if index >= OsCode::GAMEPAD_COUNT {
+            return None;
+        }
+        // SAFETY: the reserved range is a contiguous run of discriminants on a
+        // `#[repr(u16)]` enum, so every value in it names a variant. The
+        // `gamepad_indices_round_trip` test walks the whole range.
+        Some(unsafe {
+            core::mem::transmute::<u16, OsCode>(OsCode::PAD_SOUTH as u16 + index as u16)
+        })
+    }
+}
+
+#[test]
+fn gamepad_indices_round_trip() {
+    for index in 0..OsCode::GAMEPAD_COUNT {
+        let osc = OsCode::from_gamepad_index(index).expect("below the count");
+        assert_eq!(osc.gamepad_index(), Some(index));
+        assert_eq!(
+            u16::from(osc),
+            u16::from(OsCode::PAD_SOUTH) + u16::from(index)
+        );
+        // `Debug` on a transmuted value is the cheapest proof that the
+        // discriminant really names a variant.
+        assert!(format!("{osc:?}").starts_with("PAD_"), "{osc:?}");
+    }
+    assert_eq!(OsCode::from_gamepad_index(OsCode::GAMEPAD_COUNT), None);
+    assert_eq!(OsCode::KEY_A.gamepad_index(), None);
+    assert_eq!(OsCode::KEY_MAX.gamepad_index(), None);
+    assert_eq!(OsCode::OSCODE_MAX.gamepad_index(), None);
 }
 
 use core::fmt;
@@ -1224,7 +1433,7 @@ impl fmt::Display for OsCode {
 
 #[test]
 fn parser_key_max_lt_keyberon_key_max() {
-    assert!(u16::from(OsCode::KEY_MAX) < KEY_MAX);
+    assert!(u16::from(OsCode::OSCODE_MAX) < KEY_MAX);
 }
 
 #[cfg(test)]

--- a/parser/src/layers.rs
+++ b/parser/src/layers.rs
@@ -8,8 +8,9 @@ use crate::keys::OsCode;
 
 use std::sync::Arc;
 
-// OsCode::KEY_MAX is the biggest OsCode
-pub const KEYS_IN_ROW: usize = OsCode::KEY_MAX as usize;
+// OsCode::OSCODE_MAX is one past the biggest OsCode, including the synthetic
+// gamepad controls that live above the OS scancode range.
+pub const KEYS_IN_ROW: usize = OsCode::OSCODE_MAX as usize;
 pub const LAYER_ROWS: usize = 2;
 pub const DEFAULT_ACTION: KanataAction = KanataAction::KeyCode(KeyCode::ErrorUndefined);
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod cfg;
 pub mod custom_action;
+pub mod gamepad;
 pub mod keys;
 pub mod layers;
 pub mod lsp_hints;

--- a/parser/src/sequences.rs
+++ b/parser/src/sequences.rs
@@ -25,5 +25,12 @@ pub fn mod_mask_for_keycode(kc: KeyCode) -> u16 {
 #[test]
 fn keys_fit_within_mask() {
     use crate::keys::OsCode;
-    assert!(MASK_KEYCODES >= u16::from(OsCode::KEY_MAX));
+    // The mask has to cover the whole `OsCode` range, not just the codes a
+    // sequence can name. A sequence cannot hold a controller control -- the
+    // key list is parsed as actions, and those are rejected in an output
+    // position -- but the mask is applied to raw codes, so it still has to
+    // reach past the reserved range.
+    assert!(MASK_KEYCODES >= u16::from(OsCode::OSCODE_MAX));
+    // And the overlap marker has to stay clear of all of them.
+    const { assert!(KEY_OVERLAP_MARKER > MASK_KEYCODES) };
 }

--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -416,3 +416,278 @@ fn split<T>(amount: i32, positive: T, negative: T) -> Option<(T, u16)> {
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanata_parser::gamepad::{
+        Curve, Directional, Motion, PadButton, PadCode, Side, StickPosition, Unit,
+    };
+
+    fn pad(n: u32) -> PadDeviceId {
+        PadDeviceId::new(n)
+    }
+
+    fn info(name: &str) -> PadDeviceInfo {
+        PadDeviceInfo {
+            name: name.to_string(),
+            vendor_id: Some(0x054c),
+            product_id: Some(0x0ce6),
+        }
+    }
+
+    fn engine() -> PadEngine {
+        PadEngine::new(GamepadConfig::default(), None)
+    }
+
+    fn feed(e: &mut PadEngine, id: PadDeviceId, input: PadInput) -> Vec<PadEdge> {
+        let mut edges = Vec::new();
+        e.feed(id, input, &mut edges);
+        edges
+    }
+
+    fn stick(x: f32) -> PadInput {
+        PadInput::Stick {
+            side: Side::Left,
+            value: StickPosition::new(x, 0.0),
+        }
+    }
+
+    const SOUTH: PadCode = PadCode::button(PadButton::South);
+    const PRESS: PadInput = PadInput::Button {
+        button: PadButton::South,
+        pressed: true,
+    };
+    const RELEASE: PadInput = PadInput::Button {
+        button: PadButton::South,
+        pressed: false,
+    };
+
+    /// A config whose left stick is digital, for the tests that need two pads
+    /// to push one stick different ways.
+    fn digital() -> GamepadConfig {
+        let mut config = GamepadConfig::default();
+        config.projection_mut(Directional::LeftStick).digital = Some(Default::default());
+        config
+    }
+
+    #[test]
+    fn several_controllers_merge_into_one_logical_pad() {
+        let mut e = engine();
+        // A backend can report for a device the engine rejected or never saw.
+        assert!(feed(&mut e, pad(1), PRESS).is_empty());
+
+        e.connect(pad(1), info("one"));
+        e.connect(pad(2), info("two"));
+        assert_eq!(
+            feed(&mut e, pad(1), PRESS).len(),
+            1,
+            "first press is visible"
+        );
+        assert!(
+            feed(&mut e, pad(2), PRESS).is_empty(),
+            "the second controller must not re-press a held control"
+        );
+        assert!(
+            feed(&mut e, pad(1), RELEASE).is_empty(),
+            "still held by the other controller"
+        );
+        assert_eq!(
+            feed(&mut e, pad(2), RELEASE),
+            vec![PadEdge {
+                code: SOUTH,
+                pressed: false
+            }],
+            "the last release must be visible"
+        );
+    }
+
+    #[test]
+    fn one_controllers_stick_does_not_cancel_anothers() {
+        let mut e = PadEngine::new(digital(), None);
+        e.connect(pad(1), info("one"));
+        e.connect(pad(2), info("two"));
+        assert_eq!(feed(&mut e, pad(1), stick(1.0)).len(), 1);
+        // The second pad pushing the opposite way presses its own direction
+        // rather than resolving against the first pad's.
+        let edges = feed(&mut e, pad(2), stick(-1.0));
+        assert_eq!(edges.len(), 1);
+        assert!(edges[0].pressed);
+    }
+
+    #[test]
+    fn disconnecting_releases_only_what_that_controller_held() {
+        // A pad unplugged mid-press leaves a key down with nothing left that
+        // could ever release it.
+        let mut e = engine();
+        e.connect(pad(1), info("one"));
+        e.connect(pad(2), info("two"));
+        feed(&mut e, pad(1), PRESS);
+
+        let mut edges = Vec::new();
+        e.disconnect(pad(2), &mut edges);
+        assert!(edges.is_empty(), "pad 2 held nothing: {edges:?}");
+        e.disconnect(pad(1), &mut edges);
+        assert_eq!(
+            edges,
+            vec![PadEdge {
+                code: SOUTH,
+                pressed: false
+            }]
+        );
+        assert_eq!(e.connected_count(), 0);
+        e.disconnect(pad(9), &mut edges); // an unknown device is harmless
+
+        // And a reconnecting controller starts from a clean slate: if its
+        // projector had survived, this press would be swallowed as a repeat.
+        e.connect(pad(1), info("one"));
+        assert_eq!(feed(&mut e, pad(1), PRESS).len(), 1);
+    }
+
+    #[test]
+    fn every_matcher_field_the_user_gave_has_to_match() {
+        let named = |name: &str| InputDeviceMatcher {
+            name: Some(name.into()),
+            ..Default::default()
+        };
+        for (matcher, expected) in [
+            (named("DualSense"), Connection::Accepted),
+            (named("Xbox"), Connection::NotSelected),
+            (
+                InputDeviceMatcher {
+                    vendor_id: Some(0x054c),
+                    product_id: Some(0x9999),
+                    ..named("DualSense")
+                },
+                Connection::NotSelected,
+            ),
+            // Nothing specified is not a constraint at all.
+            (InputDeviceMatcher::default(), Connection::Accepted),
+        ] {
+            let mut e = PadEngine::new(GamepadConfig::default(), Some(matcher.clone()));
+            assert_eq!(
+                e.connect(pad(1), info("DualSense")),
+                expected,
+                "{matcher:?}"
+            );
+            // A rejected controller never reaches the layout either.
+            assert_eq!(
+                feed(&mut e, pad(1), PRESS).is_empty(),
+                expected == Connection::NotSelected
+            );
+        }
+    }
+
+    #[test]
+    fn reconfigure_releases_across_every_controller() {
+        let mut e = PadEngine::new(digital(), None);
+        e.connect(pad(1), info("one"));
+        e.connect(pad(2), info("two"));
+        feed(&mut e, pad(1), PRESS);
+        feed(&mut e, pad(2), stick(1.0));
+
+        let mut edges = Vec::new();
+        e.reconfigure(GamepadConfig::default(), &mut edges);
+        assert_eq!(edges.len(), 2, "both controllers should release: {edges:?}");
+        assert!(edges.iter().all(|edge| !edge.pressed));
+        // The new declaration is in force, and nothing is stuck held.
+        assert!(feed(&mut e, pad(2), stick(1.0)).is_empty());
+        assert_eq!(feed(&mut e, pad(1), PRESS).len(), 1);
+    }
+
+    #[test]
+    fn motion_demand_sums_across_controllers_and_leaves_with_them() {
+        // Two controllers behave like two hands on one pointer.
+        let mut config = GamepadConfig::default();
+        config.trigger_mut(Side::Right).motions.set(
+            MotionKind::Scroll,
+            kanata_parser::gamepad::TriggerMotion {
+                direction: kanata_parser::gamepad::Cardinal::Up,
+                motion: Motion {
+                    deadzone: Unit::ZERO,
+                    speed: 10_000.0,
+                    curve: Curve::Linear,
+                    invert: Vec2::KEEP,
+                },
+            },
+        );
+        let mut e = PadEngine::new(config, None);
+        e.connect(pad(1), info("one"));
+        e.connect(pad(2), info("two"));
+        assert!(e.demand().is_idle());
+
+        let squeeze = PadInput::Trigger {
+            side: Side::Right,
+            value: Unit::ONE,
+        };
+        feed(&mut e, pad(1), squeeze);
+        assert!((e.demand()[MotionKind::Scroll].y - 10.0).abs() < 1e-3);
+        feed(&mut e, pad(2), squeeze);
+        assert!((e.demand()[MotionKind::Scroll].y - 20.0).abs() < 1e-3);
+        e.disconnect(pad(2), &mut Vec::new());
+        assert!((e.demand()[MotionKind::Scroll].y - 10.0).abs() < 1e-3);
+    }
+
+    fn mouse(x: f32, y: f32) -> Demand {
+        let mut demand = Demand::default();
+        demand[MotionKind::Mouse] = Vec2 { x, y };
+        demand
+    }
+
+    #[test]
+    fn the_accumulator_keeps_the_average_rate_exact() {
+        let mut acc = Accumulator::default();
+        assert!(acc.accrue(Demand::default()).is_empty());
+        // Rounding independently each tick would give 7000 or 8000.
+        let total: i32 = (0..1000)
+            .map(|_| acc.accrue(mouse(7.5, 0.0)).0[MotionKind::Mouse as usize].0)
+            .sum();
+        assert_eq!(total, 7500);
+        // A reset drops the partial move rather than letting it surface as a
+        // stray pixel on the next push.
+        acc.accrue(mouse(0.9, 0.0));
+        acc.reset();
+        assert!(acc.accrue(mouse(0.2, 0.0)).is_empty());
+    }
+
+    #[test]
+    fn accrued_movement_splits_by_axis_and_direction() {
+        let mut acc = Accumulator::default();
+        let mut demand = mouse(-1.0, -2.0);
+        demand[MotionKind::Scroll] = Vec2 { x: 4.0, y: -3.0 };
+        let accrued = acc.accrue(demand);
+
+        assert_eq!(
+            accrued
+                .mouse_moves(|distance| distance)
+                .map(|m| m.map(|m| (m.direction, m.distance))),
+            [Some((MoveDirection::Left, 1)), Some((MoveDirection::Up, 2))]
+        );
+        assert_eq!(
+            accrued.scrolls(),
+            [
+                Some((MWheelDirection::Right, 4)),
+                Some((MWheelDirection::Down, 3))
+            ]
+        );
+        // An axis at rest produces nothing at all, and a controller pointer is
+        // still kanata's pointer, so movemouse-speed has to reach it.
+        let scaled = acc.accrue(mouse(5.0, 0.0)).mouse_moves(|d| d * 2);
+        assert_eq!(scaled.map(|m| m.map(|m| m.distance)), [Some(10), None]);
+    }
+
+    #[test]
+    fn an_extreme_demand_saturates_rather_than_wrapping() {
+        let accrued = Accrued([(i32::MAX, i32::MIN), (i32::MIN, 0)]);
+        let moves = accrued.mouse_moves(|d| d);
+        assert_eq!(moves[0].map(|m| m.distance), Some(u16::MAX));
+        assert_eq!(
+            moves[1].map(|m| (m.direction, m.distance)),
+            Some((MoveDirection::Up, u16::MAX))
+        );
+        assert_eq!(
+            accrued.scrolls()[0],
+            Some((MWheelDirection::Left, u16::MAX))
+        );
+    }
+}

--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -69,6 +69,8 @@ pub struct PadEngine {
     held: PadSet,
     /// Whether the last sample found the controllers asking for movement.
     moving: bool,
+    /// Whether a debounced threshold crossing still needs clock time.
+    pending: bool,
 }
 
 impl PadEngine {
@@ -79,6 +81,7 @@ impl PadEngine {
             pads: HashMap::default(),
             held: PadSet::EMPTY,
             moving: false,
+            pending: false,
         }
     }
 
@@ -97,6 +100,17 @@ impl PadEngine {
         let moving = !self.demand().is_idle();
         let started = moving && !self.moving;
         self.moving = moving;
+        started
+    }
+
+    /// Whether a new debounced crossing needs to wake the processing loop.
+    pub fn take_pending_start(&mut self) -> bool {
+        let pending = self
+            .pads
+            .values()
+            .any(|(projector, _)| projector.has_pending());
+        let started = pending && !self.pending;
+        self.pending = pending;
         started
     }
 
@@ -130,6 +144,10 @@ impl PadEngine {
     /// nothing left that could ever release it.
     pub fn disconnect(&mut self, id: PadDeviceId, edges: &mut Vec<PadEdge>) {
         if self.pads.remove(&id).is_some() {
+            self.pending = self
+                .pads
+                .values()
+                .any(|(projector, _)| projector.has_pending());
             self.merge(edges);
         }
     }
@@ -143,10 +161,29 @@ impl PadEngine {
         }
     }
 
+    /// Advance every pending threshold crossing and publish its edges.
+    pub fn tick(&mut self, milliseconds: u16, edges: &mut Vec<PadEdge>) {
+        for (projector, _) in self.pads.values_mut() {
+            projector.tick(milliseconds);
+        }
+        self.pending = self
+            .pads
+            .values()
+            .any(|(projector, _)| projector.has_pending());
+        self.merge(edges);
+    }
+
+    pub fn has_pending(&self) -> bool {
+        self.pads
+            .values()
+            .any(|(projector, _)| projector.has_pending())
+    }
+
     /// Swap in a new declaration across every connected controller.
     pub fn reconfigure(&mut self, config: GamepadConfig, edges: &mut Vec<PadEdge>) {
         self.config = config;
         self.moving = false;
+        self.pending = false;
         for (projector, _) in self.pads.values_mut() {
             projector.reconfigure(config);
         }
@@ -157,6 +194,7 @@ impl PadEngine {
     /// controllers themselves connected.
     pub fn release_all(&mut self, edges: &mut Vec<PadEdge>) {
         self.moving = false;
+        self.pending = false;
         for (projector, _) in self.pads.values_mut() {
             projector.reset();
         }
@@ -272,6 +310,16 @@ impl GamepadHandle {
     /// What the continuous projections want this tick.
     pub fn demand(&self) -> Demand {
         self.engine.lock().demand()
+    }
+
+    /// Advance pending threshold crossings and collect their key edges.
+    pub fn tick(&self, milliseconds: u16, edges: &mut Vec<PadEdge>) {
+        self.engine.lock().tick(milliseconds, edges);
+    }
+
+    /// Whether a debounced crossing still needs clock time.
+    pub fn has_pending(&self) -> bool {
+        self.engine.lock().has_pending()
     }
 
     /// Offer a controller to the engine, as the backend does on connection.

--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -1,0 +1,200 @@
+//! Game controller input at runtime.
+//!
+//! [`source`] is the only place that knows a controller library exists: it
+//! owns a thread and sends key events straight to the processing loop, so a
+//! controller button has no more latency than a key. [`PadEngine`] merges any
+//! number of controllers into one logical pad -- a control is pressed while
+//! any controller holds it and released when the last one lets go, which is a
+//! bitwise OR of their [`PadSet`]s and one diff for the edges.
+//!
+//! Continuous output is *not* pushed. A stick driving the pointer is a rate,
+//! not an event, so the tick loop samples it once a millisecond through
+//! [`GamepadHandle::demand`]; pushing it would make pointer speed depend on
+//! how often a particular controller happens to report.
+
+pub mod source;
+
+use std::sync::Arc;
+use std::sync::mpsc::SyncSender;
+
+use kanata_parser::cfg::InputDeviceMatcher;
+use kanata_parser::custom_action::{MWheelDirection, MoveDirection};
+use kanata_parser::gamepad::{
+    Demand, GamepadConfig, MotionKind, PadEdge, PadInput, PadSet, Projector, Vec2,
+};
+use parking_lot::Mutex;
+use rustc_hash::FxHashMap as HashMap;
+
+use crate::kanata::{CalculatedMouseMove, MAPPED_KEYS};
+use crate::oskbd::{KeyEvent, KeyValue};
+
+/// A backend-assigned controller identity, stable while the device stays
+/// connected.
+///
+/// Deliberately opaque. An evdev node number or an XInput slot index is not a
+/// stable identity, and letting one become one in a config would bake in a
+/// value that changes when a device is replugged.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PadDeviceId(u32);
+
+impl PadDeviceId {
+    pub const fn new(raw: u32) -> PadDeviceId {
+        PadDeviceId(raw)
+    }
+}
+
+/// What a backend knows about a controller when it connects.
+#[derive(Clone, Debug, Default)]
+pub struct PadDeviceInfo {
+    pub name: String,
+    pub vendor_id: Option<u16>,
+    pub product_id: Option<u16>,
+}
+
+/// The result of offering a newly connected controller to the engine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Connection {
+    Accepted,
+    /// The controller did not match the configured `definputdevices` entry.
+    NotSelected,
+}
+
+/// Every connected controller, merged into one logical pad.
+pub struct PadEngine {
+    config: GamepadConfig,
+    /// The `definputdevices` entry named by `(device N)`, if any.
+    matcher: Option<InputDeviceMatcher>,
+    pads: HashMap<PadDeviceId, (Projector, PadDeviceInfo)>,
+    /// The union last handed to the layout.
+    held: PadSet,
+    /// Whether the last sample found the controllers asking for movement.
+    moving: bool,
+}
+
+impl PadEngine {
+    pub fn new(config: GamepadConfig, matcher: Option<InputDeviceMatcher>) -> PadEngine {
+        PadEngine {
+            config,
+            matcher,
+            pads: HashMap::default(),
+            held: PadSet::EMPTY,
+            moving: false,
+        }
+    }
+
+    /// Whether the controllers have *just* started asking for movement.
+    ///
+    /// A control held at a deflection produces no edges, so a motion
+    /// projection sends nothing down the input channel. The backend nudges the
+    /// processing loop once per transition into movement; from there the tick
+    /// loop keeps itself awake for as long as the demand lasts.
+    ///
+    /// The flag lives here rather than in the backend because the processing
+    /// thread resets projectors behind the backend's back, on live reload and
+    /// on a state clean. A copy cached out there would stay armed across that,
+    /// and the next push would never wake the loop.
+    pub fn take_motion_start(&mut self) -> bool {
+        let moving = !self.demand().is_idle();
+        let started = moving && !self.moving;
+        self.moving = moving;
+        started
+    }
+
+    pub fn connected_count(&self) -> usize {
+        self.pads.len()
+    }
+
+    /// Human-readable description of a connected controller, for logs.
+    pub fn device_name(&self, id: PadDeviceId) -> Option<&str> {
+        self.pads.get(&id).map(|(_, info)| info.name.as_str())
+    }
+
+    /// Offer a newly connected controller to the engine.
+    pub fn connect(&mut self, id: PadDeviceId, info: PadDeviceInfo) -> Connection {
+        if let Some(matcher) = &self.matcher
+            && !matches_device(matcher, &info)
+        {
+            return Connection::NotSelected;
+        }
+        // A backend replaying a connection is not an error; keep the state
+        // that is already tracking the device.
+        self.pads
+            .entry(id)
+            .or_insert_with(|| (Projector::new(self.config), info));
+        Connection::Accepted
+    }
+
+    /// Drop a controller, releasing everything it was holding.
+    ///
+    /// Without this a controller unplugged mid-press leaves a key down with
+    /// nothing left that could ever release it.
+    pub fn disconnect(&mut self, id: PadDeviceId, edges: &mut Vec<PadEdge>) {
+        if self.pads.remove(&id).is_some() {
+            self.merge(edges);
+        }
+    }
+
+    /// Feed one reading from a connected controller. Readings from a device
+    /// the engine never accepted are dropped.
+    pub fn feed(&mut self, id: PadDeviceId, input: PadInput, edges: &mut Vec<PadEdge>) {
+        if let Some((projector, _)) = self.pads.get_mut(&id) {
+            projector.feed(input);
+            self.merge(edges);
+        }
+    }
+
+    /// Swap in a new declaration across every connected controller.
+    pub fn reconfigure(&mut self, config: GamepadConfig, edges: &mut Vec<PadEdge>) {
+        self.config = config;
+        self.moving = false;
+        for (projector, _) in self.pads.values_mut() {
+            projector.reconfigure(config);
+        }
+        self.merge(edges);
+    }
+
+    /// Release every control every controller is holding, keeping the
+    /// controllers themselves connected.
+    pub fn release_all(&mut self, edges: &mut Vec<PadEdge>) {
+        self.moving = false;
+        for (projector, _) in self.pads.values_mut() {
+            projector.reset();
+        }
+        self.merge(edges);
+    }
+
+    /// Sum the motion demand of every controller.
+    ///
+    /// Summing rather than picking one keeps two controllers behaving like two
+    /// hands on one pointer; an idle controller contributes nothing.
+    pub fn demand(&self) -> Demand {
+        self.pads
+            .values()
+            .map(|(projector, _)| projector.demand())
+            .fold(Demand::default(), |total, demand| total + demand)
+    }
+
+    /// Republish the merged set, appending whatever transitions that implies.
+    fn merge(&mut self, edges: &mut Vec<PadEdge>) {
+        let next = self
+            .pads
+            .values()
+            .fold(PadSet::EMPTY, |all, (projector, _)| all | projector.held());
+        edges.extend(self.held.edges(next));
+        self.held = next;
+    }
+}
+
+/// Whether a controller satisfies a `definputdevices` matcher.
+///
+/// Every field the user specified has to match; fields they left out are not
+/// constraints.
+fn matches_device(matcher: &InputDeviceMatcher, info: &PadDeviceInfo) -> bool {
+    matcher.name.as_ref().is_none_or(|name| *name == info.name)
+        && matcher
+            .vendor_id
+            .is_none_or(|vendor| Some(vendor) == info.vendor_id)
+        && matcher
+            .product_id
+            .is_none_or(|product| Some(product) == info.product_id)
+}

--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -198,3 +198,138 @@ fn matches_device(matcher: &InputDeviceMatcher, info: &PadDeviceInfo) -> bool {
             .product_id
             .is_none_or(|product| Some(product) == info.product_id)
 }
+
+/// Kanata's handle on the running controller backend.
+///
+/// Nothing here reaches the processing loop by itself. Every method that can
+/// produce edges hands them back to the caller, because those callers run *on*
+/// the processing thread: pushing releases down the input channel from there
+/// would be a thread sending to itself, which can only be done with a
+/// `try_send` that drops a release when the queue is full.
+pub struct GamepadHandle {
+    engine: Arc<Mutex<PadEngine>>,
+    /// Whether anything drives the pointer or the wheel. Kept out here so the
+    /// tick loop can skip sampling -- and so skip taking the engine lock a
+    /// thousand times a second -- for the common keys-only configuration.
+    drives_motion: bool,
+}
+
+impl GamepadHandle {
+    /// Build the controller state machine, without a backend behind it.
+    ///
+    /// `devices` is the parsed `definputdevices` table, used to resolve the
+    /// `(device N)` reference if the declaration has one.
+    ///
+    /// Separate from [`GamepadHandle::spawn_backend`] so everything downstream
+    /// of the hardware can be driven from a recorded trace; the simulated
+    /// input tests stand in for the backend that way.
+    pub fn new(
+        config: GamepadConfig,
+        devices: Option<&[(std::num::NonZeroU8, InputDeviceMatcher)]>,
+    ) -> GamepadHandle {
+        GamepadHandle {
+            drives_motion: config.drives_motion(),
+            engine: Arc::new(Mutex::new(PadEngine::new(
+                config,
+                resolve_matcher(&config, devices),
+            ))),
+        }
+    }
+
+    /// Start the thread that reads real controllers into this engine.
+    pub fn spawn_backend(&self, tx: SyncSender<KeyEvent>) {
+        source::spawn(self.engine.clone(), tx);
+    }
+
+    /// Swap in a reloaded declaration, returning the edges the caller has to
+    /// apply.
+    ///
+    /// Every control the old declaration held is released first, so a
+    /// projection that disappears cannot strand a key down.
+    ///
+    /// Which controller is selected is fixed at startup and not revisited
+    /// here, matching the existing rule that `definputdevices` is not re-read
+    /// on live reload.
+    pub fn reconfigure(&mut self, config: GamepadConfig, edges: &mut Vec<PadEdge>) {
+        self.drives_motion = config.drives_motion();
+        self.engine.lock().reconfigure(config, edges);
+    }
+
+    /// Let go of everything the controllers are holding, without changing what
+    /// they project.
+    ///
+    /// `drives_motion` deliberately survives: it describes the declaration,
+    /// not the held state.
+    pub fn release_all(&mut self, edges: &mut Vec<PadEdge>) {
+        self.engine.lock().release_all(edges);
+    }
+
+    /// Whether the tick loop has anything to sample.
+    pub fn drives_motion(&self) -> bool {
+        self.drives_motion
+    }
+
+    /// What the continuous projections want this tick.
+    pub fn demand(&self) -> Demand {
+        self.engine.lock().demand()
+    }
+
+    /// Offer a controller to the engine, as the backend does on connection.
+    ///
+    /// Public for the simulated-input tests, which have no hardware to
+    /// connect; the backend thread owns the engine directly.
+    pub fn connect(&self, id: PadDeviceId, info: PadDeviceInfo) -> Connection {
+        self.engine.lock().connect(id, info)
+    }
+
+    /// Feed one reading from a connected controller, as the backend does.
+    pub fn feed(&self, id: PadDeviceId, input: PadInput, edges: &mut Vec<PadEdge>) {
+        self.engine.lock().feed(id, input, edges);
+    }
+}
+
+fn resolve_matcher(
+    config: &GamepadConfig,
+    devices: Option<&[(std::num::NonZeroU8, InputDeviceMatcher)]>,
+) -> Option<InputDeviceMatcher> {
+    let wanted = config.device?;
+    let (_, matcher) = devices?.iter().find(|(id, _)| *id == wanted)?;
+    // `hash` is a keyboard-only concept. Reported rather than silently
+    // ignored, because a config that looks like it selects one device but
+    // actually accepts all of them is worse than a warning.
+    if matcher.hash.is_some() {
+        log::warn!(
+            "gamepad: definputdevices entry {wanted} matches on `hash`, which controllers \
+             do not report. Match on name, vendor_id or product_id instead."
+        );
+    }
+    Some(matcher.clone())
+}
+
+/// Turn the edges a controller produced into input events for the processing
+/// loop, dropping any control `defsrc` does not map.
+///
+/// This is the same gate the keyboard path uses. There is no passthrough
+/// branch because the controller was never seized: the OS already saw the
+/// original event.
+///
+/// Filtering is separated from delivery so that no caller holds the
+/// `MAPPED_KEYS` lock while doing anything that can block. A live reload
+/// replaces `MAPPED_KEYS` from the thread that drains the input channel, so a
+/// send under this lock would let the two wait on each other.
+pub(crate) fn gate_on_defsrc(edges: &[PadEdge], out: &mut Vec<KeyEvent>) {
+    if edges.is_empty() {
+        return;
+    }
+    let mapped = MAPPED_KEYS.lock();
+    out.extend(edges.iter().filter_map(|edge| {
+        let code = edge.code.os_code();
+        mapped.contains(&code).then(|| {
+            let value = match edge.pressed {
+                true => KeyValue::Press,
+                false => KeyValue::Release,
+            };
+            KeyEvent::new(code, value)
+        })
+    }));
+}

--- a/src/gamepad/mod.rs
+++ b/src/gamepad/mod.rs
@@ -333,3 +333,86 @@ pub(crate) fn gate_on_defsrc(edges: &[PadEdge], out: &mut Vec<KeyEvent>) {
         })
     }));
 }
+
+/// Carries fractional pointer and wheel movement between ticks.
+///
+/// A stick at 30% of a 25,000 px/s speed asks for 7.5 pixels a millisecond.
+/// Rounding each tick independently would run permanently slow or fast, and
+/// rounding a small demand to zero would make slow movement impossible rather
+/// than merely slow.
+#[derive(Default)]
+pub struct Accumulator([Vec2; MotionKind::ALL.len()]);
+
+impl Accumulator {
+    /// Add this tick's demand and take whatever whole units have accrued.
+    pub fn accrue(&mut self, demand: Demand) -> Accrued {
+        let mut accrued = Accrued::default();
+        for kind in MotionKind::ALL {
+            let carry = &mut self.0[kind as usize];
+            *carry += demand[kind];
+            accrued.0[kind as usize] = carry.take_whole();
+        }
+        accrued
+    }
+
+    /// Drop any partial movement.
+    ///
+    /// Called when everything returns to rest, so a fraction left over from
+    /// the last push cannot leak into the next one as a stray pixel.
+    pub fn reset(&mut self) {
+        *self = Accumulator::default();
+    }
+}
+
+/// Whole units ready to send to the OS this tick.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Accrued([(i32, i32); MotionKind::ALL.len()]);
+
+impl Accrued {
+    pub fn is_empty(self) -> bool {
+        self.0.iter().all(|axes| *axes == (0, 0))
+    }
+
+    /// The pointer moves this tick, as kanata's mouse primitives take them.
+    ///
+    /// One entry per axis, `None` for an axis that is not moving; the caller
+    /// picks `move_mouse` or `move_mouse_many` from what is present. An array
+    /// rather than a `Vec` keeps the per-millisecond tick path allocation
+    /// free.
+    pub fn mouse_moves(self, scale: impl Fn(u16) -> u16) -> [Option<CalculatedMouseMove>; 2] {
+        let (x, y) = self.0[MotionKind::Mouse as usize];
+        [
+            split(x, MoveDirection::Right, MoveDirection::Left),
+            split(y, MoveDirection::Down, MoveDirection::Up),
+        ]
+        .map(|axis| {
+            axis.map(|(direction, distance)| CalculatedMouseMove {
+                direction,
+                distance: scale(distance),
+            })
+        })
+    }
+
+    /// The wheel notches this tick, as (direction, distance) pairs.
+    pub fn scrolls(self) -> [Option<(MWheelDirection, u16)>; 2] {
+        let (x, y) = self.0[MotionKind::Scroll as usize];
+        [
+            split(x, MWheelDirection::Right, MWheelDirection::Left),
+            // Stick Y and wheel-up are both up-positive, so no flip here. The
+            // user-facing invert-y knob was applied in the projection.
+            split(y, MWheelDirection::Up, MWheelDirection::Down),
+        ]
+    }
+}
+
+/// Split a signed amount into a direction and a distance, or `None` for an
+/// axis that is not moving. Saturating, so an absurd demand cannot wrap.
+fn split<T>(amount: i32, positive: T, negative: T) -> Option<(T, u16)> {
+    match amount {
+        0 => None,
+        _ => Some((
+            if amount > 0 { positive } else { negative },
+            amount.unsigned_abs().min(u16::MAX as u32) as u16,
+        )),
+    }
+}

--- a/src/gamepad/source.rs
+++ b/src/gamepad/source.rs
@@ -1,0 +1,178 @@
+//! The controller backend: gilrs events in, [`PadInput`] out.
+//!
+//! The only file that knows a controller library exists. It runs on its own
+//! thread because `gilrs::Gilrs` is not `Send` on every platform, so the
+//! context is built inside the thread and only translated events leave it. One
+//! backend covers Linux (evdev), macOS (IOKit) and Windows (XInput), which is
+//! why there is not a single `#[cfg]` below.
+//!
+//! Worth stating plainly rather than leaving to be discovered: **the
+//! controller is not seized.** Games and the desktop still see the pad, so
+//! kanata cannot suppress the original input the way it does for a grabbed
+//! keyboard.
+
+use std::sync::Arc;
+use std::sync::mpsc::SyncSender;
+use std::time::Duration;
+
+use gilrs::{Axis, Button, Event, EventType, GilrsBuilder};
+use kanata_parser::gamepad::{
+    Cardinal, CardinalSet, PadButton, PadEdge, PadInput, Side, StickPosition, Unit,
+};
+use kanata_parser::keys::OsCode;
+use parking_lot::Mutex;
+use rustc_hash::FxHashMap as HashMap;
+
+use super::{Connection, PadDeviceId, PadDeviceInfo, PadEngine, gate_on_defsrc};
+use crate::oskbd::{KeyEvent, KeyValue};
+
+/// How long to wait for a controller event before looping.
+///
+/// Only exists so the thread can notice that the processing loop has gone away
+/// and exit, instead of blocking forever on a channel nobody reads.
+const POLL_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// What a gilrs button name is, in kanata's vocabulary.
+///
+/// Both vocabularies are positional, so this is a rename rather than a
+/// remapping: gilrs's `South` and kanata's `pad-south` are the same physical
+/// control on every controller.
+enum Control {
+    Button(PadButton),
+    /// A d-pad contact, which is a direction rather than a button.
+    Contact(Cardinal),
+    /// A control gilrs could not name. It reaches the layout only if the user
+    /// bound its backend code to a slot in `defgamepad`.
+    Unnamed,
+}
+
+fn classify(button: Button) -> Control {
+    match button {
+        Button::South => Control::Button(PadButton::South),
+        Button::East => Control::Button(PadButton::East),
+        Button::West => Control::Button(PadButton::West),
+        Button::North => Control::Button(PadButton::North),
+        Button::C => Control::Button(PadButton::C),
+        Button::Z => Control::Button(PadButton::Z),
+        Button::LeftTrigger => Control::Button(PadButton::L1),
+        Button::RightTrigger => Control::Button(PadButton::R1),
+        Button::LeftTrigger2 => Control::Button(PadButton::L2),
+        Button::RightTrigger2 => Control::Button(PadButton::R2),
+        Button::Select => Control::Button(PadButton::Select),
+        Button::Start => Control::Button(PadButton::Start),
+        Button::Mode => Control::Button(PadButton::Mode),
+        Button::LeftThumb => Control::Button(PadButton::L3),
+        Button::RightThumb => Control::Button(PadButton::R3),
+        Button::DPadUp => Control::Contact(Cardinal::Up),
+        Button::DPadDown => Control::Contact(Cardinal::Down),
+        Button::DPadLeft => Control::Contact(Cardinal::Left),
+        Button::DPadRight => Control::Contact(Cardinal::Right),
+        // Deliberately exhaustive: if gilrs grows a button this should stop
+        // compiling rather than silently drop the control.
+        Button::Unknown => Control::Unnamed,
+    }
+}
+
+/// The stick a gilrs axis belongs to, if it is one. Triggers and extra axes
+/// are reported through their own events.
+fn stick_side(axis: Axis) -> Option<Side> {
+    match axis {
+        Axis::LeftStickX | Axis::LeftStickY => Some(Side::Left),
+        Axis::RightStickX | Axis::RightStickY => Some(Side::Right),
+        _ => None,
+    }
+}
+
+/// The trigger an analog button report belongs to, if it is one.
+fn trigger_side(button: Button) -> Option<Side> {
+    match button {
+        Button::LeftTrigger2 => Some(Side::Left),
+        Button::RightTrigger2 => Some(Side::Right),
+        _ => None,
+    }
+}
+
+/// Per-controller latching the backend itself needs, as distinct from the
+/// projection state the engine holds.
+///
+/// A stick reports its axes one at a time and a d-pad reports one contact at a
+/// time, but a projection needs the whole reading: fed piecemeal, a diagonal
+/// push briefly looks like a cardinal one and emits a spurious edge. Latching
+/// the most recent value of each is what makes a whole reading reach the
+/// projector.
+#[derive(Default)]
+struct Pad {
+    sticks: [StickPosition; 2],
+    hat: CardinalSet,
+    contacts: CardinalSet,
+}
+
+/// Translate one backend event into a reading, or `None` for an event that
+/// carries no input.
+fn translate(event: EventType, pad: &mut Pad) -> Option<PadInput> {
+    Some(match event {
+        EventType::ButtonPressed(button, code) | EventType::ButtonReleased(button, code) => {
+            let pressed = matches!(event, EventType::ButtonPressed(..));
+            match classify(button) {
+                Control::Button(button) => PadInput::Button { button, pressed },
+                Control::Contact(dir) => {
+                    pad.contacts.set(dir, pressed);
+                    PadInput::Contacts(pad.contacts)
+                }
+                Control::Unnamed => {
+                    let code = code.into_u32();
+                    log::debug!(
+                        "gamepad: unnamed control {code}; bind it with (button-slot N {code})"
+                    );
+                    PadInput::Native { code, pressed }
+                }
+            }
+        }
+        // A trigger's analog half. The digital half arrives separately as a
+        // ButtonPressed and the projector holds the control while either says
+        // so. Any other analog button report duplicates a digital edge that is
+        // already handled.
+        EventType::ButtonChanged(button, value, _) => PadInput::Trigger {
+            side: trigger_side(button)?,
+            value: Unit::new(value),
+        },
+        EventType::AxisChanged(Axis::DPadX, value, _) => {
+            quantize(&mut pad.hat, value, Cardinal::Right, Cardinal::Left);
+            PadInput::Hat(pad.hat)
+        }
+        EventType::AxisChanged(Axis::DPadY, value, _) => {
+            quantize(&mut pad.hat, value, Cardinal::Up, Cardinal::Down);
+            PadInput::Hat(pad.hat)
+        }
+        EventType::AxisChanged(axis, value, _) => {
+            let side = stick_side(axis)?;
+            let previous = pad.sticks[side as usize];
+            let vector = match axis {
+                Axis::LeftStickX | Axis::RightStickX => {
+                    StickPosition::new(value, previous.y().get())
+                }
+                _ => StickPosition::new(previous.x().get(), value),
+            };
+            pad.sticks[side as usize] = vector;
+            PadInput::Stick {
+                side,
+                value: vector,
+            }
+        }
+        // Connection changes are handled by the caller, which needs the gilrs
+        // context to describe the device. Anything else -- a dropped filter
+        // event, force feedback finishing -- is not input.
+        _ => return None,
+    })
+}
+
+/// Collapse a driver's analog hat reading onto one axis of the set.
+///
+/// A hat is digital hardware, but drivers report it through an analog axis and
+/// some bounce through intermediate values on the way. The band is wide
+/// because only the extremes carry meaning, and a NaN reads as centered rather
+/// than as a direction jammed on.
+fn quantize(hat: &mut CardinalSet, value: f32, positive: Cardinal, negative: Cardinal) {
+    hat.set(positive, value > 0.5);
+    hat.set(negative, value < -0.5);
+}

--- a/src/gamepad/source.rs
+++ b/src/gamepad/source.rs
@@ -176,3 +176,110 @@ fn quantize(hat: &mut CardinalSet, value: f32, positive: Cardinal, negative: Car
     hat.set(positive, value > 0.5);
     hat.set(negative, value < -0.5);
 }
+
+/// Everything the backend thread owns except the gilrs context itself.
+///
+/// Split out because building a `Gilrs` needs hardware and none of this does:
+/// with the context on one side of the line, the whole event path -- latching,
+/// projection, the `defsrc` gate -- can be driven from a recorded trace.
+struct Dispatcher {
+    engine: Arc<Mutex<PadEngine>>,
+    pads: HashMap<PadDeviceId, Pad>,
+    edges: Vec<PadEdge>,
+    events: Vec<KeyEvent>,
+}
+
+impl Dispatcher {
+    fn new(engine: Arc<Mutex<PadEngine>>) -> Dispatcher {
+        Dispatcher {
+            engine,
+            pads: HashMap::default(),
+            edges: Vec::new(),
+            events: Vec::new(),
+        }
+    }
+
+    /// Handle one backend event, returning the input events it implies.
+    ///
+    /// `info` describes the device and is needed only for a connection, which
+    /// is the one thing that has to be read out of the gilrs context.
+    fn dispatch(
+        &mut self,
+        device: PadDeviceId,
+        event: EventType,
+        info: Option<PadDeviceInfo>,
+    ) -> &[KeyEvent] {
+        self.edges.clear();
+        self.events.clear();
+        // Only an analog reading or a departing controller can change what the
+        // continuous projections are asking for.
+        let mut resampled = matches!(event, EventType::Disconnected);
+        match event {
+            EventType::Connected => {
+                self.pads.insert(device, Pad::default());
+                if let Some(info) = info {
+                    self.offer(device, info);
+                }
+            }
+            EventType::Disconnected => {
+                self.pads.remove(&device);
+                let mut engine = self.engine.lock();
+                if let Some(name) = engine.device_name(device) {
+                    log::info!("gamepad: {name} disconnected");
+                }
+                engine.disconnect(device, &mut self.edges);
+            }
+            other => {
+                let pad = self.pads.entry(device).or_default();
+                if let Some(input) = translate(other, pad) {
+                    // Anything that is not a digital control can change what
+                    // the continuous projections are asking for -- including a
+                    // d-pad contact or hat, because a d-pad reads as a stick
+                    // at full deflection.
+                    resampled |=
+                        !matches!(input, PadInput::Button { .. } | PadInput::Native { .. });
+                    // The engine lock is dropped at the end of this statement,
+                    // before the gate below takes MAPPED_KEYS and before the
+                    // caller sends. The processing thread takes the engine lock
+                    // during a live reload, so holding it across either would
+                    // let the two wait on each other.
+                    self.engine.lock().feed(device, input, &mut self.edges);
+                }
+            }
+        }
+        gate_on_defsrc(&self.edges, &mut self.events);
+        if resampled {
+            self.wake_for_motion();
+        }
+        &self.events
+    }
+
+    /// Nudge the processing loop when a control starts asking for movement.
+    ///
+    /// A stick held at a deflection produces no edges -- it is already where
+    /// the user put it -- so a mouse or scroll projection sends *nothing* down
+    /// the input channel. Without this the loop would go idle, block on the
+    /// channel, and leave the pointer frozen mid-push until some unrelated
+    /// input happened to wake it.
+    ///
+    /// One nudge per transition into movement is enough: from there the tick
+    /// loop keeps itself awake for as long as the demand lasts, and the next
+    /// reading that returns to rest arms this again.
+    fn wake_for_motion(&mut self) {
+        if self.engine.lock().take_motion_start() {
+            self.events
+                .push(KeyEvent::new(OsCode::KEY_RESERVED, KeyValue::WakeUp));
+        }
+    }
+
+    fn offer(&self, id: PadDeviceId, info: PadDeviceInfo) {
+        let name = info.name.clone();
+        match self.engine.lock().connect(id, info) {
+            Connection::Accepted => log::info!("gamepad: using \"{name}\""),
+            Connection::NotSelected => log::info!(
+                "gamepad: ignoring \"{name}\", it does not match the definputdevices \
+                 entry named by defgamepad"
+            ),
+        }
+    }
+}

--- a/src/gamepad/source.rs
+++ b/src/gamepad/source.rs
@@ -283,3 +283,61 @@ impl Dispatcher {
         }
     }
 }
+
+/// Start the controller thread.
+///
+/// Returns immediately. Failure to reach a controller backend is logged and
+/// leaves kanata running as a keyboard remapper, because a missing controller
+/// library is not a reason to refuse to start.
+pub fn spawn(engine: Arc<Mutex<PadEngine>>, tx: SyncSender<KeyEvent>) {
+    std::thread::spawn(move || {
+        if let Err(e) = run(engine, tx) {
+            log::error!("gamepad: input thread stopped: {e}");
+        }
+    });
+}
+
+fn run(engine: Arc<Mutex<PadEngine>>, tx: SyncSender<KeyEvent>) -> Result<(), String> {
+    // Default filters would apply gilrs's own deadzone and jitter handling on
+    // top of ours. The projector is built to be exact, so it wants raw values.
+    let mut gilrs = GilrsBuilder::new()
+        .with_default_filters(false)
+        .set_update_state(false)
+        .build()
+        .map_err(|e| format!("could not start a controller backend: {e}"))?;
+
+    let mut dispatcher = Dispatcher::new(engine);
+    for (id, pad) in gilrs.gamepads() {
+        dispatcher.offer(device_id(id), describe(&pad));
+    }
+    log::info!(
+        "gamepad: backend ready, {} controller(s) connected",
+        dispatcher.engine.lock().connected_count()
+    );
+
+    loop {
+        let Some(Event { id, event, .. }) = gilrs.next_event_blocking(Some(POLL_TIMEOUT)) else {
+            continue;
+        };
+        // Reading the device out of the context is the one thing `dispatch`
+        // cannot do for itself.
+        let info = matches!(event, EventType::Connected).then(|| describe(&gilrs.gamepad(id)));
+        for event in dispatcher.dispatch(device_id(id), event, info) {
+            if tx.send(*event).is_err() {
+                return Ok(());
+            }
+        }
+    }
+}
+
+fn device_id(id: gilrs::GamepadId) -> PadDeviceId {
+    PadDeviceId::new(usize::from(id) as u32)
+}
+
+fn describe(pad: &gilrs::Gamepad<'_>) -> PadDeviceInfo {
+    PadDeviceInfo {
+        name: pad.name().to_string(),
+        vendor_id: pad.vendor_id(),
+        product_id: pad.product_id(),
+    }
+}

--- a/src/gamepad/source.rs
+++ b/src/gamepad/source.rs
@@ -251,6 +251,7 @@ impl Dispatcher {
         if resampled {
             self.wake_for_motion();
         }
+        self.wake_for_pending();
         &self.events
     }
 
@@ -267,6 +268,16 @@ impl Dispatcher {
     /// reading that returns to rest arms this again.
     fn wake_for_motion(&mut self) {
         if self.engine.lock().take_motion_start() {
+            self.events
+                .push(KeyEvent::new(OsCode::KEY_RESERVED, KeyValue::WakeUp));
+        }
+    }
+
+    /// A debounced crossing has no edge yet, but the timer that makes it an
+    /// edge belongs to the processing loop. Wake it exactly once per pending
+    /// period; `is_idle` keeps the loop running until the period completes.
+    fn wake_for_pending(&mut self) {
+        if self.engine.lock().take_pending_start() {
             self.events
                 .push(KeyEvent::new(OsCode::KEY_RESERVED, KeyValue::WakeUp));
         }

--- a/src/gamepad/source.rs
+++ b/src/gamepad/source.rs
@@ -341,3 +341,265 @@ fn describe(pad: &gilrs::Gamepad<'_>) -> PadDeviceInfo {
         product_id: pad.product_id(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kanata_parser::gamepad::{
+        Digital, Dir, DirMode, Directional, GamepadConfig, Motion, MotionKind, PadCode, PadSet,
+        Projection, Unit,
+    };
+
+    fn code() -> gilrs::ev::Code {
+        // gilrs exposes backend codes only through a live device, so borrow
+        // one from a button that always has a mapping.
+        Button::South.to_nec().expect("South always has a code")
+    }
+
+    fn axis(axis: Axis, value: f32) -> EventType {
+        EventType::AxisChanged(axis, value, code())
+    }
+
+    fn translated(events: &[EventType]) -> Vec<PadInput> {
+        let mut pad = Pad::default();
+        events
+            .iter()
+            .filter_map(|event| translate(*event, &mut pad))
+            .collect()
+    }
+
+    #[test]
+    fn a_multi_axis_report_carries_every_axis_with_it() {
+        // Backends report one axis at a time, but a projection needs the whole
+        // reading: without the latch a diagonal push briefly looks cardinal.
+        assert_eq!(
+            translated(&[
+                axis(Axis::LeftStickX, 0.5),
+                axis(Axis::RightStickY, 1.0),
+                axis(Axis::LeftStickY, -0.25),
+            ]),
+            vec![
+                PadInput::Stick {
+                    side: Side::Left,
+                    value: StickPosition::new(0.5, 0.0)
+                },
+                PadInput::Stick {
+                    side: Side::Right,
+                    value: StickPosition::new(0.0, 1.0)
+                },
+                // The right stick's report must not have disturbed the left.
+                PadInput::Stick {
+                    side: Side::Left,
+                    value: StickPosition::new(0.5, -0.25)
+                },
+            ]
+        );
+        assert_eq!(
+            translated(&[axis(Axis::DPadX, 1.0), axis(Axis::DPadY, -1.0)]),
+            vec![
+                PadInput::Hat(CardinalSet::of(&[Cardinal::Right])),
+                PadInput::Hat(CardinalSet::of(&[Cardinal::Right, Cardinal::Down])),
+            ]
+        );
+        assert_eq!(
+            translated(&[
+                EventType::ButtonPressed(Button::DPadUp, code()),
+                EventType::ButtonPressed(Button::DPadRight, code()),
+            ]),
+            vec![
+                PadInput::Contacts(CardinalSet::of(&[Cardinal::Up])),
+                PadInput::Contacts(CardinalSet::of(&[Cardinal::Up, Cardinal::Right])),
+            ]
+        );
+    }
+
+    #[test]
+    fn only_the_trigger_axes_survive_as_analog_readings() {
+        assert_eq!(
+            translated(&[
+                EventType::ButtonChanged(Button::LeftTrigger2, 0.75, code()),
+                // The digital edge for this already arrived as ButtonPressed;
+                // acting on the analog report too would double-fire.
+                EventType::ButtonChanged(Button::South, 1.0, code()),
+                EventType::ButtonChanged(Button::LeftTrigger, 1.0, code()),
+                // And an axis that names no control is dropped entirely.
+                axis(Axis::LeftZ, 1.0),
+            ]),
+            vec![PadInput::Trigger {
+                side: Side::Left,
+                value: Unit::new(0.75)
+            }]
+        );
+        // A control gilrs cannot name keeps its backend code, so the user can
+        // bind it to a slot.
+        assert!(matches!(
+            translated(&[EventType::ButtonPressed(Button::Unknown, code())]).as_slice(),
+            [PadInput::Native { .. }]
+        ));
+    }
+
+    #[test]
+    fn a_diagonal_push_never_looks_like_a_cardinal_one() {
+        // The seam between `translate` and the engine, each of which is
+        // covered on its own. Both axes cross the threshold in the same frame
+        // but arrive one at a time, and latching is what stops the first
+        // report from leaving Right held on the way to Up-Right.
+        let mut config = GamepadConfig::default();
+        config.projection_mut(Directional::LeftStick).digital = Some(Digital {
+            mode: DirMode::EightWay,
+            ..Digital::default()
+        });
+        let device = PadDeviceId::new(0);
+        let mut engine = PadEngine::new(config, None);
+        engine.connect(device, PadDeviceInfo::default());
+        let mut pad = Pad::default();
+        let mut edges = Vec::new();
+        for event in [axis(Axis::LeftStickX, 0.8), axis(Axis::LeftStickY, 0.8)] {
+            let input = translate(event, &mut pad).expect("a reading");
+            engine.feed(device, input, &mut edges);
+        }
+        let held = edges.iter().fold(PadSet::EMPTY, |mut set, edge| {
+            set.set(edge.code, edge.pressed);
+            set
+        });
+        assert_eq!(
+            held.iter().collect::<Vec<_>>(),
+            vec![PadCode::direction(Directional::LeftStick, Dir::UpRight)]
+        );
+    }
+
+    // The event path the backend thread actually runs, minus the gilrs context
+    // it cannot build without hardware.
+
+    /// Drive a `Dispatcher` over a trace, with `defsrc` claiming `mapped`.
+    ///
+    /// `MAPPED_KEYS` is process-wide, so these serialize on the same lock the
+    /// config tests use rather than racing a parse in another test.
+    fn dispatch_trace(
+        config: GamepadConfig,
+        mapped: &[OsCode],
+        trace: &[(PadDeviceId, EventType)],
+    ) -> Vec<KeyEvent> {
+        let _lk = match crate::tests::CFG_PARSE_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let previous = std::mem::take(&mut *crate::kanata::MAPPED_KEYS.lock());
+        crate::kanata::MAPPED_KEYS
+            .lock()
+            .extend(mapped.iter().copied());
+
+        let mut dispatcher = Dispatcher::new(Arc::new(Mutex::new(PadEngine::new(config, None))));
+        let mut seen = Vec::new();
+        for (device, event) in trace {
+            let info = matches!(event, EventType::Connected).then(PadDeviceInfo::default);
+            seen.extend_from_slice(dispatcher.dispatch(*device, *event, info));
+        }
+
+        *crate::kanata::MAPPED_KEYS.lock() = previous;
+        seen
+    }
+
+    fn mouse_config() -> GamepadConfig {
+        let mut config = GamepadConfig::default();
+        *config.projection_mut(Directional::RightStick) = Projection {
+            digital: None,
+            motions: {
+                let mut motions: kanata_parser::gamepad::Motions<Motion> = Default::default();
+                motions.set(
+                    MotionKind::Mouse,
+                    Motion {
+                        deadzone: Unit::ZERO,
+                        ..Motion::MOUSE
+                    },
+                );
+                motions
+            },
+        };
+        config
+    }
+
+    fn push(x: f32) -> (PadDeviceId, EventType) {
+        (PadDeviceId::new(0), axis(Axis::RightStickX, x))
+    }
+
+    #[test]
+    fn a_stick_driving_the_pointer_wakes_the_loop_once_per_push() {
+        // A stick held at a deflection produces no edges, so a mouse
+        // projection sends nothing down the input channel. Without a nudge the
+        // loop goes idle, blocks on that channel, and the pointer freezes
+        // mid-push until some unrelated input happens to wake it. One nudge is
+        // enough: from there the tick loop keeps itself awake, so a nudge per
+        // sample would be channel noise at the controller's report rate.
+        let mut trace = vec![(PadDeviceId::new(0), EventType::Connected)];
+        trace.extend((0..10).map(|step| push(1.0 - step as f32 / 100.0)));
+        let events = dispatch_trace(mouse_config(), &[], &trace);
+        assert_eq!(
+            events.iter().map(|e| e.value).collect::<Vec<_>>(),
+            vec![KeyValue::WakeUp],
+            "pushing the stick should wake the loop exactly once: {events:?}"
+        );
+
+        // Returning to rest and pushing again arms it for the next push.
+        let mut trace = vec![(PadDeviceId::new(0), EventType::Connected)];
+        trace.extend([push(1.0), push(0.0), push(-1.0)]);
+        assert_eq!(
+            dispatch_trace(mouse_config(), &[], &trace).len(),
+            2,
+            "the second push did not wake the loop"
+        );
+    }
+
+    #[test]
+    fn nothing_wakes_the_loop_when_no_control_drives_motion() {
+        // The nudge exists for continuous output only. A digital config has
+        // edges to send, so it may not cost a spurious wake-up.
+        let mut config = GamepadConfig::default();
+        config.projection_mut(Directional::RightStick).digital = Some(Digital::default());
+        let mut trace = vec![
+            (PadDeviceId::new(0), EventType::Connected),
+            (
+                PadDeviceId::new(0),
+                EventType::ButtonPressed(Button::South, code()),
+            ),
+        ];
+        trace.push(push(1.0));
+        let events = dispatch_trace(
+            config,
+            &[PadCode::button(PadButton::South).os_code()],
+            &trace,
+        );
+        assert!(
+            events.iter().all(|e| e.value != KeyValue::WakeUp),
+            "a digital config woke the loop for nothing: {events:?}"
+        );
+    }
+
+    #[test]
+    fn only_mapped_controls_of_a_connected_pad_reach_the_loop() {
+        // The same `defsrc` gate the keyboard path uses; without it a
+        // controller would press coordinates the layout does not own. A pad
+        // unplugged mid-press has to release, too, or the key is stranded with
+        // nothing left that could ever let go of it.
+        let pad = PadDeviceId::new(3);
+        let south = PadCode::button(PadButton::South).os_code();
+        let events = dispatch_trace(
+            GamepadConfig::default(),
+            &[south],
+            &[
+                (pad, EventType::Connected),
+                (pad, EventType::ButtonPressed(Button::South, code())),
+                (pad, EventType::ButtonPressed(Button::East, code())),
+                (
+                    PadDeviceId::new(7),
+                    EventType::ButtonPressed(Button::South, code()),
+                ),
+                (pad, EventType::Disconnected),
+            ],
+        );
+        assert_eq!(
+            events.iter().map(|e| (e.code, e.value)).collect::<Vec<_>>(),
+            vec![(south, KeyValue::Press), (south, KeyValue::Release)]
+        );
+    }
+}

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -202,6 +202,8 @@ pub struct Kanata {
     /// freeze mid-push until the controller happened to send another event.
     /// The keyboard-driven mouse states are in `is_idle` for the same reason.
     gamepad_moving: bool,
+    /// Whether a debounced controller threshold crossing is waiting to settle.
+    gamepad_pending: bool,
     /// The user configuration for backtracking to find valid sequences. See
     /// <../../docs/sequence-adding-chords-ideas.md> for more info.
     pub sequence_backtrack_modcancel: bool,
@@ -491,6 +493,7 @@ impl Kanata {
             gamepad: None,
             gamepad_accumulator: Default::default(),
             gamepad_moving: false,
+            gamepad_pending: false,
             sequence_backtrack_modcancel: cfg.options.sequence_backtrack_modcancel,
             sequence_always_on: cfg.options.sequence_always_on,
             sequence_input_mode: cfg.options.sequence_input_mode,
@@ -651,6 +654,7 @@ impl Kanata {
             gamepad: None,
             gamepad_accumulator: Default::default(),
             gamepad_moving: false,
+            gamepad_pending: false,
             sequence_backtrack_modcancel: cfg.options.sequence_backtrack_modcancel,
             sequence_always_on: cfg.options.sequence_always_on,
             sequence_input_mode: cfg.options.sequence_input_mode,
@@ -838,6 +842,7 @@ impl Kanata {
             // meaning under the new one.
             self.gamepad_accumulator.reset();
             self.gamepad_moving = false;
+            self.gamepad_pending = false;
             let mut edges = Vec::new();
             match (&mut self.gamepad, self.gamepad_config) {
                 // A declaration that was removed is a reconfiguration to
@@ -1102,6 +1107,7 @@ impl Kanata {
         self.live_reload_requested |= self.handle_keystate_changes(_tx)?;
         self.handle_scrolling()?;
         self.handle_move_mouse()?;
+        self.handle_gamepad_edges()?;
         self.handle_gamepad_motion()?;
         self.tick_sequence_state()?;
         self.tick_idle_timeout();
@@ -1157,6 +1163,22 @@ impl Kanata {
             self.kbd_out.scroll(direction, distance)?;
         }
         Ok(())
+    }
+
+    /// Advance controller thresholds that are waiting to settle.
+    ///
+    /// This follows Kanata's other millisecond waiting states: the backend
+    /// records a pending crossing, and the processing loop owns the clock and
+    /// applies the eventual edges through the normal layout path.
+    fn handle_gamepad_edges(&mut self) -> Result<()> {
+        let Some(gamepad) = self.gamepad.as_ref() else {
+            self.gamepad_pending = false;
+            return Ok(());
+        };
+        let mut edges = Vec::new();
+        gamepad.tick(1, &mut edges);
+        self.gamepad_pending = gamepad.has_pending();
+        self.apply_gamepad_edges(&edges)
     }
 
     /// Feed edges a controller produced into the processing loop.
@@ -2699,7 +2721,7 @@ impl Kanata {
     pub fn is_idle(&self) -> bool {
         let pressed_keys_means_not_idle =
             !self.waiting_for_idle.is_empty() || self.live_reload_requested;
-        if self.gamepad_moving {
+        if self.gamepad_moving || self.gamepad_pending {
             return false;
         }
         let layout = self.layout.b();

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -183,6 +183,25 @@ pub struct Kanata {
     pub move_mouse_state_horizontal: Option<MoveMouseState>,
     /// A list of mouse speed modifiers in percentages by which mouse travel distance is scaled.
     pub move_mouse_speed_modifiers: Vec<u16>,
+    /// Effective controller configuration, retained so that a live reload can
+    /// hand new projections to the running backend. Also present when mapped
+    /// portable buttons require only the defaults and no `defgamepad` block.
+    pub gamepad_config: Option<kanata_parser::gamepad::GamepadConfig>,
+    /// Handle on the controller backend. `None` until `start_gamepad` runs,
+    /// and permanently `None` for configurations that never mention a
+    /// controller, which is what keeps kanata from opening controller devices
+    /// it was not asked to touch.
+    pub gamepad: Option<crate::gamepad::GamepadHandle>,
+    /// Carries fractional pointer and scroll movement between ticks.
+    gamepad_accumulator: crate::gamepad::Accumulator,
+    /// Whether the last sample found a stick asking for continuous movement.
+    ///
+    /// Read by `is_idle`. A stick held at a deflection reports *nothing* — it
+    /// is already where the user put it — so without this the processing loop
+    /// would conclude it had nothing to do and block, and the pointer would
+    /// freeze mid-push until the controller happened to send another event.
+    /// The keyboard-driven mouse states are in `is_idle` for the same reason.
+    gamepad_moving: bool,
     /// The user configuration for backtracking to find valid sequences. See
     /// <../../docs/sequence-adding-chords-ideas.md> for more info.
     pub sequence_backtrack_modcancel: bool,
@@ -364,7 +383,7 @@ enum ReloadAction {
     ReloadFile(String),
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CalculatedMouseMove {
     pub direction: MoveDirection,
     pub distance: u16,
@@ -468,6 +487,10 @@ impl Kanata {
             move_mouse_state_vertical: None,
             move_mouse_state_horizontal: None,
             move_mouse_speed_modifiers: Vec::new(),
+            gamepad_config: cfg.gamepad,
+            gamepad: None,
+            gamepad_accumulator: Default::default(),
+            gamepad_moving: false,
             sequence_backtrack_modcancel: cfg.options.sequence_backtrack_modcancel,
             sequence_always_on: cfg.options.sequence_always_on,
             sequence_input_mode: cfg.options.sequence_input_mode,
@@ -624,6 +647,10 @@ impl Kanata {
             move_mouse_state_vertical: None,
             move_mouse_state_horizontal: None,
             move_mouse_speed_modifiers: Vec::new(),
+            gamepad_config: cfg.gamepad,
+            gamepad: None,
+            gamepad_accumulator: Default::default(),
+            gamepad_moving: false,
             sequence_backtrack_modcancel: cfg.options.sequence_backtrack_modcancel,
             sequence_always_on: cfg.options.sequence_always_on,
             sequence_input_mode: cfg.options.sequence_input_mode,
@@ -739,7 +766,7 @@ impl Kanata {
         Ok(Arc::new(Mutex::new(k)))
     }
 
-    fn do_live_reload(&mut self, _tx: &Option<Sender<ServerMessage>>) -> Result<()> {
+    pub(crate) fn do_live_reload(&mut self, _tx: &Option<Sender<ServerMessage>>) -> Result<()> {
         let cfg = match cfg::new_from_file(&self.cfg_paths[self.cur_cfg_idx]) {
             Ok(c) => c,
             Err(e) => {
@@ -801,6 +828,37 @@ impl Kanata {
         }
 
         *MAPPED_KEYS.lock() = cfg.mapped_keys;
+        // Hand the new projections over *after* MAPPED_KEYS is current, so the
+        // releases this produces are gated against the new mapping rather than
+        // the old one.
+        self.gamepad_config = cfg.gamepad;
+        {
+            // Whatever the new declaration is, the pointer starts from rest:
+            // a fraction of a pixel left over from the old projection has no
+            // meaning under the new one.
+            self.gamepad_accumulator.reset();
+            self.gamepad_moving = false;
+            let mut edges = Vec::new();
+            match (&mut self.gamepad, self.gamepad_config) {
+                // A declaration that was removed is a reconfiguration to
+                // "nothing declared", not merely a release: the projectors have
+                // to stop projecting too, or the deleted stick keeps producing
+                // edges under the thresholds of a config that is no longer in
+                // the file. Buttons and triggers carry on, because they never
+                // needed a declaration in the first place.
+                (Some(gamepad), config) => {
+                    gamepad.reconfigure(config.unwrap_or_default(), &mut edges)
+                }
+                // Adding controller input to a running instance needs the
+                // channel that only startup has, so it takes a restart.
+                (None, Some(_)) => log::warn!(
+                    "controller input was added by this reload, but its backend starts \
+                     at launch. Restart kanata to pick up the controller."
+                ),
+                (None, None) => {}
+            }
+            self.apply_gamepad_edges(&edges)?;
+        }
         #[cfg(any(target_os = "linux", target_os = "android"))]
         Kanata::set_repeat_rate(cfg.options.linux_opts.linux_x11_repeat_delay_rate)?;
         // The macOS mouse-tap reload hook is invoked further down, *after* the
@@ -1044,6 +1102,7 @@ impl Kanata {
         self.live_reload_requested |= self.handle_keystate_changes(_tx)?;
         self.handle_scrolling()?;
         self.handle_move_mouse()?;
+        self.handle_gamepad_motion()?;
         self.tick_sequence_state()?;
         self.tick_idle_timeout();
         self.tick_physical_idle_timeout();
@@ -1058,6 +1117,85 @@ impl Kanata {
             self.kbd_out.tick();
         }
         Ok(())
+    }
+
+    /// Drive the pointer and wheel from any control with a motion projection.
+    ///
+    /// Sampled here rather than pushed from the controller thread because a
+    /// deflection is a rate: how fast the pointer moves should depend on the
+    /// clock, not on how often a particular controller reports.
+    fn handle_gamepad_motion(&mut self) -> Result<()> {
+        let Some(gamepad) = self.gamepad.as_ref().filter(|g| g.drives_motion()) else {
+            return Ok(());
+        };
+        let demand = gamepad.demand();
+        // Recorded before the early return so `is_idle` sees both edges of it.
+        self.gamepad_moving = !demand.is_idle();
+        if demand.is_idle() {
+            // Drop any partial movement so a leftover fraction cannot surface
+            // as a stray pixel the next time a stick is pushed.
+            self.gamepad_accumulator.reset();
+            return Ok(());
+        }
+        let accrued = self.gamepad_accumulator.accrue(demand);
+        if accrued.is_empty() {
+            return Ok(());
+        }
+        // A controller pointer is still kanata's pointer, so `movemouse-speed`
+        // scales it exactly as it scales the mousemove actions.
+        let moves = accrued.mouse_moves(|distance| {
+            apply_mouse_distance_modifiers(distance, &self.move_mouse_speed_modifiers)
+        });
+        match moves {
+            // Both axes in one call, which is what keeps a diagonal from being
+            // delivered as two perpendicular steps.
+            [Some(x), Some(y)] => self.kbd_out.move_mouse_many(&[x, y])?,
+            [Some(mv), None] | [None, Some(mv)] => self.kbd_out.move_mouse(mv)?,
+            [None, None] => {}
+        }
+        for (direction, distance) in accrued.scrolls().into_iter().flatten() {
+            self.kbd_out.scroll(direction, distance)?;
+        }
+        Ok(())
+    }
+
+    /// Feed edges a controller produced into the processing loop.
+    ///
+    /// For the callers that already run *on* the processing thread: a live
+    /// reload and a state clean. They hand the events straight to
+    /// `handle_input_event` rather than down the input channel, because the
+    /// channel's only reader is this very thread and a self-send has to be a
+    /// `try_send` that drops a release when the queue is full.
+    ///
+    /// The controller thread cannot use this — it is a different thread — and
+    /// sends `KeyEvent`s down the channel instead. Both paths pass through the
+    /// same `defsrc` gate, and neither holds a lock across the delivery.
+    pub(crate) fn apply_gamepad_edges(
+        &mut self,
+        edges: &[kanata_parser::gamepad::PadEdge],
+    ) -> Result<()> {
+        let mut events = Vec::new();
+        crate::gamepad::gate_on_defsrc(edges, &mut events);
+        for event in events {
+            self.handle_input_event(&event)?;
+        }
+        Ok(())
+    }
+
+    /// Start controller input if the configuration maps a controller control
+    /// or declares an analog projection.
+    ///
+    /// Separate from `new` because the backend needs the channel into the
+    /// processing loop, which does not exist until the caller has built it.
+    pub fn start_gamepad(kanata: &Arc<Mutex<Self>>, tx: Sender<KeyEvent>) {
+        let mut k = kanata.lock();
+        let Some(config) = k.gamepad_config else {
+            return;
+        };
+        let devices = k.input_devices.clone();
+        let handle = crate::gamepad::GamepadHandle::new(config, devices.as_deref());
+        handle.spawn_backend(tx);
+        k.gamepad = Some(handle);
     }
 
     fn handle_scrolling(&mut self) -> Result<()> {
@@ -2270,7 +2408,12 @@ impl Kanata {
                     {
                         let mut k = kanata.lock();
                         info!("Init: releasing {:?}", kev.code);
-                        k.kbd_out.release_key(kev.code).expect("key released");
+                        // Through `output_logic`, not `KbdOut` directly: this
+                        // drain runs while the controller backend is already
+                        // delivering, and a pad code has no scancode for the
+                        // OS layer to emit. On macOS writing one is an `Err`
+                        // that the `expect` below would turn into a panic.
+                        release_key(&mut k.kbd_out, kev.code).expect("key released");
                     }
                     std::thread::sleep(time::Duration::from_millis(1));
                 }
@@ -2556,6 +2699,9 @@ impl Kanata {
     pub fn is_idle(&self) -> bool {
         let pressed_keys_means_not_idle =
             !self.waiting_for_idle.is_empty() || self.live_reload_requested;
+        if self.gamepad_moving {
+            return false;
+        }
         let layout = self.layout.b();
         layout.queue.is_empty()
             && zippy_is_idle()
@@ -2656,6 +2802,16 @@ pub fn clean_state(kanata: &Arc<Mutex<Kanata>>, tick: u128) -> Result<()> {
     let layout = k.layout.bm();
     #[cfg(all(not(feature = "interception_driver"), target_os = "windows"))]
     release_normalkey_states(layout);
+    // Controller input never enters PRESSED_KEYS — it arrives on the channel
+    // rather than from the OS hook — so the sweep below cannot reach a control
+    // a pad is holding. Release those from the engine that does know.
+    {
+        let mut edges = Vec::new();
+        if let Some(gamepad) = &mut k.gamepad {
+            gamepad.release_all(&mut edges);
+        }
+        k.apply_gamepad_edges(&edges)?;
+    }
     k.tick_ms(tick, &None)?;
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {

--- a/src/kanata/output_logic.rs
+++ b/src/kanata/output_logic.rs
@@ -32,17 +32,30 @@ pub(crate) use zippychord::*;
 // that can be assumed to be used by devices still in production.
 pub(super) const KEY_IGNORE_MIN: u16 = 0x2a4; // KEY_MACRO21
 pub(super) const KEY_IGNORE_MAX: u16 = 0x2ad; // KEY_MACRO30
+
+/// Whether this code must never reach the OS.
+///
+/// Two disjoint reasons, both of which want the same answer here rather than
+/// at each writer: the macro keys above, and the synthetic gamepad controls,
+/// which name a physical control on a pad and have no scancode any OS could
+/// be asked to emit. Putting one in an output position is rejected at parse
+/// time; this is the backstop for the paths that build an output from a
+/// `defsrc` position instead of from a key name.
+fn is_ignored_output(osc: OsCode) -> bool {
+    matches!(u16::from(osc), KEY_IGNORE_MIN..=KEY_IGNORE_MAX) || osc.is_gamepad_code()
+}
+
 pub(super) fn write_key(kb: &mut KbdOut, osc: OsCode, val: KeyValue) -> Result<(), std::io::Error> {
-    match u16::from(osc) {
-        KEY_IGNORE_MIN..=KEY_IGNORE_MAX => Ok(()),
-        _ => kb.write_key(osc, val),
+    match is_ignored_output(osc) {
+        true => Ok(()),
+        false => kb.write_key(osc, val),
     }
 }
 pub(super) fn press_key(kb: &mut KbdOut, osc: OsCode) -> Result<(), std::io::Error> {
     use OsCode::*;
-    match u16::from(osc) {
-        KEY_IGNORE_MIN..=KEY_IGNORE_MAX => Ok(()),
-        _ => match osc {
+    match is_ignored_output(osc) {
+        true => Ok(()),
+        false => match osc {
             BTN_LEFT | BTN_RIGHT | BTN_MIDDLE | BTN_SIDE | BTN_EXTRA => {
                 let btn = osc_to_btn(osc);
                 kb.click_btn(btn)
@@ -57,9 +70,9 @@ pub(super) fn press_key(kb: &mut KbdOut, osc: OsCode) -> Result<(), std::io::Err
 }
 pub(super) fn release_key(kb: &mut KbdOut, osc: OsCode) -> Result<(), std::io::Error> {
     use OsCode::*;
-    match u16::from(osc) {
-        KEY_IGNORE_MIN..=KEY_IGNORE_MAX => Ok(()),
-        _ => match osc {
+    match is_ignored_output(osc) {
+        true => Ok(()),
+        false => match osc {
             BTN_LEFT | BTN_RIGHT | BTN_MIDDLE | BTN_SIDE | BTN_EXTRA => {
                 let btn = osc_to_btn(osc);
                 kb.release_btn(btn)
@@ -134,5 +147,40 @@ pub(super) fn zippy_tick(_caps_word_is_active: bool) {
     #[cfg(feature = "zippychord")]
     {
         zch().zch_tick(_caps_word_is_active)
+    }
+}
+
+#[cfg(test)]
+mod ignored_output_tests {
+    use super::*;
+
+    #[test]
+    fn no_controller_control_can_reach_the_os() {
+        // No OS reports these as a scancode, so none can be asked to emit one.
+        // Parsing rejects them in an output position; this is the backstop for
+        // every writer that builds an output from a `defsrc` position instead
+        // of from a key name.
+        for index in 0..OsCode::GAMEPAD_COUNT {
+            let osc = OsCode::from_gamepad_index(index).expect("in range");
+            assert!(is_ignored_output(osc), "{osc} would have reached the OS");
+        }
+    }
+
+    #[test]
+    fn everything_else_keeps_the_behaviour_it_had() {
+        for osc in [OsCode::from(KEY_IGNORE_MIN), OsCode::from(KEY_IGNORE_MAX)] {
+            assert!(is_ignored_output(osc), "{osc} should still be ignored");
+        }
+        for osc in [
+            OsCode::KEY_A,
+            OsCode::KEY_LEFTSHIFT,
+            OsCode::KEY_F24,
+            OsCode::BTN_LEFT,
+            OsCode::MouseWheelUp,
+            OsCode::from(KEY_IGNORE_MIN - 1),
+            OsCode::from(KEY_IGNORE_MAX + 1),
+        ] {
+            assert!(!is_ignored_output(osc), "{osc} was wrongly suppressed");
+        }
     }
 }

--- a/src/kanata/sequences.rs
+++ b/src/kanata/sequences.rs
@@ -274,7 +274,9 @@ use kanata_keyberon::key_code::KeyCode::*;
 pub(super) fn do_successful_sequence_termination(
     kbd_out: &mut KbdOut,
     state: &mut SequenceState,
-    layout: &mut Layout<'_, 767, 2, &CustomAction>,
+    // The parser already names this shape; spelling the row width out here
+    // once let it silently desynchronize from the layout.
+    layout: &mut BorrowedKLayout<'_>,
     i: u8,
     j: u16,
     seq_type: EndSequenceType,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+pub mod gamepad;
 #[cfg(all(target_os = "windows", feature = "gui"))]
 pub mod gui;
 pub mod kanata;

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,11 @@ mod cli {
 
         Kanata::start_processing_loop(kanata_arc.clone(), rx, ntx, args.nodelay);
 
+        // Started after the processing loop so the first controller event has
+        // somewhere to go, and before the keyboard event loop, which does not
+        // return.
+        Kanata::start_gamepad(&kanata_arc, tx.clone());
+
         if let (Some(server), Some(nrx)) = (server, nrx) {
             #[allow(clippy::unit_arg)]
             Kanata::start_notification_loop(nrx, server.connections);

--- a/src/main_lib/win_gui.rs
+++ b/src/main_lib/win_gui.rs
@@ -206,6 +206,8 @@ fn main_impl() -> Result<()> {
     };
     Kanata::start_processing_loop(kanata_arc.clone(), rx, ntx, args.nodelay);
 
+    Kanata::start_gamepad(&kanata_arc, tx.clone());
+
     if let (Some(server), Some(nrx)) = (server, nrx) {
         #[allow(clippy::unit_arg)]
         Kanata::start_notification_loop(nrx, server.connections);

--- a/src/tests/sim_tests/gamepad_sim_tests.rs
+++ b/src/tests/sim_tests/gamepad_sim_tests.rs
@@ -1,0 +1,266 @@
+//! Controller controls driven through the real processing loop.
+//!
+//! The projector and the engine are unit-tested on their own. What these cover
+//! is the claim `defgamepad` is built around: a controller control is an
+//! ordinary kanata input, so every action in the language already works on it
+//! with nothing added. If that ever stops being true these break, and no
+//! amount of testing the gamepad module in isolation would have noticed.
+
+use super::*;
+
+const PAD: &str = "\
+(defcfg process-unmapped-keys no)
+(defgamepad
+  (stick left (digital (mode 4way)))
+  (trigger left (threshold 0.30)))
+(defsrc pad-a pad-b pad-l2 pad-lstick-up a)
+";
+
+#[test]
+fn a_controller_control_is_an_ordinary_input() {
+    let cfg = format!("{PAD}(deflayer base x y z w q)");
+    assert_eq!(
+        simulate(
+            cfg.clone(),
+            "d:pad-a t:10 u:pad-a t:10 d:pad-b t:10 u:pad-b t:10".into()
+        )
+        .to_ascii(),
+        "dn:X t:10ms up:X t:10ms dn:Y t:10ms up:Y"
+    );
+    // A projected stick direction is no different from a button.
+    assert_eq!(
+        simulate(cfg, "d:pad-lstick-up t:10 u:pad-lstick-up t:10".into()).to_ascii(),
+        "dn:W t:10ms up:W"
+    );
+}
+
+#[test]
+fn tap_hold_works_on_a_controller_button() {
+    // The headline claim: nothing in tap-hold knows a controller exists.
+    let cfg = format!("{PAD}(deflayer base (tap-hold 100 100 spc lctl) y z w q)");
+    assert_eq!(
+        simulate(cfg.clone(), "d:pad-a t:30 u:pad-a t:50".into()).to_ascii(),
+        "t:30ms dn:Space t:6ms up:Space",
+        "a short press should tap"
+    );
+    assert_eq!(
+        simulate(cfg, "d:pad-a t:150 u:pad-a t:10".into()).to_ascii(),
+        "t:100ms dn:LCtrl t:50ms up:LCtrl",
+        "a long press should hold"
+    );
+}
+
+#[test]
+fn a_controller_button_can_reach_a_layer_that_a_key_then_uses() {
+    // A pad control and a keyboard key composing in one chord is the thing
+    // that would break if controller input took a separate path.
+    let result = simulate(
+        format!(
+            "{PAD}\
+             (deflayer base x y z w (layer-while-held nav))\
+             (deflayer nav 1 2 3 4 _)"
+        ),
+        "d:a t:10 d:pad-a t:10 u:pad-a t:10 u:a t:10 d:pad-a t:10 u:pad-a t:10".into(),
+    )
+    .to_ascii();
+    assert_eq!(
+        result,
+        "t:10ms dn:Kb1 t:10ms up:Kb1 t:20ms dn:X t:10ms up:X"
+    );
+}
+
+#[test]
+fn a_controller_control_never_reaches_the_os_as_a_scancode() {
+    // `use-defsrc` builds its output from the defsrc position rather than from
+    // a key name, so it is the one path that can hand a pad code to the output
+    // layer. It must produce nothing rather than an invalid scancode.
+    let result = simulate(
+        format!("{PAD}(deflayer base use-defsrc use-defsrc use-defsrc use-defsrc use-defsrc)"),
+        "d:pad-a t:10 u:pad-a t:10 d:a t:10 u:a t:10".into(),
+    )
+    .to_ascii();
+    assert_eq!(result, "t:20ms dn:A t:10ms up:A");
+}
+
+#[test]
+fn controller_controls_are_not_swept_in_by_process_unmapped_keys() {
+    // A controller is a separate device the user opted into with defsrc.
+    // Sweeping its controls in would claim a device kanata was never asked to
+    // touch.
+    let parsed = Kanata::new_from_str(
+        "(defcfg process-unmapped-keys yes)\n(defsrc a)\n(deflayer base b)\n",
+        Default::default(),
+    )
+    .expect("parses");
+    let mapped = crate::kanata::MAPPED_KEYS.lock();
+    assert!(mapped.contains(&str_to_oscode("b").unwrap()));
+    assert!(
+        !mapped.iter().any(|osc| osc.is_gamepad_code()),
+        "process-unmapped-keys claimed a controller control"
+    );
+    drop(parsed);
+}
+
+/// Everything below needs the controller engine, which only exists in a build
+/// with the backend. The tests above do not: a controller control is an
+/// ordinary `OsCode`, so `d:pad-a` works in any build — which is the whole
+/// point of parsing `defgamepad` everywhere.
+mod motion {
+    use super::*;
+
+    // These drive an analog control through the tick loop, which is the only
+    // place a continuous projection becomes real pointer or wheel movement.
+    // Everything upstream of the `pad:` verb is unit-tested; this is the seam.
+
+    /// A stick fast enough to see, with the curve and inversion taken out of
+    /// the way so the arithmetic under test is only the deadzone and the speed.
+    const MOUSE: &str = "\
+    (defcfg process-unmapped-keys no)
+    (defgamepad (stick right (mouse (deadzone 0.1) (speed 10000) (curve linear) (invert-y no))))
+    (defsrc a)
+    (deflayer base a)
+    ";
+
+    /// Total pointer travel in one direction across a simulation.
+    fn travelled(result: &str, direction: &str) -> u32 {
+        let needle = format!("out🖰:move {direction},");
+        result
+            .split('\n')
+            .filter_map(|line| line.strip_prefix(needle.as_str()))
+            .map(|d| d.parse::<u32>().expect("a distance"))
+            .sum()
+    }
+
+    #[test]
+    fn a_pushed_stick_moves_the_pointer_and_centering_stops_it() {
+        let result = simulate(
+            MOUSE.to_string(),
+            "pad:right:1.0,0.0 t:3 pad:right:0.0,0.0 t:5".to_string(),
+        );
+        // Full deflection at 10,000 px/s (10 px/tick) for three ticks and then nothing: the
+        // five ticks after centering would show up as another 50 pixels.
+        assert_eq!(travelled(&result, "Right"), 30, "{result}");
+
+        // A stick held still reports no further events, so the movement above
+        // only happens if a held stick keeps the processing loop awake.
+        // Without that, the first tick moves and the pointer then freezes.
+        let held = simulate(MOUSE.to_string(), "pad:right:1.0,0.0 t:20".to_string());
+        assert_eq!(
+            travelled(&held, "Right"),
+            200,
+            "the pointer stalled: {held}"
+        );
+    }
+
+    #[test]
+    fn both_axes_move_together_rather_than_as_two_steps() {
+        // A diagonal delivered as two independent steps would stair-step
+        // visibly; `move_mouse_many` is what keeps them in one call.
+        let result = simulate(MOUSE.to_string(), "pad:right:1.0,1.0 t:1".to_string());
+        assert_eq!(travelled(&result, "Right"), 7, "{result}");
+        assert_eq!(travelled(&result, "Down"), 7, "{result}");
+    }
+
+    #[test]
+    fn the_deadzone_holds_the_pointer_still_but_does_not_round_slow_pushes_away() {
+        // A resting controller walking the cursor across the screen all day is
+        // the failure on one side; making slow movement impossible rather than
+        // merely slow is the failure on the other.
+        let resting = simulate(MOUSE.to_string(), "pad:right:0.05,0.05 t:50".to_string());
+        assert!(!resting.contains("move"), "the pointer drifted: {resting}");
+
+        // 0.115 is barely past the 0.1 deadzone: about a sixth of a pixel per
+        // tick, which only accumulates into movement if the remainder carries.
+        let crawl = simulate(MOUSE.to_string(), "pad:right:0.115,0.0 t:20".to_string());
+        let moved = travelled(&crawl, "Right");
+        assert!((1..=5).contains(&moved), "crept {moved} pixels: {crawl}");
+    }
+
+    #[test]
+    fn movemouse_speed_scales_controller_movement_too() {
+        // A controller pointer is still kanata's pointer, so the existing
+        // speed modifier has to reach it.
+        let cfg = "\
+    (defcfg process-unmapped-keys no)
+    (defgamepad (stick right (mouse (speed 10000) (curve linear) (invert-y no))))
+    (defsrc a)
+    (deflayer base (movemouse-speed 200))
+    ";
+        let result = simulate(cfg.to_string(), "d:a t:1 pad:right:1.0,0.0 t:1".to_string());
+        assert_eq!(
+            travelled(&result, "Right"),
+            20,
+            "200% of 10 px/tick: {result}"
+        );
+    }
+
+    #[test]
+    fn a_scroll_projection_turns_the_wheel_rather_than_moving_the_pointer() {
+        let cfg = "\
+    (defcfg process-unmapped-keys no)
+    (defgamepad (stick left (scroll (speed 2000) (curve linear))))
+    (defsrc a)
+    (deflayer base a)
+    ";
+        let result = simulate(cfg.to_string(), "pad:left:0.0,1.0 t:2".to_string());
+        assert!(!result.contains("move"), "scroll must not move the pointer");
+        assert!(
+            result.contains("scroll:Up,2"),
+            "a stick pushed away should scroll up: {result}"
+        );
+    }
+
+    #[test]
+    fn a_trigger_can_drive_the_wheel_by_how_hard_it_is_squeezed() {
+        // A trigger is one number, so it is told which way to push. Squeezing
+        // harder scrolls faster, which a digital control cannot express.
+        let cfg = "\
+    (defcfg process-unmapped-keys no)
+    (defgamepad (trigger right (scroll down (deadzone 0) (speed 4000) (curve linear))))
+    (defsrc a)
+    (deflayer base a)
+    ";
+        let half = simulate(cfg.to_string(), "pad:rt:0.5 t:1".to_string());
+        assert!(half.contains("scroll:Down,2"), "{half}");
+        let full = simulate(cfg.to_string(), "pad:rt:1.0 t:1".to_string());
+        assert!(full.contains("scroll:Down,4"), "{full}");
+    }
+
+    #[test]
+    fn one_stick_can_press_keys_and_move_the_pointer_at_the_same_time() {
+        // The threshold and the displacement read the same value without
+        // disturbing each other, so there is no reason to make the user pick.
+        let cfg = "\
+    (defcfg process-unmapped-keys no)
+    (defgamepad
+      (stick right (digital (threshold 0.5)) (mouse (deadzone 0) (speed 10000) (curve linear))))
+    (defsrc pad-rstick-right)
+    (deflayer base x)
+    ";
+        let result = simulate(cfg.to_string(), "pad:right:1.0,0.0 t:2".to_string());
+        assert_eq!(travelled(&result, "Right"), 20, "{result}");
+        assert!(
+            result.contains("↓X"),
+            "the threshold key never pressed: {result}"
+        );
+    }
+
+    #[test]
+    fn a_digital_projection_uses_raw_deflection_through_the_whole_stack() {
+        // The config says 0.5, so 0.45 must be silent and 0.55 must press, and
+        // no deadzone anywhere is able to move that point.
+        let cfg = "\
+    (defcfg process-unmapped-keys no)
+    (defgamepad (stick left (digital (threshold 0.5))))
+    (defsrc pad-lstick-up)
+    (deflayer base x)
+    ";
+        let below = simulate(cfg.to_string(), "pad:left:0.0,0.45 t:5".to_string());
+        assert!(below.is_empty(), "0.45 is below the threshold: {below}");
+        assert_eq!(
+            simulate(cfg.to_string(), "pad:left:0.0,0.55 t:5".to_string()).to_ascii(),
+            "dn:X",
+            "0.55 is above it"
+        );
+    }
+}

--- a/src/tests/sim_tests/gamepad_sim_tests.rs
+++ b/src/tests/sim_tests/gamepad_sim_tests.rs
@@ -264,3 +264,300 @@ mod motion {
         );
     }
 }
+
+mod from_the_tick {
+    use super::*;
+    use kanata_parser::gamepad::{
+        Cardinal, CardinalSet, Dir, PadButton, PadInput, Side, StickPosition,
+    };
+
+    // A live reload and a state clean both produce controller releases from
+    // *inside* the tick, on the very thread that drains the input channel.
+    // Pushing them down that channel would be a self-send that drops a release
+    // when the queue is full; they are applied directly instead, and these
+    // cover that path and the engine reset that goes with it.
+
+    /// A `Kanata` with a controller connected but no backend thread.
+    fn with_pad(cfg: &str) -> Kanata {
+        let mut k = Kanata::new_from_str(cfg, Default::default()).expect("the config parses");
+        let handle = crate::gamepad::GamepadHandle::new(
+            k.gamepad_config.expect("defgamepad"),
+            k.input_devices.as_deref(),
+        );
+        handle.connect(SIM_PAD, Default::default());
+        k.gamepad = Some(handle);
+        k
+    }
+
+    /// Feed one reading through the engine, as the backend would, and deliver
+    /// whatever edges come back.
+    fn feed(k: &mut Kanata, input: PadInput) {
+        let mut edges = Vec::new();
+        k.gamepad
+            .as_ref()
+            .expect("a controller")
+            .feed(SIM_PAD, input, &mut edges);
+        k.apply_gamepad_edges(&edges).expect("edges apply");
+    }
+
+    fn south(pressed: bool) -> PadInput {
+        PadInput::Button {
+            button: PadButton::South,
+            pressed,
+        }
+    }
+
+    fn stick(side: Side, x: f32, y: f32) -> PadInput {
+        PadInput::Stick {
+            side,
+            value: StickPosition::new(x, y),
+        }
+    }
+
+    fn lock_cfg() -> impl Drop {
+        match CFG_PARSE_LOCK.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    const ONE_BUTTON: &str = "\
+    (defcfg process-unmapped-keys no)
+    (defgamepad (stick left (digital)))
+    (defsrc pad-a)
+    (deflayer base x)
+    ";
+
+    /// Drive a d-pad contact trace and report the key events the OS saw.
+    ///
+    /// Timing is dropped: what these are about is which keys came out and in
+    /// what order, and one contact change can produce two edges, which the
+    /// layout then spreads over as many ticks.
+    fn dpad_output(cfg: &str, trace: &[(Dir, bool)]) -> String {
+        let mut k = with_pad(cfg);
+        let mut contacts = CardinalSet::EMPTY;
+        for (dir, pressed) in trace {
+            contacts.set(
+                Cardinal::try_from(*dir).expect("test trace uses cardinals"),
+                *pressed,
+            );
+            feed(&mut k, PadInput::Contacts(contacts));
+            k.tick_ms(5, &None).expect("ticks fine");
+        }
+        k.kbd_out
+            .outputs
+            .events
+            .join(" ")
+            .to_ascii()
+            .split_whitespace()
+            .filter(|event| event.starts_with("dn:") || event.starts_with("up:"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    #[test]
+    fn socd_resolves_a_dpad_conflict_all_the_way_to_the_output() {
+        // An opposed pair of contacts is something real hardware reports, and
+        // what the OS sees has to be the resolved answer rather than two keys
+        // held at once.
+        let _lk = lock_cfg();
+        let out = dpad_output(
+            "(defcfg process-unmapped-keys no)
+             (defgamepad (dpad (digital (socd neutral))))
+             (defsrc pad-dpad-up pad-dpad-down)
+             (deflayer base w s)",
+            &[
+                (Dir::Up, true),
+                // Down arrives while Up is still held: under neutral both go
+                // away, so the W that was down has to be released.
+                (Dir::Down, true),
+                // Letting go of Up leaves Down unopposed, and S becomes real
+                // without the user having touched Down again.
+                (Dir::Up, false),
+                (Dir::Down, false),
+            ],
+        );
+        assert_eq!(
+            out, "dn:W up:W dn:S up:S",
+            "an opposed pair must leave nothing held, and hand over on release"
+        );
+
+        // The default is to report both, because on a d-pad an opposed pair is
+        // the user pressing two buttons and kanata's job is to say so.
+        let both = dpad_output(
+            "(defcfg process-unmapped-keys no)
+             (defsrc pad-dpad-up pad-dpad-down)
+             (deflayer base w s)
+             (defgamepad)",
+            &[(Dir::Up, true), (Dir::Down, true)],
+        );
+        assert_eq!(both, "dn:W dn:S");
+    }
+
+    #[test]
+    fn an_eight_way_dpad_presses_the_diagonal_all_the_way_to_the_output() {
+        // The d-pad shares the sticks' projection, so eight-way reaches it for
+        // free — and a diagonal has to replace its components, not join them.
+        let _lk = lock_cfg();
+        let out = dpad_output(
+            "(defcfg process-unmapped-keys no)
+             (defgamepad (dpad (digital (mode 8way))))
+             (defsrc pad-dpad-up pad-dpad-right pad-dpad-upright)
+             (deflayer base w d e)",
+            &[(Dir::Up, true), (Dir::Right, true), (Dir::Up, false)],
+        );
+        assert_eq!(out, "dn:W up:W dn:E up:E dn:D");
+    }
+
+    #[test]
+    fn a_release_produced_inside_the_tick_reaches_the_layout() {
+        // The delivery path that replaced the self-send. Nothing here touches
+        // the input channel, and the release must still land.
+        let _lk = lock_cfg();
+        let mut k = with_pad(ONE_BUTTON);
+        feed(&mut k, south(true));
+        k.tick_ms(5, &None).expect("ticks fine");
+        assert!(
+            k.kbd_out.outputs.events.join("\n").contains("↓X"),
+            "the press should have landed"
+        );
+
+        let mut edges = Vec::new();
+        k.gamepad
+            .as_mut()
+            .expect("a controller")
+            .release_all(&mut edges);
+        assert!(!edges.is_empty(), "there was something to release");
+        k.apply_gamepad_edges(&edges).expect("edges apply");
+        k.tick_ms(5, &None).expect("ticks fine");
+
+        let out = k.kbd_out.outputs.events.join("\n");
+        assert!(out.contains("↑X"), "the release was dropped: {out}");
+    }
+
+    /// Reload `k` from a config written to a temporary file.
+    fn reload(k: &mut Kanata, name: &str, cfg: &str) {
+        let path = std::env::temp_dir().join(name);
+        std::fs::write(&path, cfg).expect("a writable config");
+        k.cfg_paths = vec![path.clone()];
+        k.cur_cfg_idx = 0;
+        let outcome = k.do_live_reload(&None);
+        let _ = std::fs::remove_file(&path);
+        outcome.expect("the reload succeeds");
+        k.tick_ms(5, &None).expect("ticks fine");
+    }
+
+    #[test]
+    fn a_live_reload_resets_the_engine_so_a_held_control_works_again() {
+        // A controller held across a reload has already been counted as
+        // pressed. Without the reset the next press is swallowed as a repeat
+        // and the control is dead until it is released and pressed again,
+        // which the user has no way to know they must do.
+        let _lk = lock_cfg();
+        let mut k = with_pad(ONE_BUTTON);
+        feed(&mut k, south(true));
+        k.tick_ms(5, &None).expect("ticks fine");
+        reload(&mut k, "kanata-gamepad-reload.kbd", ONE_BUTTON);
+
+        let before = k.kbd_out.outputs.events.len();
+        feed(&mut k, south(true));
+        k.tick_ms(5, &None).expect("ticks fine");
+        let after: Vec<_> = k.kbd_out.outputs.events[before..].to_vec();
+        assert!(
+            after.iter().any(|e| e.contains("↓X")),
+            "the control was dead after the reload: {after:?}"
+        );
+    }
+
+    #[test]
+    fn a_reload_that_drops_defgamepad_stops_the_projections_it_declared() {
+        // Removing the declaration has to remove what it declared, not merely
+        // release it: the deleted stick must stop projecting entirely, or it
+        // keeps producing edges under thresholds no longer in the file. The
+        // fixture uses a *mouse* stick so `drives_motion` starts out true.
+        let _lk = lock_cfg();
+        let mut k = with_pad(
+            "(defcfg process-unmapped-keys no)
+             (defgamepad
+               (stick left (digital))
+               (stick right (mouse (deadzone 0.0) (speed 20000) (curve linear))))
+             (defsrc pad-a pad-lstick-up)
+             (deflayer base x w)",
+        );
+        feed(&mut k, south(true));
+        feed(&mut k, stick(Side::Left, 0.0, 1.0));
+        k.tick_ms(5, &None).expect("ticks fine");
+        assert!(
+            k.gamepad.as_ref().expect("a controller").drives_motion(),
+            "the fixture has to start out driving the pointer, or the check \
+             below proves nothing"
+        );
+
+        reload(
+            &mut k,
+            "kanata-gamepad-drop.kbd",
+            "(defcfg process-unmapped-keys no)\n(defsrc a)\n(deflayer base y)\n",
+        );
+
+        assert!(
+            !k.gamepad
+                .as_ref()
+                .expect("the handle stays up")
+                .drives_motion(),
+            "a dropped declaration must stop the tick loop sampling"
+        );
+        // The stick that was declared is gone, so pushing it produces nothing
+        // at all: not an edge under the old thresholds, and no motion demand.
+        feed(&mut k, stick(Side::Left, 0.0, -1.0));
+        feed(&mut k, stick(Side::Right, 1.0, 0.0));
+        assert!(
+            k.gamepad.as_ref().expect("a controller").demand().is_idle(),
+            "the deleted mouse projection is still asking for movement"
+        );
+
+        let before = k.kbd_out.outputs.events.len();
+        k.handle_input_event(&KeyEvent::new(
+            str_to_oscode("a").expect("a key"),
+            KeyValue::Press,
+        ))
+        .expect("the press applies");
+        k.tick_ms(5, &None).expect("ticks fine");
+        let after: Vec<_> = k.kbd_out.outputs.events[before..].to_vec();
+        assert!(
+            after.iter().any(|e| e.contains("↓Y")),
+            "the keyboard stopped working after the reload: {after:?}"
+        );
+    }
+
+    #[test]
+    fn a_state_clean_lets_go_without_disabling_the_pointer() {
+        // `clean_state` cleans state, not configuration. Switching the pointer
+        // off here would leave a mouse stick dead for the rest of the process,
+        // with nothing to say why and no reload to put it back.
+        let _lk = lock_cfg();
+        let mut k = with_pad(
+            "(defcfg process-unmapped-keys no)
+             (defgamepad (stick right (mouse (deadzone 0.0) (speed 20000) (curve linear))))
+             (defsrc pad-a)
+             (deflayer base x)",
+        );
+        feed(&mut k, south(true));
+        feed(&mut k, stick(Side::Right, 1.0, 0.0));
+
+        let mut edges = Vec::new();
+        k.gamepad
+            .as_mut()
+            .expect("a controller")
+            .release_all(&mut edges);
+        k.apply_gamepad_edges(&edges).expect("edges apply");
+
+        assert!(
+            k.gamepad.as_ref().expect("a controller").drives_motion(),
+            "a release must not switch the pointer off for good"
+        );
+        // And the stick still drives it: the projection was never the thing
+        // being released.
+        feed(&mut k, stick(Side::Right, 1.0, 0.0));
+        assert!(!k.gamepad.as_ref().expect("a controller").demand().is_idle());
+    }
+}

--- a/src/tests/sim_tests/gamepad_sim_tests.rs
+++ b/src/tests/sim_tests/gamepad_sim_tests.rs
@@ -435,6 +435,36 @@ mod from_the_tick {
         assert!(out.contains("↑X"), "the release was dropped: {out}");
     }
 
+    #[test]
+    fn debounce_waits_for_the_tick_and_filters_a_brief_crossing() {
+        let _lk = lock_cfg();
+        let mut k = with_pad(
+            "(defcfg process-unmapped-keys no)
+             (defgamepad (stick left (digital (threshold 0.5) (debounce 3))))
+             (defsrc pad-lstick-up)
+             (deflayer base x)",
+        );
+
+        feed(&mut k, stick(Side::Left, 0.0, 1.0));
+        k.tick_ms(2, &None).expect("ticks fine");
+        assert!(k.kbd_out.outputs.events.is_empty(), "must still be pending");
+
+        // Returning before the deadline cancels the candidate press.
+        feed(&mut k, stick(Side::Left, 0.0, 0.0));
+        k.tick_ms(4, &None).expect("ticks fine");
+        assert!(
+            k.kbd_out.outputs.events.is_empty(),
+            "brief crossing leaked through"
+        );
+
+        feed(&mut k, stick(Side::Left, 0.0, 1.0));
+        k.tick_ms(4, &None).expect("ticks fine");
+        assert!(
+            k.kbd_out.outputs.events.join(" ").contains("↓X"),
+            "settled crossing never pressed"
+        );
+    }
+
     /// Reload `k` from a config written to a temporary file.
     fn reload(k: &mut Kanata, name: &str, cfg: &str) {
         let path = std::env::temp_dir().join(name);

--- a/src/tests/sim_tests/mod.rs
+++ b/src/tests/sim_tests/mod.rs
@@ -45,6 +45,76 @@ fn apply_fakekey_action(k: &mut Kanata, name: &str, action: FakeKeyAction) {
     handle_fakekey_action(action, k.layout.bm(), FAKE_KEY_ROW, *index as u16);
 }
 
+/// The controller the `pad:` verb speaks for.
+///
+/// One is enough: merging several is the engine's own concern and is covered
+/// there, without needing a processing loop.
+const SIM_PAD: crate::gamepad::PadDeviceId = crate::gamepad::PadDeviceId::new(0);
+
+/// Move an analog control, as the controller backend would.
+///
+/// `spec` is `<control>:<value>`, where a stick takes `<x>,<y>` in
+/// `-1.0..=1.0` (y-up) and a trigger takes a single `0.0..=1.0`:
+///
+/// ```text
+/// pad:left:0.5,-0.25   pad:right:0,1   pad:lt:0.8
+/// ```
+///
+/// This stands in for the backend thread, which needs hardware; everything
+/// downstream of it — projection, the `defsrc` gate, the layout, the tick
+/// loop's motion sampling — is exactly what runs in production. Digital
+/// controls need none of this: they are ordinary `OsCode`s, so `d:pad-a`
+/// already works.
+fn apply_pad_analog(k: &mut Kanata, spec: &str) {
+    use kanata_parser::gamepad::{PadInput, Side, StickPosition, Unit};
+
+    let (control, value) = spec
+        .split_once(':')
+        .unwrap_or_else(|| panic!("pad spec must be <control>:<value>, got: {spec}"));
+    let number = |text: &str| {
+        text.parse::<f32>()
+            .unwrap_or_else(|_| panic!("expected a number in the pad spec, got: {text}"))
+    };
+    let input = match control {
+        "left" | "right" => {
+            let side = match control {
+                "left" => Side::Left,
+                _ => Side::Right,
+            };
+            let (x, y) = value
+                .split_once(',')
+                .unwrap_or_else(|| panic!("a stick takes <x>,<y>, got: {value}"));
+            PadInput::Stick {
+                side,
+                value: StickPosition::new(number(x), number(y)),
+            }
+        }
+        "lt" | "rt" => PadInput::Trigger {
+            side: match control {
+                "lt" => Side::Left,
+                _ => Side::Right,
+            },
+            value: Unit::new(number(value)),
+        },
+        other => panic!("unknown analog control: {other}\nvalid: left, right, lt, rt"),
+    };
+
+    // Created on first use: `Kanata::start_gamepad` is a startup step the sim
+    // does not run, since it would spawn a thread looking for real hardware.
+    let gamepad = k.gamepad.get_or_insert_with(|| {
+        let config = k
+            .gamepad_config
+            .expect("the config must declare defgamepad to drive an analog control");
+        let handle = crate::gamepad::GamepadHandle::new(config, k.input_devices.as_deref());
+        handle.connect(SIM_PAD, Default::default());
+        handle
+    });
+    let mut edges = Vec::new();
+    gamepad.feed(SIM_PAD, input, &mut edges);
+    k.apply_gamepad_edges(&edges)
+        .expect("controller edges apply fine");
+}
+
 /// Apply a layer switch to the kanata instance
 fn apply_layer_switch(k: &mut Kanata, layer_name: &str) {
     let layer_idx = k
@@ -59,6 +129,7 @@ mod block_keys_tests;
 mod capsword_sim_tests;
 mod chord_sim_tests;
 mod delay_tests;
+mod gamepad_sim_tests;
 mod layer_sim_tests;
 mod macro_sim_tests;
 mod mouse_sim_tests;
@@ -147,6 +218,8 @@ fn simulate_with_file_content<S: AsRef<str>>(
                 "ls" | "layer-switch" | "🔀" => {
                     apply_layer_switch(&mut k, val);
                 }
+                // Controller analog control: pad:left:0.5,-0.25 or pad:lt:0.8
+                "pad" => apply_pad_analog(&mut k, val),
                 _ => panic!("invalid item {pair}"),
             },
             None => panic!("invalid item {pair}"),


### PR DESCRIPTION
#### 9. Processing Loop Integration (`gamepad/processing-integration`)

Wires the evaluated gamepad architecture into the live `Kanata` processing loop.

- **Daemon State:** Expands the `Kanata` struct to track configurations, active handles, motion accumulators, and pending debounce states.
- **Idle Prevention:** Modifies `is_idle()` to evaluate `gamepad_moving` and `gamepad_pending`, preventing the daemon from sleeping during active analog movement or in-flight debounces.
- **Emission Safeguards:** Implements a secondary, absolute guard within `is_ignored_output()` across all core write paths (`write_key`, `press_key`, `release_key`). This guarantees synthetic codes cannot be transmitted to the OS, even if erroneously forced through a raw `defsrc` position.
- **Simulation Testing:** Introduces the `pad:<control>:<value>` verb to the simulation test framework, allowing rigorous, deterministic testing of the backend thread alongside production layout logic.

