### PR TITLE
fix(mouse): reset movemouse-accel on direction reversal with inherit-accel-state

### DIFF
--- a/docs/config.adoc
+++ b/docs/config.adoc
@@ -4398,9 +4398,15 @@ For more context, see https://github.com/jtroo/kanata/issues/435.
 By default `movemouse-accel` actions will track the acceleration
 state for vertical and horizontal axes separately.
 
-When this setting is enabled, `movemouse-accel` will behave exactly like mouse movements in https://qmk.fm[QMK],
+When this setting is enabled, `movemouse-accel` will behave like mouse movements in https://qmk.fm[QMK],
 i.e. the acceleration state of new mouse
 movement actions will be inherited if others are already being pressed.
+
+Reversing direction on an axis (for example switching from
+`movemouse-accel-left` to `movemouse-accel-right`) resets the acceleration
+back to the minimum distance rather than inheriting the current speed. This
+matches QMK's behavior after https://github.com/qmk/qmk_firmware/issues/4242
+was fixed.
 
 .Example:
 [source]

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1626,32 +1626,39 @@ impl Kanata {
                         min_distance,
                         max_distance,
                     } => {
-                        // Fix #2142: when reversing direction on the same axis
-                        // (e.g. accel-left then accel-right), the acceleration
-                        // must reset instead of being inherited, matching the
-                        // fixed QMK behavior (qmk/qmk_firmware#4242). Inheriting
-                        // here would carry a maxed-out speed into the reversed
-                        // movement, causing a jarring turnaround on overshoot.
-                        let same_axis_state = match direction {
-                            MoveDirection::Up | MoveDirection::Down => {
-                                &self.move_mouse_state_vertical
-                            }
-                            MoveDirection::Left | MoveDirection::Right => {
-                                &self.move_mouse_state_horizontal
-                            }
+                        // Inheriting acceleration is normally desired so that a new
+                        // axis starts at the same speed as one already in flight
+                        // (e.g. diagonal movement), matching QMK's behavior. But
+                        // reversing direction on the *same* axis (accel-left held,
+                        // then accel-right pressed) must reset instead of
+                        // inheriting: otherwise the maxed-out speed carries into
+                        // the reversed movement and causes a jarring turnaround
+                        // on overshoot. The other axis is unaffected by this axis
+                        // reversing, so it stays eligible to be inherited from.
+                        let is_horizontal = matches!(
+                            direction,
+                            MoveDirection::Left | MoveDirection::Right
+                        );
+                        let same_axis_state = if is_horizontal {
+                            &self.move_mouse_state_horizontal
+                        } else {
+                            &self.move_mouse_state_vertical
                         };
                         let reversing_direction = matches!(
                             same_axis_state,
                             Some(MoveMouseState { direction: active, .. })
                                 if is_opposite_move_direction(*active, *direction)
                         );
-                        let inherited_accel_state = if self.movemouse_inherit_accel_state
-                            && !reversing_direction
-                        {
-                            match (
-                                &self.move_mouse_state_horizontal,
-                                &self.move_mouse_state_vertical,
-                            ) {
+                        let horizontal_source = self
+                            .move_mouse_state_horizontal
+                            .as_ref()
+                            .filter(|_| !(is_horizontal && reversing_direction));
+                        let vertical_source = self
+                            .move_mouse_state_vertical
+                            .as_ref()
+                            .filter(|_| !(!is_horizontal && reversing_direction));
+                        let inherited_accel_state = if self.movemouse_inherit_accel_state {
+                            match (horizontal_source, vertical_source) {
                                 (
                                     Some(MoveMouseState {
                                         move_mouse_accel_state: Some(s),

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -1626,43 +1626,65 @@ impl Kanata {
                         min_distance,
                         max_distance,
                     } => {
-                        let move_mouse_accel_state = match (
-                            self.movemouse_inherit_accel_state,
-                            &self.move_mouse_state_horizontal,
-                            &self.move_mouse_state_vertical,
-                        ) {
-                            (
-                                true,
-                                Some(MoveMouseState {
-                                    move_mouse_accel_state: Some(s),
-                                    ..
-                                }),
-                                _,
-                            )
-                            | (
-                                true,
-                                _,
-                                Some(MoveMouseState {
-                                    move_mouse_accel_state: Some(s),
-                                    ..
-                                }),
-                            ) => *s,
-                            _ => {
-                                let f_max_distance: f64 = *max_distance as f64;
-                                let f_min_distance: f64 = *min_distance as f64;
-                                let f_accel_time: f64 = *accel_time as f64;
-                                let increment =
-                                    (f_max_distance - f_min_distance) / f_accel_time;
-
-                                MoveMouseAccelState {
-                                    accel_ticks_from_min: 0,
-                                    accel_ticks_until_max: *accel_time,
-                                    accel_increment: increment,
-                                    min_distance: *min_distance,
-                                    max_distance: *max_distance,
-                                }
+                        // Fix #2142: when reversing direction on the same axis
+                        // (e.g. accel-left then accel-right), the acceleration
+                        // must reset instead of being inherited, matching the
+                        // fixed QMK behavior (qmk/qmk_firmware#4242). Inheriting
+                        // here would carry a maxed-out speed into the reversed
+                        // movement, causing a jarring turnaround on overshoot.
+                        let same_axis_state = match direction {
+                            MoveDirection::Up | MoveDirection::Down => {
+                                &self.move_mouse_state_vertical
+                            }
+                            MoveDirection::Left | MoveDirection::Right => {
+                                &self.move_mouse_state_horizontal
                             }
                         };
+                        let reversing_direction = matches!(
+                            same_axis_state,
+                            Some(MoveMouseState { direction: active, .. })
+                                if is_opposite_move_direction(*active, *direction)
+                        );
+                        let inherited_accel_state = if self.movemouse_inherit_accel_state
+                            && !reversing_direction
+                        {
+                            match (
+                                &self.move_mouse_state_horizontal,
+                                &self.move_mouse_state_vertical,
+                            ) {
+                                (
+                                    Some(MoveMouseState {
+                                        move_mouse_accel_state: Some(s),
+                                        ..
+                                    }),
+                                    _,
+                                )
+                                | (
+                                    _,
+                                    Some(MoveMouseState {
+                                        move_mouse_accel_state: Some(s),
+                                        ..
+                                    }),
+                                ) => Some(*s),
+                                _ => None,
+                            }
+                        } else {
+                            None
+                        };
+                        let move_mouse_accel_state = inherited_accel_state.unwrap_or_else(|| {
+                            let f_max_distance: f64 = *max_distance as f64;
+                            let f_min_distance: f64 = *min_distance as f64;
+                            let f_accel_time: f64 = *accel_time as f64;
+                            let increment = (f_max_distance - f_min_distance) / f_accel_time;
+
+                            MoveMouseAccelState {
+                                accel_ticks_from_min: 0,
+                                accel_ticks_until_max: *accel_time,
+                                accel_increment: increment,
+                                min_distance: *min_distance,
+                                max_distance: *max_distance,
+                            }
+                        });
 
                         match direction {
                             MoveDirection::Up | MoveDirection::Down => {
@@ -2631,6 +2653,17 @@ fn run_multi_cmd(cmds: Vec<(Option<log::Level>, Option<log::Level>, Vec<String>)
             }
         }
     });
+}
+
+/// Returns true if the two directions are exact opposites on the same axis
+/// (up/down or left/right). Used to reset mouse acceleration on direction
+/// reversal (see fix #2142).
+fn is_opposite_move_direction(a: MoveDirection, b: MoveDirection) -> bool {
+    use MoveDirection::*;
+    matches!(
+        (a, b),
+        (Up, Down) | (Down, Up) | (Left, Right) | (Right, Left)
+    )
 }
 
 fn apply_mouse_distance_modifiers(initial_distance: u16, mods: &Vec<u16>) -> u16 {

--- a/src/kanata/mod.rs
+++ b/src/kanata/mod.rs
@@ -2663,8 +2663,7 @@ fn run_multi_cmd(cmds: Vec<(Option<log::Level>, Option<log::Level>, Vec<String>)
 }
 
 /// Returns true if the two directions are exact opposites on the same axis
-/// (up/down or left/right). Used to reset mouse acceleration on direction
-/// reversal (see fix #2142).
+/// (up/down or left/right).
 fn is_opposite_move_direction(a: MoveDirection, b: MoveDirection) -> bool {
     use MoveDirection::*;
     matches!(

--- a/src/tests/sim_tests/mouse_sim_tests.rs
+++ b/src/tests/sim_tests/mouse_sim_tests.rs
@@ -82,3 +82,28 @@ fn movemouse_accel_resets_on_direction_reversal() {
         result
     );
 }
+
+#[test]
+fn movemouse_accel_reversal_keeps_other_axis_inheritance() {
+    // With `movemouse-inherit-accel-state yes`, a same-axis reversal must
+    // still let the *other* axis be inherited from. Up is held and maxed
+    // out first, then left is pressed (cross-axis inherit from up, so it
+    // starts maxed), then right is pressed while left is still held (a
+    // same-axis reversal on left/right). Right must reset relative to
+    // left, but it can still inherit the still-active, still-maxed up
+    // state, so it also starts maxed rather than ramping from the minimum.
+    let result = simulate(
+        "(defcfg movemouse-inherit-accel-state yes)
+         (defsrc a b c)
+         (deflayermap (base)
+           a (movemouse-accel-up 1 3 1 4)
+           b (movemouse-accel-left 1 3 1 4)
+           c (movemouse-accel-right 1 3 1 4))",
+        "d:a t:6 d:b t:6 d:c t:2 u:a u:b u:c t:2",
+    )
+    .to_ascii();
+    assert_eq!(
+        "out🖰:move Up,1 t:1ms out🖰:move Up,2 t:1ms out🖰:move Up,3 t:1ms out🖰:move Up,4 t:1ms out🖰:move Up,4 t:1ms out🖰:move Up,4 t:1ms out🖰:move Up,4 out🖰:move Left,4 t:1ms out🖰:move Up,4 out🖰:move Left,4 t:1ms out🖰:move Up,4 out🖰:move Left,4 t:1ms out🖰:move Up,4 out🖰:move Left,4 t:1ms out🖰:move Up,4 out🖰:move Left,4 t:1ms out🖰:move Up,4 out🖰:move Left,4 t:1ms out🖰:move Up,4 out🖰:move Right,4 t:1ms out🖰:move Up,4 out🖰:move Right,4 t:1ms out🖰:move Right,4 t:1ms out🖰:move Right,4",
+        result
+    );
+}

--- a/src/tests/sim_tests/mouse_sim_tests.rs
+++ b/src/tests/sim_tests/mouse_sim_tests.rs
@@ -60,3 +60,25 @@ fn mwheel_accel_stops_decel_on_mod_press() {
         );
     }
 }
+
+#[test]
+fn movemouse_accel_resets_on_direction_reversal() {
+    // Regression test for #2142.
+    // With `movemouse-inherit-accel-state yes`, reversing direction on the
+    // same axis (accel-left held, then accel-right pressed) must reset the
+    // acceleration back to the minimum distance instead of inheriting the
+    // maxed-out speed, matching the fixed QMK behavior.
+    let result = simulate(
+        "(defcfg movemouse-inherit-accel-state yes)
+         (defsrc a b)
+         (deflayermap (base)
+           a (movemouse-accel-left 1 3 1 4)
+           b (movemouse-accel-right 1 3 1 4))",
+        "d:a t:6 d:b t:6 u:a u:b t:2",
+    )
+    .to_ascii();
+    assert_eq!(
+        "out🖰:move Left,1 t:1ms out🖰:move Left,2 t:1ms out🖰:move Left,3 t:1ms out🖰:move Left,4 t:1ms out🖰:move Left,4 t:1ms out🖰:move Left,4 t:1ms out🖰:move Right,1 t:1ms out🖰:move Right,2 t:1ms out🖰:move Right,3 t:1ms out🖰:move Right,4 t:1ms out🖰:move Right,4 t:1ms out🖰:move Right,4 t:1ms out🖰:move Right,4",
+        result
+    );
+}


### PR DESCRIPTION
## Describe your changes

Fixes #2142.

Three commits:

1. **Reset accel on same-axis reversal.** With `movemouse-inherit-accel-state yes`, a new `movemouse-accel` action always inherited the existing acceleration state from whichever axis had one, no matter the direction. Reversing direction on an axis (accel-left held, then accel-right pressed) carried the maxed-out speed into the new direction, causing a jarring turnaround when you overshoot a target. This detects a same-axis direction reversal and starts a fresh acceleration state (from the minimum distance) in that case instead of inheriting.

2. **Keep cross-axis inheritance during that reversal.** The first commit's check disabled inheritance from *both* axes whenever the current axis reversed, even when the other axis was still active and unrelated to the reversal. Example: hold up until it maxes out, tap left (correctly inherits the maxed speed from up), then switch to right while left is still held. That's a same-axis reversal on left/right, but up hasn't reversed, so right should still inherit its maxed speed. It was resetting to the minimum instead. Fixed by scoping the "don't inherit" check to just the axis that's reversing, matching same-direction re-triggering and cross-axis inheritance staying unchanged as intended, and matches QMK's behavior after qmk/qmk_firmware#4242 was fixed.

3. **Drop an issue-number reference from a doc comment.** Cosmetic only, no behavior change.

## Checklist

- Add documentation to docs/config.adoc
  - [x] Yes
- Add example and basic docs to cfg_samples/kanata.kbd
  - [x] N/A (behavior of an existing action, no new config syntax)
- Update error messages
  - [x] N/A
- Added tests, or did manual testing
  - [x] Yes, two simulated-input regression tests: one for the same-axis reversal reset, one for the reversal-shouldn't-block-cross-axis-inheritance case. Both fail without their respective fix and pass with it. Also ran the full test suite, clippy, and fmt clean.